### PR TITLE
Cleanup update script

### DIFF
--- a/update
+++ b/update
@@ -46,6 +46,7 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
   })
 
   // Write bin/list.json
+  // Ascending list of builds and descending map of releases.
   fs.writeFile(path.join(__dirname, '/bin/list.json'), JSON.stringify({ builds: parsedList, releases: releases }, null, 2), function (err) {
     if (err) {
       throw err
@@ -53,6 +54,8 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     console.log('Updated bin/list.json')
   })
 
+  // Write bin/list.js
+  // Descending list of build filenames and descending map of releases.
   fs.writeFile(path.join(__dirname, '/bin/list.js'), generateLegacyListJS(buildNames, releases), function (err) {
     if (err) {
       throw err

--- a/update
+++ b/update
@@ -29,16 +29,16 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     }, {})
 
   // descending list
-  const builds = parsedList
+  const buildNames = parsedList
     .slice().reverse()
     .map(function (ver) { return ver.path })
 
   // latest build
-  const latestBuildFile = builds[0]
+  const latestBuildFile = buildNames[0]
 
   // Write bin/list.txt
   // A descending list of file names.
-  fs.writeFile(path.join(__dirname, '/bin/list.txt'), builds.join('\n'), function (err) {
+  fs.writeFile(path.join(__dirname, '/bin/list.txt'), buildNames.join('\n'), function (err) {
     if (err) {
       throw err
     }
@@ -53,7 +53,7 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     console.log('Updated bin/list.json')
   })
 
-  fs.writeFile(path.join(__dirname, '/bin/list.js'), generateLegacyListJS(builds, releases), function (err) {
+  fs.writeFile(path.join(__dirname, '/bin/list.js'), generateLegacyListJS(buildNames, releases), function (err) {
     if (err) {
       throw err
     }

--- a/update
+++ b/update
@@ -34,7 +34,7 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     .map(function (ver) { return ver.path })
 
   // latest build
-  const latest = parsedList[parsedList.length - 1].path
+  const latestBuildFile = builds[0]
 
   // Write bin/list.txt
   // A descending list of file names.
@@ -60,8 +60,8 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     console.log('Updated bin/list.js')
   })
 
-  // Read latest version
-  fs.readFile(path.join(__dirname, '/bin/', latest), function (err, data) {
+  // Read latest build file
+  fs.readFile(path.join(__dirname, '/bin/', latestBuildFile), function (err, data) {
     if (err) {
       throw err
     }

--- a/update
+++ b/update
@@ -31,14 +31,11 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     .map(function (ver) { return ver.path })
     .reverse()
 
-  const pathList = builds
-    .reverse()
-    .reduce(function (prev, next) { return prev + '\n' + next })
-
   const latest = parsedList.reverse()[parsedList.length - 1].path
 
   // Write bin/list.txt
-  fs.writeFile(path.join(__dirname, '/bin/list.txt'), pathList, function (err) {
+  // A descending list of file names.
+  fs.writeFile(path.join(__dirname, '/bin/list.txt'), builds.reverse().join('\n'), function (err) {
     if (err) {
       throw err
     }

--- a/update
+++ b/update
@@ -18,8 +18,9 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     .filter(function (version) { return version })
     .map(function (pars) { return { path: pars[0], version: pars[1], prerelease: pars[3], build: pars[5] } })
 
+  // descending list
   const releases = parsedList
-    .reverse()
+    .slice().reverse()
     .reduce(function (prev, next) {
       if (next.prerelease === undefined) {
         prev[next.version] = next.path
@@ -27,15 +28,17 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
       return prev
     }, {})
 
+  // descending list
   const builds = parsedList
+    .slice().reverse()
     .map(function (ver) { return ver.path })
-    .reverse()
 
-  const latest = parsedList.reverse()[parsedList.length - 1].path
+  // latest build
+  const latest = parsedList[parsedList.length - 1].path
 
   // Write bin/list.txt
   // A descending list of file names.
-  fs.writeFile(path.join(__dirname, '/bin/list.txt'), builds.reverse().join('\n'), function (err) {
+  fs.writeFile(path.join(__dirname, '/bin/list.txt'), builds.join('\n'), function (err) {
     if (err) {
       throw err
     }


### PR DESCRIPTION
The update script used `reverse()` which changes the order in-place. Cleaned up, because that made it hard to follow.

Note: no need to run update, because the output hasn't changed.