### PR TITLE
Include github URLs in list.json

### DIFF
--- a/bin/list.json
+++ b/bin/list.json
@@ -5,9 +5,12 @@
       "version": "0.1.1",
       "build": "commit.6ff4cd6",
       "longVersion": "0.1.1+commit.6ff4cd6",
+      "sha256": "0xfc54135edfe07d835216f87fa6c3b9049e1415c2825027b926daad018e09269f",
       "keccak256": "0xd8b8c64f4e9de41e6604e6ac30274eff5b80f831f8534f0ad85ec0aff466bb25",
       "urls": [
-        "bzzr://8f3c028825a1b72645f46920b67dca9432a87fc37a8940a2b2ce1dd6ddc2e29b"
+        "bzzr://8f3c028825a1b72645f46920b67dca9432a87fc37a8940a2b2ce1dd6ddc2e29b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.1+commit.6ff4cd6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.1+commit.6ff4cd6.js"
       ]
     },
     {
@@ -15,9 +18,12 @@
       "version": "0.1.2",
       "build": "commit.d0d36e3",
       "longVersion": "0.1.2+commit.d0d36e3",
+      "sha256": "0x7ad9fa9de246a33c5e5472127b6e0b6e713f3900c7ea360c7c2824f6e9202a0f",
       "keccak256": "0xa70b3d4acf77a303efa93c3ddcadd55b8762c7be109fd8f259ec7d6be654f03e",
       "urls": [
-        "bzzr://e662d71e9b8e1b0311c129b962e678e5dd63487ad9b020ee539d7f74cd7392c9"
+        "bzzr://e662d71e9b8e1b0311c129b962e678e5dd63487ad9b020ee539d7f74cd7392c9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.2+commit.d0d36e3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.2+commit.d0d36e3.js"
       ]
     },
     {
@@ -26,9 +32,12 @@
       "prerelease": "nightly.2015.9.25",
       "build": "commit.4457170",
       "longVersion": "0.1.3-nightly.2015.9.25+commit.4457170",
+      "sha256": "0x7b65e00aee537a341df83de88125bd18e020b86a31ef6e506c3881142daeb35b",
       "keccak256": "0x07de160862e662ea027a5451b78a7d9db6c9d7dd11a314fc19c68b095cb1c6ce",
       "urls": [
-        "bzzr://378cfc60e8801e992ec574511c050450e771d60cf9527c9d00353ec2eab4d5b5"
+        "bzzr://378cfc60e8801e992ec574511c050450e771d60cf9527c9d00353ec2eab4d5b5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.3-nightly.2015.9.25+commit.4457170.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.3-nightly.2015.9.25+commit.4457170.js"
       ]
     },
     {
@@ -37,9 +46,12 @@
       "prerelease": "nightly.2015.9.28",
       "build": "commit.4457170",
       "longVersion": "0.1.3-nightly.2015.9.28+commit.4457170",
+      "sha256": "0x850917e16b843162739269b1ba89722e08ef0fbe12d1e38bcbab97bf0eeaa2ef",
       "keccak256": "0xa04df894a1fddc56f0a5e2ec41a858a17e1aca7cf3ad18bb78a026b9fd79e19b",
       "urls": [
-        "bzzr://91c514a73ad2d3ae4cf31c20532d4f325e28afed5b3846dcde7b7dd72a7c4864"
+        "bzzr://91c514a73ad2d3ae4cf31c20532d4f325e28afed5b3846dcde7b7dd72a7c4864",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.3-nightly.2015.9.28+commit.4457170.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.3-nightly.2015.9.28+commit.4457170.js"
       ]
     },
     {
@@ -48,9 +60,12 @@
       "prerelease": "nightly.2015.9.29",
       "build": "commit.3ff932c",
       "longVersion": "0.1.3-nightly.2015.9.29+commit.3ff932c",
+      "sha256": "0x2124f7474e31bfa0758decc2a2544bed47e9a4dec458fd2793ea4674186c47ee",
       "keccak256": "0x6212a9c0a8c43bd0aa65c6ea44df979c0ac8076c0caffb7626187f716494470e",
       "urls": [
-        "bzzr://dcce6719f72d942523ccc834fc9656c063026681999684df89db56d2b7b1193b"
+        "bzzr://dcce6719f72d942523ccc834fc9656c063026681999684df89db56d2b7b1193b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.3-nightly.2015.9.29+commit.3ff932c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.3-nightly.2015.9.29+commit.3ff932c.js"
       ]
     },
     {
@@ -58,9 +73,12 @@
       "version": "0.1.3",
       "build": "commit.28f561",
       "longVersion": "0.1.3+commit.28f561",
+      "sha256": "0x1a806813a02d4925b180737aff1d58d6ee9bee38a528fb49dbbfd3e676d00a1c",
       "keccak256": "0x39ac3bf19dd7749006b19243aab5bdfd1e92b93133a2fa236e9d61af957dd444",
       "urls": [
-        "bzzr://05a3b37b2d7823363272c5b5648e12f3737457430a1f4e4477f6c3467592f7df"
+        "bzzr://05a3b37b2d7823363272c5b5648e12f3737457430a1f4e4477f6c3467592f7df",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.3+commit.28f561.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.3+commit.28f561.js"
       ]
     },
     {
@@ -69,9 +87,12 @@
       "prerelease": "nightly.2015.10.2",
       "build": "commit.795c894",
       "longVersion": "0.1.4-nightly.2015.10.2+commit.795c894",
+      "sha256": "0x26c003798eb828ccee0b1d658b3753a60405a21d72348722b290ec6a834f608a",
       "keccak256": "0xbbec189c18f89be0e8922a51ae5c36d8af93862adcebd7e56eefbf553294c1c9",
       "urls": [
-        "bzzr://45e946f18d0dd78d88405670a94c0a5971b3df495ca3cd8d744d3e0e29faa7a2"
+        "bzzr://45e946f18d0dd78d88405670a94c0a5971b3df495ca3cd8d744d3e0e29faa7a2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.4-nightly.2015.10.2+commit.795c894.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.4-nightly.2015.10.2+commit.795c894.js"
       ]
     },
     {
@@ -80,9 +101,12 @@
       "prerelease": "nightly.2015.10.5",
       "build": "commit.a33d173",
       "longVersion": "0.1.4-nightly.2015.10.5+commit.a33d173",
+      "sha256": "0x919aabc2c97ea54d03c4ccbf23783c60930ece2de40da1c4756f5ec4a05b8e8a",
       "keccak256": "0xd549468c636f2e3c404746e6c636fb7ec63b54b0a916e988e762721e83ccc1b2",
       "urls": [
-        "bzzr://95dc0995a929c94c2838f313ab4ad5cdb96d2e1c6eaecd219f5a8c226edbecde"
+        "bzzr://95dc0995a929c94c2838f313ab4ad5cdb96d2e1c6eaecd219f5a8c226edbecde",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.4-nightly.2015.10.5+commit.a33d173.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.4-nightly.2015.10.5+commit.a33d173.js"
       ]
     },
     {
@@ -91,9 +115,12 @@
       "prerelease": "nightly.2015.10.5",
       "build": "commit.7ff6762",
       "longVersion": "0.1.4-nightly.2015.10.5+commit.7ff6762",
+      "sha256": "0xf0578af6d3857538d138518f54c84ffc77df9f53e50c3e7539f345ce4eebbf20",
       "keccak256": "0x327eb1581add1b713ec7059aef981d5f4434147db77c86bf0aa2d58925d4b487",
       "urls": [
-        "bzzr://d432f13d6e6e8f15977d6e3a445844651ca8220c8fb6e69271eb32c5e103a084"
+        "bzzr://d432f13d6e6e8f15977d6e3a445844651ca8220c8fb6e69271eb32c5e103a084",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.4-nightly.2015.10.5+commit.7ff6762.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.4-nightly.2015.10.5+commit.7ff6762.js"
       ]
     },
     {
@@ -102,9 +129,12 @@
       "prerelease": "nightly.2015.10.6",
       "build": "commit.d35a4b8",
       "longVersion": "0.1.4-nightly.2015.10.6+commit.d35a4b8",
+      "sha256": "0xdda6e95e9c3d1d7ad65d974a4293f2722c23784d4cb8b5d85a34a96c153cf85b",
       "keccak256": "0x25ead85443c34a11c43628d4e0be18b99f916fde5af8dd72f04b99ca9d1477fe",
       "urls": [
-        "bzzr://0845cd024eea931fc09bf97903e06fff00f2228205f46eb3b4dff5435538e690"
+        "bzzr://0845cd024eea931fc09bf97903e06fff00f2228205f46eb3b4dff5435538e690",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.4-nightly.2015.10.6+commit.d35a4b8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.4-nightly.2015.10.6+commit.d35a4b8.js"
       ]
     },
     {
@@ -112,9 +142,12 @@
       "version": "0.1.4",
       "build": "commit.5f6c3cd",
       "longVersion": "0.1.4+commit.5f6c3cd",
+      "sha256": "0x34a1e8b62b5eae88ee59e572c8f941a375d587a7f3c21b6d24f415452bdc7a15",
       "keccak256": "0xc6b0944a8b55b534eb4eec02d3be54d26791ff60c99288ed5b2dc9c78ced32fe",
       "urls": [
-        "bzzr://4da68f33bd6bf02fff03670b9501121f5ce75cc4a2a7fea657c22d3f4a625d57"
+        "bzzr://4da68f33bd6bf02fff03670b9501121f5ce75cc4a2a7fea657c22d3f4a625d57",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.4+commit.5f6c3cd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.4+commit.5f6c3cd.js"
       ]
     },
     {
@@ -123,9 +156,12 @@
       "prerelease": "nightly.2015.10.13",
       "build": "commit.e11e10f",
       "longVersion": "0.1.5-nightly.2015.10.13+commit.e11e10f",
+      "sha256": "0x6e50b566c9e11b307e7c71e204cdba63e1eb555a623216010027a887d6b23d1b",
       "keccak256": "0x75a7f6ddc293fa833c3f8b9557f213646feb1f3acf190bbee9fd2ed3e5bb87a3",
       "urls": [
-        "bzzr://b7b4b2371045cabd508187fe76aabb8cae89ce715907686a921f527a0725f4c9"
+        "bzzr://b7b4b2371045cabd508187fe76aabb8cae89ce715907686a921f527a0725f4c9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.5-nightly.2015.10.13+commit.e11e10f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.5-nightly.2015.10.13+commit.e11e10f.js"
       ]
     },
     {
@@ -134,9 +170,12 @@
       "prerelease": "nightly.2015.10.15",
       "build": "commit.984ab6a",
       "longVersion": "0.1.5-nightly.2015.10.15+commit.984ab6a",
+      "sha256": "0x47e567199d3e0634410dc60f1bd10a66638ffec9abe86f683f40ef64e80bcad1",
       "keccak256": "0xd579bf0675fbd793da2e8f0aeb933c4c284393a559ad77aa0dd9820bcd376b3a",
       "urls": [
-        "bzzr://772f6bcb14c954334fb81a60e4ce3b4e5b8fc4646d1c1597600a6f4f8d85287b"
+        "bzzr://772f6bcb14c954334fb81a60e4ce3b4e5b8fc4646d1c1597600a6f4f8d85287b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.5-nightly.2015.10.15+commit.984ab6a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.5-nightly.2015.10.15+commit.984ab6a.js"
       ]
     },
     {
@@ -145,9 +184,12 @@
       "prerelease": "nightly.2015.10.16",
       "build": "commit.52eaa47",
       "longVersion": "0.1.5-nightly.2015.10.16+commit.52eaa47",
+      "sha256": "0x81777160a0cb9286081e62cab64b62cd9f56a9a3463f5111da209e351eaa9eb5",
       "keccak256": "0x24b5812fa67638b45602f60322417f3988859f4f6697c6d612970192e11a6c53",
       "urls": [
-        "bzzr://1243fcfefe1b30690232b297922a01e7d3725eafc96d6d519e739c7c7c841ec6"
+        "bzzr://1243fcfefe1b30690232b297922a01e7d3725eafc96d6d519e739c7c7c841ec6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.5-nightly.2015.10.16+commit.52eaa47.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.5-nightly.2015.10.16+commit.52eaa47.js"
       ]
     },
     {
@@ -155,9 +197,12 @@
       "version": "0.1.5",
       "build": "commit.23865e3",
       "longVersion": "0.1.5+commit.23865e3",
+      "sha256": "0x6c9bc5397f56746f928ce1d4e2522d2865052348d506f521b4f731f98f99c6df",
       "keccak256": "0x9639c043ae6df7267b0d904c334342e83c95bc3786dcb2b7d2a7c15c9f6ad916",
       "urls": [
-        "bzzr://c6533d87a48abff42c084159156c7fea1fe4fc8c7ee5fa64edaaa944cfb55603"
+        "bzzr://c6533d87a48abff42c084159156c7fea1fe4fc8c7ee5fa64edaaa944cfb55603",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.5+commit.23865e3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.5+commit.23865e3.js"
       ]
     },
     {
@@ -166,9 +211,12 @@
       "prerelease": "nightly.2015.10.22",
       "build": "commit.cb8f663",
       "longVersion": "0.1.6-nightly.2015.10.22+commit.cb8f663",
+      "sha256": "0x9b4db172dd44e32503a63d9cffd2b50631656b2a0d232755086aa4862337f87f",
       "keccak256": "0xc01ec46c797646ca067a01d43cec9a299a93805c72141503aade1810426f78dd",
       "urls": [
-        "bzzr://577a71aaa373c25ca3774ef46cbd52f65744ebf7990b1685be0ecae0b199fa4d"
+        "bzzr://577a71aaa373c25ca3774ef46cbd52f65744ebf7990b1685be0ecae0b199fa4d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.10.22+commit.cb8f663.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.10.22+commit.cb8f663.js"
       ]
     },
     {
@@ -177,9 +225,12 @@
       "prerelease": "nightly.2015.10.23",
       "build": "commit.7a9f8d9",
       "longVersion": "0.1.6-nightly.2015.10.23+commit.7a9f8d9",
+      "sha256": "0xedd5a1b49242c389308523a4713cf4f0a018593443a7d69ba2bb9a8fb83760a7",
       "keccak256": "0x9e5f2d9b1ff308e931b680d50c56fb98b96a2b5ce68ed84d3e8ce8c86f08de83",
       "urls": [
-        "bzzr://e849ae0a24b12802c723f4467e0932e0690179579207287229b5616f1d1b85df"
+        "bzzr://e849ae0a24b12802c723f4467e0932e0690179579207287229b5616f1d1b85df",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.10.23+commit.7a9f8d9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.10.23+commit.7a9f8d9.js"
       ]
     },
     {
@@ -188,9 +239,12 @@
       "prerelease": "nightly.2015.10.26",
       "build": "commit.e77decc",
       "longVersion": "0.1.6-nightly.2015.10.26+commit.e77decc",
+      "sha256": "0xe99184b01e8e51209e8cd029cf2a08ce0bf9fa9e07e1aefe453a89cf2b8a8510",
       "keccak256": "0xb088fb8782528c5578b3bf2048e6a5b1874c2c2a1eee5fd1d48198e325ad4306",
       "urls": [
-        "bzzr://5ac6626814a9ce5a13031fbf74ac9769bf155b2920275f39acf9821bcd97521d"
+        "bzzr://5ac6626814a9ce5a13031fbf74ac9769bf155b2920275f39acf9821bcd97521d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.10.26+commit.e77decc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.10.26+commit.e77decc.js"
       ]
     },
     {
@@ -199,9 +253,12 @@
       "prerelease": "nightly.2015.10.27",
       "build": "commit.22723da",
       "longVersion": "0.1.6-nightly.2015.10.27+commit.22723da",
+      "sha256": "0x0703a9ff3aa268f027e1ee6fc8345720548b1a017cfef06c966e1d2a823ee516",
       "keccak256": "0x439145e3be4288b971aca1121c62b90cc2b148c859b4157ae84e9ab228f8e609",
       "urls": [
-        "bzzr://1da661a66cc41b6b1751343cf5638adff12d698a8026a46bdcfa783c5a2c705c"
+        "bzzr://1da661a66cc41b6b1751343cf5638adff12d698a8026a46bdcfa783c5a2c705c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.10.27+commit.22723da.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.10.27+commit.22723da.js"
       ]
     },
     {
@@ -210,9 +267,12 @@
       "prerelease": "nightly.2015.11.2",
       "build": "commit.665344e",
       "longVersion": "0.1.6-nightly.2015.11.2+commit.665344e",
+      "sha256": "0x8a7640c0dd89d349e38a0d9c35dfc52e93d70f3e338e694f074e817e4a2dc89d",
       "keccak256": "0x52d9e3567cb9f2dd92d2be85dc88cb24cf8d90669e293e8cda17dec8eec22de3",
       "urls": [
-        "bzzr://6da7d3b8cf7170072c5ead6ce2140830f1d56581460a6cea7ce3bc4550043904"
+        "bzzr://6da7d3b8cf7170072c5ead6ce2140830f1d56581460a6cea7ce3bc4550043904",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.11.2+commit.665344e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.11.2+commit.665344e.js"
       ]
     },
     {
@@ -221,9 +281,12 @@
       "prerelease": "nightly.2015.11.3",
       "build": "commit.48ffa08",
       "longVersion": "0.1.6-nightly.2015.11.3+commit.48ffa08",
+      "sha256": "0x8b3d0fc558138e22ece848678914305203e35dbbcb765b7597dcd60038245620",
       "keccak256": "0x196e60c68548a1b0d09f79446300c7045d92a6c61e6f9d3103b514c628d6e3c2",
       "urls": [
-        "bzzr://ba5064107498b2ae67b091d73febab2177fc9a2d6376ef0de73636a5a4853a81"
+        "bzzr://ba5064107498b2ae67b091d73febab2177fc9a2d6376ef0de73636a5a4853a81",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.11.3+commit.48ffa08.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.11.3+commit.48ffa08.js"
       ]
     },
     {
@@ -232,9 +295,12 @@
       "prerelease": "nightly.2015.11.7",
       "build": "commit.94ea61c",
       "longVersion": "0.1.6-nightly.2015.11.7+commit.94ea61c",
+      "sha256": "0x8bd53ddecfcd1bdf47af3f6e06007281540f6b490c4758e9e0b797ea71df08f8",
       "keccak256": "0x8d6dc6a11481a5bf3a197b2bba7c445f13a2652ee6cf5f31811b8c66204f81b5",
       "urls": [
-        "bzzr://66e3417949d6eb9aff78ccca5f9b576b92f0af691f18935d07298140ebf4e34e"
+        "bzzr://66e3417949d6eb9aff78ccca5f9b576b92f0af691f18935d07298140ebf4e34e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.11.7+commit.94ea61c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.11.7+commit.94ea61c.js"
       ]
     },
     {
@@ -243,9 +309,12 @@
       "prerelease": "nightly.2015.11.12",
       "build": "commit.321b1ed",
       "longVersion": "0.1.6-nightly.2015.11.12+commit.321b1ed",
+      "sha256": "0x64380ddd7c409f0ae64144297927b24b9ad5338f9817258197da6f9e083917dd",
       "keccak256": "0x52845ac387cb670c99560710fe649263fa14d28a79ba4b08381688d36adbc921",
       "urls": [
-        "bzzr://e5a9fde92df9d40c7f8932ead550328f110144829b702f50cc61f8b277c834c6"
+        "bzzr://e5a9fde92df9d40c7f8932ead550328f110144829b702f50cc61f8b277c834c6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.11.12+commit.321b1ed.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.11.12+commit.321b1ed.js"
       ]
     },
     {
@@ -254,9 +323,12 @@
       "prerelease": "nightly.2015.11.16",
       "build": "commit.c881d10",
       "longVersion": "0.1.6-nightly.2015.11.16+commit.c881d10",
+      "sha256": "0x1e16f8dbdf4ac168b95543e0753622354c05b1527b1eada470fa70cf75c1d096",
       "keccak256": "0x4dd03f8976b78f217c9e12bd3100c25db7602e4bfa5e7ef9bca1e8cf976b3f22",
       "urls": [
-        "bzzr://3da23a3c9e2e7c844338f5927d7012a89ff8e33364a0c9b595eb0fcd6d2dabf4"
+        "bzzr://3da23a3c9e2e7c844338f5927d7012a89ff8e33364a0c9b595eb0fcd6d2dabf4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6-nightly.2015.11.16+commit.c881d10.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6-nightly.2015.11.16+commit.c881d10.js"
       ]
     },
     {
@@ -264,9 +336,12 @@
       "version": "0.1.6",
       "build": "commit.d41f8b7",
       "longVersion": "0.1.6+commit.d41f8b7",
+      "sha256": "0xb2fcb4f707ad6545c8a65b70164c59d4555cd607b97204844d51a803917a4549",
       "keccak256": "0x08610325fc49fb7dc244cf5adfd60a664c3cfb9d4845c90b30ef6f6abb748c60",
       "urls": [
-        "bzzr://e6eca935f031f31758db12507e10fe82d576a293b210caa3775c4246bb9679f2"
+        "bzzr://e6eca935f031f31758db12507e10fe82d576a293b210caa3775c4246bb9679f2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.6+commit.d41f8b7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.6+commit.d41f8b7.js"
       ]
     },
     {
@@ -275,9 +350,12 @@
       "prerelease": "nightly.2015.11.19",
       "build": "commit.58110b2",
       "longVersion": "0.1.7-nightly.2015.11.19+commit.58110b2",
+      "sha256": "0x81cf33f3ab4213c5ff84d58e5335611e6105645dbd1bd00d7b923488dfc9c9c4",
       "keccak256": "0xde1ac4213cc34cf4f06b201c20c3a76993a4fbf75fbaf305ed2bd75041193da8",
       "urls": [
-        "bzzr://9b8d7ae62dba09ab28cdc46b89809a5a68ae80ca089519b7c5c30da107ec13d9"
+        "bzzr://9b8d7ae62dba09ab28cdc46b89809a5a68ae80ca089519b7c5c30da107ec13d9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.7-nightly.2015.11.19+commit.58110b2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.7-nightly.2015.11.19+commit.58110b2.js"
       ]
     },
     {
@@ -286,9 +364,12 @@
       "prerelease": "nightly.2015.11.23",
       "build": "commit.2554d61",
       "longVersion": "0.1.7-nightly.2015.11.23+commit.2554d61",
+      "sha256": "0x738cb734cf02e76c5a918670258ee7cfc8f0af0457030795c6bf865fc9c18b0a",
       "keccak256": "0x2a8137eb4898c4b8a1f58ec65ff1ea5f30b51b9c62c41514ac1a847b2631450d",
       "urls": [
-        "bzzr://a38b4728e8eff74f1e93ac9faeac42452f449fe3624af1d43b8d4cc1ec39ab19"
+        "bzzr://a38b4728e8eff74f1e93ac9faeac42452f449fe3624af1d43b8d4cc1ec39ab19",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.7-nightly.2015.11.23+commit.2554d61.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.7-nightly.2015.11.23+commit.2554d61.js"
       ]
     },
     {
@@ -297,9 +378,12 @@
       "prerelease": "nightly.2015.11.24",
       "build": "commit.8d16c6e",
       "longVersion": "0.1.7-nightly.2015.11.24+commit.8d16c6e",
+      "sha256": "0x1022f09d15134a43692199a10955717d7ad4443b3a0623e44e86dc362d80b19c",
       "keccak256": "0x5550576ca6d1d81c9c8c3e5c16bf34b7500315cb4bf7b9ccfd221079354dd9f7",
       "urls": [
-        "bzzr://01ae095d65a88a5e0c28b096b419b4643f393f3d8aa89a23a315ad128df8301d"
+        "bzzr://01ae095d65a88a5e0c28b096b419b4643f393f3d8aa89a23a315ad128df8301d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.7-nightly.2015.11.24+commit.8d16c6e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.7-nightly.2015.11.24+commit.8d16c6e.js"
       ]
     },
     {
@@ -308,9 +392,12 @@
       "prerelease": "nightly.2015.11.26",
       "build": "commit.f86451c",
       "longVersion": "0.1.7-nightly.2015.11.26+commit.f86451c",
+      "sha256": "0xd89f03b50b86fbae346f3da71771b6dc0273bb2f031cb816ad27080eed76ba48",
       "keccak256": "0x55778c0ba69297a898a8a613226d67fa55476004d698144ecdd1118735c53aba",
       "urls": [
-        "bzzr://d4922c0e7493b9b7b4beccb318cc12c0401583519f5919354dcd7306bd2ad50c"
+        "bzzr://d4922c0e7493b9b7b4beccb318cc12c0401583519f5919354dcd7306bd2ad50c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.7-nightly.2015.11.26+commit.f86451c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.7-nightly.2015.11.26+commit.f86451c.js"
       ]
     },
     {
@@ -318,9 +405,12 @@
       "version": "0.1.7",
       "build": "commit.b4e666c",
       "longVersion": "0.1.7+commit.b4e666c",
+      "sha256": "0x41a0cbd38f6fb957ed3748688078f6e6186d9a2e8b6706de9a63dbf65c62ffd3",
       "keccak256": "0x90567736ca352a90da3bb8cec7e9f7c5793ec6a77686ed4a87f373b456781e09",
       "urls": [
-        "bzzr://84c85953cb16cfb7da8f75b09853ced60ddc3b36de6b2570cd66032a6fe0e802"
+        "bzzr://84c85953cb16cfb7da8f75b09853ced60ddc3b36de6b2570cd66032a6fe0e802",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.1.7+commit.b4e666c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.1.7+commit.b4e666c.js"
       ]
     },
     {
@@ -329,9 +419,12 @@
       "prerelease": "nightly.2015.12.4",
       "build": "commit.2e4aa9",
       "longVersion": "0.2.0-nightly.2015.12.4+commit.2e4aa9",
+      "sha256": "0xf784cd33a43589e5950fd52292b24532cf574b6884cebc4e32eeefc5bdf11b2a",
       "keccak256": "0x31c46f8a8a47d4385e9dcb0a9903450a17b26dc4b52203ffc179ac71c32cb1c9",
       "urls": [
-        "bzzr://31a83a8a23cd5122f69a99abfbedcb90376065cacbe5d8417dfeda64b212a705"
+        "bzzr://31a83a8a23cd5122f69a99abfbedcb90376065cacbe5d8417dfeda64b212a705",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.4+commit.2e4aa9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.4+commit.2e4aa9.js"
       ]
     },
     {
@@ -340,9 +433,12 @@
       "prerelease": "nightly.2015.12.6",
       "build": "commit.ba8bc45",
       "longVersion": "0.2.0-nightly.2015.12.6+commit.ba8bc45",
+      "sha256": "0xf6541c3cd9632f1f3312e649da928b7bc80c33e05b17f8a0922be0084a120477",
       "keccak256": "0xfa8823c0d24bf317d24a907619ff9f8be539bad7bd1fb9b05a33d149d90d8e45",
       "urls": [
-        "bzzr://d234c88bb43f2a672516a33a570d8c4544401263b8476fcc3735fb3e856d1837"
+        "bzzr://d234c88bb43f2a672516a33a570d8c4544401263b8476fcc3735fb3e856d1837",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.6+commit.ba8bc45.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.6+commit.ba8bc45.js"
       ]
     },
     {
@@ -351,9 +447,12 @@
       "prerelease": "nightly.2015.12.7",
       "build": "commit.15a1468",
       "longVersion": "0.2.0-nightly.2015.12.7+commit.15a1468",
+      "sha256": "0x0a48c9d78ecf52a25983efead5f30fa81c6d2f7d7ee29611eab16d95ea512ca9",
       "keccak256": "0x26df2bfecf8ffc79c9f7cf55640278460cedb88b727c56280bfdd1650cc27038",
       "urls": [
-        "bzzr://b9dab610440a4903bfc5d792347eeb3f6a682b66f544f4acda3c4b5d36954e71"
+        "bzzr://b9dab610440a4903bfc5d792347eeb3f6a682b66f544f4acda3c4b5d36954e71",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.7+commit.15a1468.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.7+commit.15a1468.js"
       ]
     },
     {
@@ -362,9 +461,12 @@
       "prerelease": "nightly.2015.12.10",
       "build": "commit.e709895",
       "longVersion": "0.2.0-nightly.2015.12.10+commit.e709895",
+      "sha256": "0x5f9127f04c325f4b2d984d54f65c9642fcd6f40dd2bd3c0c0087ffb5a2e4d23e",
       "keccak256": "0x4c29cc4f3ba731ee5c33817e072c493abd0421f032601a3fc1402e7b78b7c2bf",
       "urls": [
-        "bzzr://bc45e1adcfea736946f600c0ec49108485f9cbc3a785a2d34b05342e2d6524dd"
+        "bzzr://bc45e1adcfea736946f600c0ec49108485f9cbc3a785a2d34b05342e2d6524dd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.10+commit.e709895.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.10+commit.e709895.js"
       ]
     },
     {
@@ -373,9 +475,12 @@
       "prerelease": "nightly.2015.12.14",
       "build": "commit.98684cc",
       "longVersion": "0.2.0-nightly.2015.12.14+commit.98684cc",
+      "sha256": "0xb577c476477daac6a802d8f1a3ece2094c66b6bad3df4fa7d6cfa473d2fd4bdd",
       "keccak256": "0x9f56a38168d15b186324f97794c5115cfb5d7298881bf3afc021f65b8fb0d708",
       "urls": [
-        "bzzr://03475f702c7c9d71354a8f5c2147746df3e02d427ccc9dc926c5e68ef0076c04"
+        "bzzr://03475f702c7c9d71354a8f5c2147746df3e02d427ccc9dc926c5e68ef0076c04",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.14+commit.98684cc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.14+commit.98684cc.js"
       ]
     },
     {
@@ -384,9 +489,12 @@
       "prerelease": "nightly.2015.12.15",
       "build": "commit.591a4f1",
       "longVersion": "0.2.0-nightly.2015.12.15+commit.591a4f1",
+      "sha256": "0x7ec49afe5c9e6c7bcadd78317a0a256319c839e953f6f3d9bf3b98a491a58934",
       "keccak256": "0xa96c0961388eee841a155093d28aaef386f6494add28abf045cb0398f33b01f4",
       "urls": [
-        "bzzr://7feb62fe9b6d14ab8aa9ac7058136acc9e0d703b89b36266be3eab0ac3048959"
+        "bzzr://7feb62fe9b6d14ab8aa9ac7058136acc9e0d703b89b36266be3eab0ac3048959",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.15+commit.591a4f1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.15+commit.591a4f1.js"
       ]
     },
     {
@@ -395,9 +503,12 @@
       "prerelease": "nightly.2015.12.17",
       "build": "commit.fe23cc8",
       "longVersion": "0.2.0-nightly.2015.12.17+commit.fe23cc8",
+      "sha256": "0xaaff86aa4826a22d5467d090b4d3c596738a3d73100c3f4b0982cbf53d5fbf00",
       "keccak256": "0x030691f85a088857eac9401be6fd57c87434dab1f620e1d694c997377df01680",
       "urls": [
-        "bzzr://950f83df1c7969dd9c79ef97d063e38e558cea36e04bfe9bf4b6f5fb57139caf"
+        "bzzr://950f83df1c7969dd9c79ef97d063e38e558cea36e04bfe9bf4b6f5fb57139caf",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.17+commit.fe23cc8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.17+commit.fe23cc8.js"
       ]
     },
     {
@@ -406,9 +517,12 @@
       "prerelease": "nightly.2015.12.18",
       "build": "commit.6c6295b",
       "longVersion": "0.2.0-nightly.2015.12.18+commit.6c6295b",
+      "sha256": "0x12aa89dbf6b88c9c3ffdeedf50c8d1a0cf60d11b33ad31ebb1fe89799235bf57",
       "keccak256": "0x6a558a93889075c37b5bddea2c929f6352ef99d79a7e5fd17474fe51729d81be",
       "urls": [
-        "bzzr://00c5f3030740910755b2d81ac40fd33a00794c691025270585f86b8b345d04f4"
+        "bzzr://00c5f3030740910755b2d81ac40fd33a00794c691025270585f86b8b345d04f4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.18+commit.6c6295b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.18+commit.6c6295b.js"
       ]
     },
     {
@@ -417,9 +531,12 @@
       "prerelease": "nightly.2015.12.21",
       "build": "commit.6b711d0",
       "longVersion": "0.2.0-nightly.2015.12.21+commit.6b711d0",
+      "sha256": "0x3f18445e500d21bb0fa15652d8e5caff996ebae9e78e2a409b2a148ce8d4231b",
       "keccak256": "0x7134205d4d3b54c43851da8b2509b9d689a183ffb4e9df9b42c933379a34284d",
       "urls": [
-        "bzzr://641010abe88aad72994f6aa8609b2a25dfe2f6934ecc1c8e09235ca687cb4649"
+        "bzzr://641010abe88aad72994f6aa8609b2a25dfe2f6934ecc1c8e09235ca687cb4649",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2015.12.21+commit.6b711d0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2015.12.21+commit.6b711d0.js"
       ]
     },
     {
@@ -428,9 +545,12 @@
       "prerelease": "nightly.2016.1.4",
       "build": "commit.252bd14",
       "longVersion": "0.2.0-nightly.2016.1.4+commit.252bd14",
+      "sha256": "0x4380ed34c1604934f5293fdbc5f26686c0d2193e5ea65a1a02d3c238e6e0015e",
       "keccak256": "0x37b8c54f603c41e5f428e24b318d03bac39a41379cb65cd25a4fea33fa5d8a7c",
       "urls": [
-        "bzzr://1728b9ebeca09f568c1b4ddeafd962df26aa23b5e6bdf5947c0150e90101610d"
+        "bzzr://1728b9ebeca09f568c1b4ddeafd962df26aa23b5e6bdf5947c0150e90101610d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.4+commit.252bd14.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.4+commit.252bd14.js"
       ]
     },
     {
@@ -439,9 +559,12 @@
       "prerelease": "nightly.2016.1.5",
       "build": "commit.b158e48",
       "longVersion": "0.2.0-nightly.2016.1.5+commit.b158e48",
+      "sha256": "0xde4e7d17bace9c977c80e284af8f2a6b5e43a3b12ff3a5b9baa072834549b6ed",
       "keccak256": "0x593d522652ddc1ee3db466c7c5606cde834e4c9b0a3204793ae3cf0be08d26b0",
       "urls": [
-        "bzzr://e8bec2bd7742f713b0f8cdcd7e8b666f828052e1aba94ca82d7b8330835afd2c"
+        "bzzr://e8bec2bd7742f713b0f8cdcd7e8b666f828052e1aba94ca82d7b8330835afd2c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.5+commit.b158e48.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.5+commit.b158e48.js"
       ]
     },
     {
@@ -450,9 +573,12 @@
       "prerelease": "nightly.2016.1.11",
       "build": "commit.aa645d1",
       "longVersion": "0.2.0-nightly.2016.1.11+commit.aa645d1",
+      "sha256": "0xcf2fe2e6bc7f3c174c0714473580229042c01b8e96b80361ac33c5cd1c6f55c2",
       "keccak256": "0xad9f2b8457b137128ca2ac5d9e2c0859c20f3a50f4a47b5b003e8ad4c3495592",
       "urls": [
-        "bzzr://5e12fd41f1266f50a8ae40f1c688c155053424dc631ad370987754760f622e6a"
+        "bzzr://5e12fd41f1266f50a8ae40f1c688c155053424dc631ad370987754760f622e6a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.11+commit.aa645d1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.11+commit.aa645d1.js"
       ]
     },
     {
@@ -461,9 +587,12 @@
       "prerelease": "nightly.2016.1.12",
       "build": "commit.2c1aac",
       "longVersion": "0.2.0-nightly.2016.1.12+commit.2c1aac",
+      "sha256": "0xd0410c6b86144f1c5d0f1ae08683a1f75e21009dd864f13b3648a8c3eca0037b",
       "keccak256": "0x8cdbe82379e54fcee7523d8f91da7847485af04dad12764b879920c346cfd5ba",
       "urls": [
-        "bzzr://7e79f1970d7d627b9d5d044f92022d3d6b38b4cde007045134e326f372d113a0"
+        "bzzr://7e79f1970d7d627b9d5d044f92022d3d6b38b4cde007045134e326f372d113a0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.12+commit.2c1aac.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.12+commit.2c1aac.js"
       ]
     },
     {
@@ -472,9 +601,12 @@
       "prerelease": "nightly.2016.1.13",
       "build": "commit.d2f18c7",
       "longVersion": "0.2.0-nightly.2016.1.13+commit.d2f18c7",
+      "sha256": "0x17ae0d5645cf3ff11d6a8e6ff53f4cad10924bd365d8887c88769d4055d92678",
       "keccak256": "0xc72add9ee24838642fbafc8d119dab07bc0e438a0238c0510d635fc62132cb18",
       "urls": [
-        "bzzr://d2e0a7427bb8c54dcd1b1772b44bcdad3f0ebd53ce45f835726035a0690237f8"
+        "bzzr://d2e0a7427bb8c54dcd1b1772b44bcdad3f0ebd53ce45f835726035a0690237f8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.13+commit.d2f18c7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.13+commit.d2f18c7.js"
       ]
     },
     {
@@ -483,9 +615,12 @@
       "prerelease": "nightly.2016.1.14",
       "build": "commit.ca45cfe",
       "longVersion": "0.2.0-nightly.2016.1.14+commit.ca45cfe",
+      "sha256": "0xf49e17483b623bc64fcb8bed77afd8680a5eb73d6fced894ea6f57d5ac0924da",
       "keccak256": "0xe3be7fc0122058349ac82061efcdd334fbef8f58903888a2d3113a74e7a35090",
       "urls": [
-        "bzzr://ac03811fb9bc71abbf617d4f6b7f3a28bce233a09e10050e7d275dd02888d558"
+        "bzzr://ac03811fb9bc71abbf617d4f6b7f3a28bce233a09e10050e7d275dd02888d558",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.14+commit.ca45cfe.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.14+commit.ca45cfe.js"
       ]
     },
     {
@@ -494,9 +629,12 @@
       "prerelease": "nightly.2016.1.15",
       "build": "commit.cc4b4f5",
       "longVersion": "0.2.0-nightly.2016.1.15+commit.cc4b4f5",
+      "sha256": "0xc63bddc9361264e02d90678420d1f6a579c14b54200834105743bccafe966bfa",
       "keccak256": "0x1cc2cef112836ac74da29840c8d6f446ea8636d3f1333133b497dbd8db2be4c8",
       "urls": [
-        "bzzr://8f48810e9960053e702cf8e8bd3e0d468e58ab8cb2e1df1cf3c968fd3257b9a4"
+        "bzzr://8f48810e9960053e702cf8e8bd3e0d468e58ab8cb2e1df1cf3c968fd3257b9a4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.15+commit.cc4b4f5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.15+commit.cc4b4f5.js"
       ]
     },
     {
@@ -505,9 +643,12 @@
       "prerelease": "nightly.2016.1.18",
       "build": "commit.2340e8",
       "longVersion": "0.2.0-nightly.2016.1.18+commit.2340e8",
+      "sha256": "0x49cc0745429ee6164b33f50a85780368a1dbbb6c713763d85e60797929d23a25",
       "keccak256": "0xa584a215226c553db1b111cb7145abd529c3953b932e5609468a63620c7b4a90",
       "urls": [
-        "bzzr://0d13f14050c5ea001028ad3d6f792121427813b2bc2738e2420b5fea9927ab70"
+        "bzzr://0d13f14050c5ea001028ad3d6f792121427813b2bc2738e2420b5fea9927ab70",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.18+commit.2340e8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.18+commit.2340e8.js"
       ]
     },
     {
@@ -516,9 +657,12 @@
       "prerelease": "nightly.2016.1.19",
       "build": "commit.d21c427",
       "longVersion": "0.2.0-nightly.2016.1.19+commit.d21c427",
+      "sha256": "0xcac952694689ac2dbc8b6c76cb6bca65876fecce503fe175328b13002d1061a8",
       "keccak256": "0x758ede33c3b73649a869f7fce0c38515dd5b49622927ebb6a9251a654128540c",
       "urls": [
-        "bzzr://5e133f752c6fb1b7d47a5d6668f630bd06e3d7e1a3deed4da7e2d4d2787afd3c"
+        "bzzr://5e133f752c6fb1b7d47a5d6668f630bd06e3d7e1a3deed4da7e2d4d2787afd3c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.19+commit.d21c427.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.19+commit.d21c427.js"
       ]
     },
     {
@@ -527,9 +671,12 @@
       "prerelease": "nightly.2016.1.20",
       "build": "commit.67c855c",
       "longVersion": "0.2.0-nightly.2016.1.20+commit.67c855c",
+      "sha256": "0x00d8b32f435d33f66dbd2243d51117d0537da2d0a0fa3e4fcaf54c913bdff818",
       "keccak256": "0x412ebe3a98a7a635389e0b7d8c334f6008195ca9c3320f668e7f7c4d8bfe3baf",
       "urls": [
-        "bzzr://52078e8cb739d298e9949709f0267f4f31ad0b54cf420e8698b97b6282274764"
+        "bzzr://52078e8cb739d298e9949709f0267f4f31ad0b54cf420e8698b97b6282274764",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.20+commit.67c855c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.20+commit.67c855c.js"
       ]
     },
     {
@@ -538,9 +685,12 @@
       "prerelease": "nightly.2016.1.24",
       "build": "commit.194679f",
       "longVersion": "0.2.0-nightly.2016.1.24+commit.194679f",
+      "sha256": "0xeeda38e019dbbdb0bad8016a4c9b6a5b94d420cef7e6a9184583521d72c6578a",
       "keccak256": "0xe94af51137b5a298f211a4989c0a35ab1d2400c7d97e7ef24629bbe7ddf9866d",
       "urls": [
-        "bzzr://0f1d06cafe2f3ed9545d8af7cfba26ce133cef765fcff529d84db4d099d57692"
+        "bzzr://0f1d06cafe2f3ed9545d8af7cfba26ce133cef765fcff529d84db4d099d57692",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.24+commit.194679f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.24+commit.194679f.js"
       ]
     },
     {
@@ -549,9 +699,12 @@
       "prerelease": "nightly.2016.1.26",
       "build": "commit.9b9d10b",
       "longVersion": "0.2.0-nightly.2016.1.26+commit.9b9d10b",
+      "sha256": "0xb6ef61c1ce26b73103a08032a494cc90ae5a4796c0d7da363b0f059923b113f9",
       "keccak256": "0x7bdca1c0cee84ed05835aabf31ab88ce3c7f02752f720eae48c72aa7e9deeb2e",
       "urls": [
-        "bzzr://52996d628ca25a8d9f613b8f4cb066ef3fffd866f94cea9dd91a8ac174532bc2"
+        "bzzr://52996d628ca25a8d9f613b8f4cb066ef3fffd866f94cea9dd91a8ac174532bc2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.26+commit.9b9d10b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.26+commit.9b9d10b.js"
       ]
     },
     {
@@ -560,9 +713,12 @@
       "prerelease": "nightly.2016.1.28",
       "build": "commit.bdbb7d8",
       "longVersion": "0.2.0-nightly.2016.1.28+commit.bdbb7d8",
+      "sha256": "0x9b8514331eeba425d566b3f63b2a7c207dce5481a85d3427f76331e6bf045669",
       "keccak256": "0x3ce149319e0d26a63fff9788fa742ee28b2b4dbcca4391c996e29d17fa23d5d6",
       "urls": [
-        "bzzr://30c30436e65119c80a122aeede3df52127ff9169cb8147364881a3b25ea65215"
+        "bzzr://30c30436e65119c80a122aeede3df52127ff9169cb8147364881a3b25ea65215",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0-nightly.2016.1.28+commit.bdbb7d8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0-nightly.2016.1.28+commit.bdbb7d8.js"
       ]
     },
     {
@@ -570,9 +726,12 @@
       "version": "0.2.0",
       "build": "commit.4dc2445",
       "longVersion": "0.2.0+commit.4dc2445",
+      "sha256": "0x0fa8617f2180be99751704256f2a50f05321a99a5a1aa537543c4fa7516dedfb",
       "keccak256": "0x7d8ea0312905d250ec7554bd84526c3d97d05f6d5748888e6ec00629bd3ea7a6",
       "urls": [
-        "bzzr://0848ea1ded5b47cbae17d915810d1bf0857d9ea625cb332a0da68550cb27c699"
+        "bzzr://0848ea1ded5b47cbae17d915810d1bf0857d9ea625cb332a0da68550cb27c699",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.0+commit.4dc2445.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.0+commit.4dc2445.js"
       ]
     },
     {
@@ -581,9 +740,12 @@
       "prerelease": "nightly.2016.2.3",
       "build": "commit.fad2d4d",
       "longVersion": "0.2.1-nightly.2016.2.3+commit.fad2d4d",
+      "sha256": "0xefbe6a047ea868a4c0abd6dc5b26c13492448c64f4f6ff0888ce6b1cfe9334d0",
       "keccak256": "0x360ecffb369197bc1e25a02acfa5b5ce15a79ad79ae1fd3480c7b456eb27d116",
       "urls": [
-        "bzzr://056a14ac38df637e27887576d15f3fc59465a79a76982ba58721278355f0693d"
+        "bzzr://056a14ac38df637e27887576d15f3fc59465a79a76982ba58721278355f0693d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.1-nightly.2016.2.3+commit.fad2d4d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.1-nightly.2016.2.3+commit.fad2d4d.js"
       ]
     },
     {
@@ -592,9 +754,12 @@
       "prerelease": "nightly.2016.2.10",
       "build": "commit.7b5d96c",
       "longVersion": "0.2.1-nightly.2016.2.10+commit.7b5d96c",
+      "sha256": "0xc029f0a9811d5aa07d9eba1b8099a2f3fe168d74f37087d4dcdea3c943f59fde",
       "keccak256": "0x969155bf9226e7424bd92c7b27fa370d34304946083078e71eaa00dce0b55abb",
       "urls": [
-        "bzzr://c5ff803ea42a6a2a4ca31292b1b823abd2d4b616e7098f0987daffa57b243649"
+        "bzzr://c5ff803ea42a6a2a4ca31292b1b823abd2d4b616e7098f0987daffa57b243649",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.1-nightly.2016.2.10+commit.7b5d96c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.1-nightly.2016.2.10+commit.7b5d96c.js"
       ]
     },
     {
@@ -603,9 +768,12 @@
       "prerelease": "nightly.2016.2.11",
       "build": "commit.c6c3c78",
       "longVersion": "0.2.1-nightly.2016.2.11+commit.c6c3c78",
+      "sha256": "0x27049ea57679865e26fb79a012e4b813fb81f30e603d64aa54ae8f8ea5dabab6",
       "keccak256": "0x4a11c814c6d5edd0d001f2263f7a161659c1a409d75c4b75d31681b75d274b91",
       "urls": [
-        "bzzr://2de8538886c22b50bee685cf81a61f4ce0d5ac93225668023f2fbc9459f9a52c"
+        "bzzr://2de8538886c22b50bee685cf81a61f4ce0d5ac93225668023f2fbc9459f9a52c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.1-nightly.2016.2.11+commit.c6c3c78.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.1-nightly.2016.2.11+commit.c6c3c78.js"
       ]
     },
     {
@@ -614,9 +782,12 @@
       "prerelease": "nightly.2016.2.13",
       "build": "commit.a14185a",
       "longVersion": "0.2.1-nightly.2016.2.13+commit.a14185a",
+      "sha256": "0xdd7db5553850a232059c8f84d387584e089c69e807ecb66b3e589ae7b1bc3956",
       "keccak256": "0xf2c2815c6bfbc15b9990443a5779b1aca67281b6b9a1e3a35560ccd27c65bc0b",
       "urls": [
-        "bzzr://940d797dd7114c00b21e701a3e7b60382caa265eeb05d4aad5772fbaed5ab9f8"
+        "bzzr://940d797dd7114c00b21e701a3e7b60382caa265eeb05d4aad5772fbaed5ab9f8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.1-nightly.2016.2.13+commit.a14185a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.1-nightly.2016.2.13+commit.a14185a.js"
       ]
     },
     {
@@ -624,9 +795,12 @@
       "version": "0.2.1",
       "build": "commit.91a6b35",
       "longVersion": "0.2.1+commit.91a6b35",
+      "sha256": "0x1f954fc43414ac9012125c6080e007508bd8502bfa180d23c3033aa6943c4550",
       "keccak256": "0x7067e5792a88111c06a7078a23358641a64d0fa273b5220bfa5212029352dbe9",
       "urls": [
-        "bzzr://5b84475c0815ab9cd44ca5b4dcf4cd14d5f7db0bf3077fc825234b648305b277"
+        "bzzr://5b84475c0815ab9cd44ca5b4dcf4cd14d5f7db0bf3077fc825234b648305b277",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.1+commit.91a6b35.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.1+commit.91a6b35.js"
       ]
     },
     {
@@ -635,9 +809,12 @@
       "prerelease": "nightly.2016.2.18",
       "build": "commit.565d717",
       "longVersion": "0.2.2-nightly.2016.2.18+commit.565d717",
+      "sha256": "0xd1875c27922539efff03f57fcb2c320b652cb7ff5105fa443a377790d468555b",
       "keccak256": "0xc32e1b53252aaa942bc1a0293dc9c0993369ed19bb53a50e9c15a757aec8f5c5",
       "urls": [
-        "bzzr://045304bfabc27555dc17006c0bda282cbfebcb5cb717001738f83d64af978d64"
+        "bzzr://045304bfabc27555dc17006c0bda282cbfebcb5cb717001738f83d64af978d64",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2-nightly.2016.2.18+commit.565d717.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2-nightly.2016.2.18+commit.565d717.js"
       ]
     },
     {
@@ -646,9 +823,12 @@
       "prerelease": "nightly.2016.2.19",
       "build": "commit.3738107",
       "longVersion": "0.2.2-nightly.2016.2.19+commit.3738107",
+      "sha256": "0x5b77ec0ee4c24198349e6974a7823aef1f6cd8bb6ca6b84d2b9ce8b430d7f907",
       "keccak256": "0x8a61a7e1aafa218636afa78f44da1941f16b7bfd7a378d29bc57ace750b03516",
       "urls": [
-        "bzzr://72a7b41fe2bc20b522694cbfef12472fa73239628fe38aec0fa19ea91131131c"
+        "bzzr://72a7b41fe2bc20b522694cbfef12472fa73239628fe38aec0fa19ea91131131c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2-nightly.2016.2.19+commit.3738107.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2-nightly.2016.2.19+commit.3738107.js"
       ]
     },
     {
@@ -657,9 +837,12 @@
       "prerelease": "nightly.2016.2.22",
       "build": "commit.8339330",
       "longVersion": "0.2.2-nightly.2016.2.22+commit.8339330",
+      "sha256": "0xdefe744db4916d9022ae48e8425b23c71d75d94936d7f684a2820bf851799546",
       "keccak256": "0x5af0df70309df2cd19586d47bcd34ed306681d12ce27d25ef89d9dde4aab1174",
       "urls": [
-        "bzzr://8dcad707031877e375ea8cafdcac8c113b9da15c3d2b29da1355431a02fb035e"
+        "bzzr://8dcad707031877e375ea8cafdcac8c113b9da15c3d2b29da1355431a02fb035e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2-nightly.2016.2.22+commit.8339330.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2-nightly.2016.2.22+commit.8339330.js"
       ]
     },
     {
@@ -668,9 +851,12 @@
       "prerelease": "nightly.2016.3.1",
       "build": "commit.2bb315",
       "longVersion": "0.2.2-nightly.2016.3.1+commit.2bb315",
+      "sha256": "0x0d86ba2d4f04a7c14073e89a0d5f6f2c5ae8be3a4e8c59ae681246d3bcd7026c",
       "keccak256": "0x4baee97d1a0ee4ee6ed2948e817aea45423111e38068b83266a568bf4f7eb30c",
       "urls": [
-        "bzzr://95f83e8530d0e679d107298ee21ce9e3c3d0287fbb3d9d302d6e12a637cb253c"
+        "bzzr://95f83e8530d0e679d107298ee21ce9e3c3d0287fbb3d9d302d6e12a637cb253c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2-nightly.2016.3.1+commit.2bb315.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2-nightly.2016.3.1+commit.2bb315.js"
       ]
     },
     {
@@ -679,9 +865,12 @@
       "prerelease": "nightly.2016.3.2",
       "build": "commit.32f3a65",
       "longVersion": "0.2.2-nightly.2016.3.2+commit.32f3a65",
+      "sha256": "0xe3677c825a9bfe4a102a4e5b7936484da875efe015d1b7d238da399f24737c46",
       "keccak256": "0xcb6b3535f841781088a92f2039b1de829bc33348ca11931a383b0dd3dfbbd9b4",
       "urls": [
-        "bzzr://7b3c018413f87be25b3d69c57bf7284d3cf92ecf00cd6397b2591778b186dee4"
+        "bzzr://7b3c018413f87be25b3d69c57bf7284d3cf92ecf00cd6397b2591778b186dee4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2-nightly.2016.3.2+commit.32f3a65.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2-nightly.2016.3.2+commit.32f3a65.js"
       ]
     },
     {
@@ -690,9 +879,12 @@
       "prerelease": "nightly.2016.3.10",
       "build": "commit.34d714f",
       "longVersion": "0.2.2-nightly.2016.3.10+commit.34d714f",
+      "sha256": "0x0642c019003d97c2e51697ab3f394940322338c433a3db415bccc2ac30217158",
       "keccak256": "0x228fdfa9e09329885989b49fb21be808313ee966b84620f57b8ec100cc308516",
       "urls": [
-        "bzzr://a05dc23b4936010ad66949017003e242ab11f55ce13c0bbad6439bd4fe540baf"
+        "bzzr://a05dc23b4936010ad66949017003e242ab11f55ce13c0bbad6439bd4fe540baf",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2-nightly.2016.3.10+commit.34d714f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2-nightly.2016.3.10+commit.34d714f.js"
       ]
     },
     {
@@ -700,9 +892,12 @@
       "version": "0.2.2",
       "build": "commit.ef92f56",
       "longVersion": "0.2.2+commit.ef92f56",
+      "sha256": "0x04f5e3c386833a5a0e15e204dec859a2499c8d7da69b89544e475c25004c4602",
       "keccak256": "0xd7b4eac4e3bf9a128f4729fa44f2efbd865739d1fc513ad3a21129fea333502d",
       "urls": [
-        "bzzr://18452b4e52d051af96e6b1331a5d123bbe3bf6c52592b59b41325502b5eadd7c"
+        "bzzr://18452b4e52d051af96e6b1331a5d123bbe3bf6c52592b59b41325502b5eadd7c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.2.2+commit.ef92f56.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.2.2+commit.ef92f56.js"
       ]
     },
     {
@@ -711,9 +906,12 @@
       "prerelease": "nightly.2016.3.11",
       "build": "commit.1f9578c",
       "longVersion": "0.3.0-nightly.2016.3.11+commit.1f9578c",
+      "sha256": "0x9eda87113669ab41e49bc82dc41dc97882a3b1a1ef4b26233a7decc218857112",
       "keccak256": "0xa8abb73404da6db6a3ae96de3ee857ed5c9fc532efeb9e122c85c36e75447753",
       "urls": [
-        "bzzr://5fc722ba4b94bc1b6aaabd79ee38f709a126b51a271eb2e790963e3646834bd6"
+        "bzzr://5fc722ba4b94bc1b6aaabd79ee38f709a126b51a271eb2e790963e3646834bd6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.0-nightly.2016.3.11+commit.1f9578c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.0-nightly.2016.3.11+commit.1f9578c.js"
       ]
     },
     {
@@ -722,9 +920,12 @@
       "prerelease": "nightly.2016.3.18",
       "build": "commit.e759a24",
       "longVersion": "0.3.0-nightly.2016.3.18+commit.e759a24",
+      "sha256": "0x6bb343f3efbb301e11bde7cce219f3687fdae895e6e0c86d094c6ab0fdf71cc1",
       "keccak256": "0x9abaae03cce80facbf16aea914d2ba040afe421ee69e3fa63b7ed6a07c487f32",
       "urls": [
-        "bzzr://a1407ca844a88c8c8732754c0ac0da43285b89949d18e9755df9a872fcd689af"
+        "bzzr://a1407ca844a88c8c8732754c0ac0da43285b89949d18e9755df9a872fcd689af",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.0-nightly.2016.3.18+commit.e759a24.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.0-nightly.2016.3.18+commit.e759a24.js"
       ]
     },
     {
@@ -733,9 +934,12 @@
       "prerelease": "nightly.2016.3.30",
       "build": "commit.2acdfc5",
       "longVersion": "0.3.0-nightly.2016.3.30+commit.2acdfc5",
+      "sha256": "0xfa7c6e62291eb09ec7da781d6ebe5f91f16d63094a05527d25e6dd37661fb022",
       "keccak256": "0x941db66dc175ec3a7e26bf191480f13f7835c4e24fd19a0d081754451a617a40",
       "urls": [
-        "bzzr://845b79a638cc6e4c689e4eee8d7e6b65e67fc0f2c089301318fdd6f3290303da"
+        "bzzr://845b79a638cc6e4c689e4eee8d7e6b65e67fc0f2c089301318fdd6f3290303da",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.0-nightly.2016.3.30+commit.2acdfc5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.0-nightly.2016.3.30+commit.2acdfc5.js"
       ]
     },
     {
@@ -744,9 +948,12 @@
       "prerelease": "nightly.2016.3.30",
       "build": "commit.c2cf806",
       "longVersion": "0.3.0-nightly.2016.3.30+commit.c2cf806",
+      "sha256": "0x5c21f9931c341c9316d73c329c1dd9574708ba770cc651387b28ad46033fcd91",
       "keccak256": "0xc87e8cd1b4ef246eb76137265ea40490eb9be91024767b5d298c7dd0b46107dc",
       "urls": [
-        "bzzr://ddbb6ecffbdbb42afb09812ce9b02fabe053b0be8eac465e5686bc03f30a5043"
+        "bzzr://ddbb6ecffbdbb42afb09812ce9b02fabe053b0be8eac465e5686bc03f30a5043",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.0-nightly.2016.3.30+commit.c2cf806.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.0-nightly.2016.3.30+commit.c2cf806.js"
       ]
     },
     {
@@ -754,9 +961,12 @@
       "version": "0.3.0",
       "build": "commit.11d6736",
       "longVersion": "0.3.0+commit.11d6736",
+      "sha256": "0xd936d1b755582da12f0d11acd3bdb85050c40dfcb779d736d8929ca2e50de9d1",
       "keccak256": "0x454d35224a9aa036650acc809cf01f1f161aac5387f57e597b6e543eaf03ffd8",
       "urls": [
-        "bzzr://23b5bb211fecf22617061fdba5037f1b82ac1e53e7cd031684fff8d16722826c"
+        "bzzr://23b5bb211fecf22617061fdba5037f1b82ac1e53e7cd031684fff8d16722826c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.0+commit.11d6736.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.0+commit.11d6736.js"
       ]
     },
     {
@@ -765,9 +975,12 @@
       "prerelease": "nightly.2016.3.31",
       "build": "commit.c67926c",
       "longVersion": "0.3.1-nightly.2016.3.31+commit.c67926c",
+      "sha256": "0x23b9bafecdc34d947955918416c51b8c06affefeab2a5b0375c18c2658bc6374",
       "keccak256": "0x3eaff752033f4b9ab4197421d1ba6db5ab657b6511384a54708f68f2c286b599",
       "urls": [
-        "bzzr://7f3e974be20dd1daedf899277356ee923562da891849f5479ca8b5b326413b73"
+        "bzzr://7f3e974be20dd1daedf899277356ee923562da891849f5479ca8b5b326413b73",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.3.31+commit.c67926c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.3.31+commit.c67926c.js"
       ]
     },
     {
@@ -776,9 +989,12 @@
       "prerelease": "nightly.2016.4.5",
       "build": "commit.12797ed",
       "longVersion": "0.3.1-nightly.2016.4.5+commit.12797ed",
+      "sha256": "0x9bac65372666e6aeb2730c7fbceeef247d3029bbeb545d758d3ffc6181987e0c",
       "keccak256": "0x4d55a70a008bfec90c26e123ffd69e3be94076994d092a2d8bb27669ade15293",
       "urls": [
-        "bzzr://e150cee6dc37cc86cddba4e5247baab8c0f133834a4fb8bc9d96eba9257fe358"
+        "bzzr://e150cee6dc37cc86cddba4e5247baab8c0f133834a4fb8bc9d96eba9257fe358",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.4.5+commit.12797ed.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.4.5+commit.12797ed.js"
       ]
     },
     {
@@ -787,9 +1003,12 @@
       "prerelease": "nightly.2016.4.7",
       "build": "commit.54bc2a",
       "longVersion": "0.3.1-nightly.2016.4.7+commit.54bc2a",
+      "sha256": "0x3c72331f7b1dab3732d4cb4ae0883ada00206f28b36902b119eb2584deeaedf0",
       "keccak256": "0x3a1519d7454cdf037c7b56f569a79612264ae81db541fa357ba27336120ddeb1",
       "urls": [
-        "bzzr://0858d22e45e237fe14762e664800bc6d8d03fe8f82912ef20eb0a13c33f28b7a"
+        "bzzr://0858d22e45e237fe14762e664800bc6d8d03fe8f82912ef20eb0a13c33f28b7a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.4.7+commit.54bc2a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.4.7+commit.54bc2a.js"
       ]
     },
     {
@@ -798,9 +1017,12 @@
       "prerelease": "nightly.2016.4.12",
       "build": "commit.3ad5e82",
       "longVersion": "0.3.1-nightly.2016.4.12+commit.3ad5e82",
+      "sha256": "0x9406c1077814e3473aa4797191ef64cefa45b818a78a2129ec1b457a7c5f5636",
       "keccak256": "0xdb64f004110a9c99b5d5f0190d1cc3831c22aab4bf7cfff4ebd5d96e32ad2c2c",
       "urls": [
-        "bzzr://3d6d1331408f7dae3e58daa061f87512098a3328c892ca467aa75f9d82f8fa3e"
+        "bzzr://3d6d1331408f7dae3e58daa061f87512098a3328c892ca467aa75f9d82f8fa3e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.4.12+commit.3ad5e82.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.4.12+commit.3ad5e82.js"
       ]
     },
     {
@@ -809,9 +1031,12 @@
       "prerelease": "nightly.2016.4.13",
       "build": "commit.9137506",
       "longVersion": "0.3.1-nightly.2016.4.13+commit.9137506",
+      "sha256": "0xcae27903aab649149d1db479cd80aee0ec0cd281e8a5fb2a1b8cc3b8634aae18",
       "keccak256": "0x27eb47675846e5ae02d3e62cf4d7415c0512f0f001029a9e09fe7e735c32626a",
       "urls": [
-        "bzzr://1fd90544532cd96b7d1c9de81a61b86ddd52ceb1e0c95a26a0583eb46fa44915"
+        "bzzr://1fd90544532cd96b7d1c9de81a61b86ddd52ceb1e0c95a26a0583eb46fa44915",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.4.13+commit.9137506.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.4.13+commit.9137506.js"
       ]
     },
     {
@@ -820,9 +1045,12 @@
       "prerelease": "nightly.2016.4.15",
       "build": "commit.7ba6c98",
       "longVersion": "0.3.1-nightly.2016.4.15+commit.7ba6c98",
+      "sha256": "0x67bdc3ec543e1233feb237bc1c342b452ab1d5b8827cd41e2faf3972784377fd",
       "keccak256": "0xcce9d20dce7941189fdd2d3b1e766b785c81830085f7d68c1ae8224df2497c2f",
       "urls": [
-        "bzzr://7834d15b5ddc341b4d3b5c40801c5b288f0eb61ee222dee2e1d19dd83e0215c5"
+        "bzzr://7834d15b5ddc341b4d3b5c40801c5b288f0eb61ee222dee2e1d19dd83e0215c5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.4.15+commit.7ba6c98.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.4.15+commit.7ba6c98.js"
       ]
     },
     {
@@ -831,9 +1059,12 @@
       "prerelease": "nightly.2016.4.18",
       "build": "commit.81ae2a7",
       "longVersion": "0.3.1-nightly.2016.4.18+commit.81ae2a7",
+      "sha256": "0xa6dd551109f4f316d9b6a469fa5066f94653db9682d28058eeeec49ae0eadfc4",
       "keccak256": "0x44064048f215bd393fa394964d6c7e29d31c98053312b0536ce4ba3c5948c25b",
       "urls": [
-        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5"
+        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1-nightly.2016.4.18+commit.81ae2a7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1-nightly.2016.4.18+commit.81ae2a7.js"
       ]
     },
     {
@@ -841,9 +1072,12 @@
       "version": "0.3.1",
       "build": "commit.c492d9b",
       "longVersion": "0.3.1+commit.c492d9b",
+      "sha256": "0xaa7c0b18821a2f23c09da479d803f73976011445d2b512cf23e4a31d1a268bd5",
       "keccak256": "0x17b583f06e82c007ca0daf40344a12b5d93e85dd31969f076ecfe705db6d360c",
       "urls": [
-        "bzzr://2b86d6491012ec3289a22ee1c2fd6a093e68dd0d93675177f9a92c1f795b9415"
+        "bzzr://2b86d6491012ec3289a22ee1c2fd6a093e68dd0d93675177f9a92c1f795b9415",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.1+commit.c492d9b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.1+commit.c492d9b.js"
       ]
     },
     {
@@ -852,9 +1086,12 @@
       "prerelease": "nightly.2016.4.22",
       "build": "commit.dd4300d",
       "longVersion": "0.3.2-nightly.2016.4.22+commit.dd4300d",
+      "sha256": "0x4a7dad730af26ab13ce5b32122f00fba59995ac2e6fca74cbef38b49cae5cc0b",
       "keccak256": "0x7a5babe98735ca334e780047aabfc0500b24c0a9f48ccd34ca4070d68215b179",
       "urls": [
-        "bzzr://d76345e68833185f3ba48ff5ca742afc14f928d624f0691cdfce1b77bae862b6"
+        "bzzr://d76345e68833185f3ba48ff5ca742afc14f928d624f0691cdfce1b77bae862b6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.4.22+commit.dd4300d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.4.22+commit.dd4300d.js"
       ]
     },
     {
@@ -863,9 +1100,12 @@
       "prerelease": "nightly.2016.5.1",
       "build": "commit.bee80f1",
       "longVersion": "0.3.2-nightly.2016.5.1+commit.bee80f1",
+      "sha256": "0x1757199d38c6f13c9aca0e72a973b9834b8b42027598d6fe85c69c321d8afaa6",
       "keccak256": "0xcdcf9aa16e51c7e214b4b491ab73fa1a294634cd0182cb7e0d9ae2ca18441acf",
       "urls": [
-        "bzzr://e1e6c1c723fcd32d1cf75579e08c6db2bf207bd7f0290095310a04b6745f6167"
+        "bzzr://e1e6c1c723fcd32d1cf75579e08c6db2bf207bd7f0290095310a04b6745f6167",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.1+commit.bee80f1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.1+commit.bee80f1.js"
       ]
     },
     {
@@ -874,9 +1114,12 @@
       "prerelease": "nightly.2016.5.3",
       "build": "commit.aa4dcbb",
       "longVersion": "0.3.2-nightly.2016.5.3+commit.aa4dcbb",
+      "sha256": "0x98a4f383aee5be5ddd769886ba36f13b53ff635466b24054bcc3cdf2956c4094",
       "keccak256": "0x9302a446e60d678f385e58d8c3f1e33fdf31b75ecab793e4932b9b2bdaef1fe4",
       "urls": [
-        "bzzr://93a3d8388e347cd8b7a126e6a38cfe17b0de2decf808ab4799a0cad644a9709e"
+        "bzzr://93a3d8388e347cd8b7a126e6a38cfe17b0de2decf808ab4799a0cad644a9709e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.3+commit.aa4dcbb.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.3+commit.aa4dcbb.js"
       ]
     },
     {
@@ -885,9 +1128,12 @@
       "prerelease": "nightly.2016.5.5",
       "build": "commit.1b7e2d3",
       "longVersion": "0.3.2-nightly.2016.5.5+commit.1b7e2d3",
+      "sha256": "0xe8f761da6443701149f37b665c0fdf63544e4d7fa8ffd1deff6230c9240c5eab",
       "keccak256": "0xcf932ca69b3d62ee094f9e137b7113a3039a212ecdf10d081efad38940b36f4f",
       "urls": [
-        "bzzr://9660b713dcfaa8db923af1c65aa9372a526023fe46d5a5b169d7ff8fa72bc6d2"
+        "bzzr://9660b713dcfaa8db923af1c65aa9372a526023fe46d5a5b169d7ff8fa72bc6d2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.5+commit.1b7e2d3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.5+commit.1b7e2d3.js"
       ]
     },
     {
@@ -896,9 +1142,12 @@
       "prerelease": "nightly.2016.5.6",
       "build": "commit.9e36bdd",
       "longVersion": "0.3.2-nightly.2016.5.6+commit.9e36bdd",
+      "sha256": "0xd6260ff64662c6012e9156709a0f54088027b591eb3793a894495bfbf69e2d31",
       "keccak256": "0x9489ef1b87235388b354970a4a340e37dcdd2d6dca017b2bb5fcff618913bb8f",
       "urls": [
-        "bzzr://2ee65d3cab7594c7b7c5111e30098bb2177a6c262476876270b2ee75bba7c04d"
+        "bzzr://2ee65d3cab7594c7b7c5111e30098bb2177a6c262476876270b2ee75bba7c04d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.6+commit.9e36bdd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.6+commit.9e36bdd.js"
       ]
     },
     {
@@ -907,9 +1156,12 @@
       "prerelease": "nightly.2016.5.12",
       "build": "commit.73ede5b",
       "longVersion": "0.3.2-nightly.2016.5.12+commit.73ede5b",
+      "sha256": "0x0d7768c896ab3f3bd62cbcc61f0a564f237f71518cc19a55202fbccda5a7d1c9",
       "keccak256": "0xb6123a4f4145798d586cd4dab2bb33407f8bfc7fc4e3b888a69ff72b0fec3dc9",
       "urls": [
-        "bzzr://e6e12735593aea666821ccdaddff3f75bf1f59228060b28928cd54cd946397b6"
+        "bzzr://e6e12735593aea666821ccdaddff3f75bf1f59228060b28928cd54cd946397b6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.12+commit.73ede5b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.12+commit.73ede5b.js"
       ]
     },
     {
@@ -918,9 +1170,12 @@
       "prerelease": "nightly.2016.5.12",
       "build": "commit.c06051d",
       "longVersion": "0.3.2-nightly.2016.5.12+commit.c06051d",
+      "sha256": "0x983d767691b17e60f38526eec77ea9408a3420f8fed8aa4b782db744d4e08614",
       "keccak256": "0xde87b806132ac2e7aa80942e562aa07c0ae289ad6f8652795c73cc17a839bd8b",
       "urls": [
-        "bzzr://50eecd81d0d0450ae1a9b96dc4b326ccea3b808d59b95db44b828c0e2dac5d87"
+        "bzzr://50eecd81d0d0450ae1a9b96dc4b326ccea3b808d59b95db44b828c0e2dac5d87",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.12+commit.c06051d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.12+commit.c06051d.js"
       ]
     },
     {
@@ -929,9 +1184,12 @@
       "prerelease": "nightly.2016.5.13",
       "build": "commit.4b445b8",
       "longVersion": "0.3.2-nightly.2016.5.13+commit.4b445b8",
+      "sha256": "0xf9fe6ad475ee114b75431a3c2449e6533c38988fe83400719f016cae0aacc3ff",
       "keccak256": "0x02323bb8210fc523cd3fb8dfec278ea06b72b456114aa8c0bfde3c670e9f9daf",
       "urls": [
-        "bzzr://4ebcf240ec9d951c0a8a2a9336d53e531291afb7825da8f5339010f1032e3777"
+        "bzzr://4ebcf240ec9d951c0a8a2a9336d53e531291afb7825da8f5339010f1032e3777",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.13+commit.4b445b8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.13+commit.4b445b8.js"
       ]
     },
     {
@@ -940,9 +1198,12 @@
       "prerelease": "nightly.2016.5.17",
       "build": "commit.a37072",
       "longVersion": "0.3.2-nightly.2016.5.17+commit.a37072",
+      "sha256": "0x989accc3f979967ffe0c23b03ae9d7b3bc4d566ffb5899f3c0818291fc8a5ef7",
       "keccak256": "0x6fa50ba43b69830219f2670cd3fd707ef17e5a501c21071a4be8011e27235d6c",
       "urls": [
-        "bzzr://0d2537be970544b5c934c3ae3148f0456fe24cf4b7b4f659664273794a8098a6"
+        "bzzr://0d2537be970544b5c934c3ae3148f0456fe24cf4b7b4f659664273794a8098a6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.17+commit.a37072.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.17+commit.a37072.js"
       ]
     },
     {
@@ -951,9 +1212,12 @@
       "prerelease": "nightly.2016.5.18",
       "build": "commit.cb865fb",
       "longVersion": "0.3.2-nightly.2016.5.18+commit.cb865fb",
+      "sha256": "0x96f964d9c5c2542498abd84f4ce3b6c679664e325844649b160b7ac48b4a2a6b",
       "keccak256": "0x2717dfe52d8b26807485664d813b926b046394b968ea6a7f438e1677b3748e4a",
       "urls": [
-        "bzzr://a3ec1928f49d3f7c2eee99ac060feaf96d441631e3f4ba68d9732f735bfd597d"
+        "bzzr://a3ec1928f49d3f7c2eee99ac060feaf96d441631e3f4ba68d9732f735bfd597d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.18+commit.cb865fb.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.18+commit.cb865fb.js"
       ]
     },
     {
@@ -962,9 +1226,12 @@
       "prerelease": "nightly.2016.5.19",
       "build": "commit.7a51852",
       "longVersion": "0.3.2-nightly.2016.5.19+commit.7a51852",
+      "sha256": "0xfe40de07cf670e952d2b56981493a878ac1b06efd821284a4976c96fb872c650",
       "keccak256": "0x52d3bf239da2501272dcc5d223caad818689c117baca308504b3dcfc11becf6b",
       "urls": [
-        "bzzr://dd83f2d7364573bcafccd65a008e7ce9a03e6b7f81d488cb74a774ad450a2d9c"
+        "bzzr://dd83f2d7364573bcafccd65a008e7ce9a03e6b7f81d488cb74a774ad450a2d9c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.19+commit.7a51852.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.19+commit.7a51852.js"
       ]
     },
     {
@@ -973,9 +1240,12 @@
       "prerelease": "nightly.2016.5.20",
       "build": "commit.e3c5418",
       "longVersion": "0.3.2-nightly.2016.5.20+commit.e3c5418",
+      "sha256": "0x9ad2a6f478769543e33836a763578a9b2d3931a1b3533aa89b3e631efd447690",
       "keccak256": "0xf68c39478270ef3bbec58992038858cbbdb3a27486181e424bf28f167dd93d3c",
       "urls": [
-        "bzzr://717e33629edfa67935dc5ca9d4de2fe6532d30bdb9a58794434b3497ebd11939"
+        "bzzr://717e33629edfa67935dc5ca9d4de2fe6532d30bdb9a58794434b3497ebd11939",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.20+commit.e3c5418.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.20+commit.e3c5418.js"
       ]
     },
     {
@@ -984,9 +1254,12 @@
       "prerelease": "nightly.2016.5.24",
       "build": "commit.86c65c9",
       "longVersion": "0.3.2-nightly.2016.5.24+commit.86c65c9",
+      "sha256": "0x4a69e769223fbcf4067839ce02198f18a62497c344197639f7ca9ff2b05ba5f3",
       "keccak256": "0x7f686f0858b0ddcca9010f6388fdbf5bbb0273d20efd7fd23680e61522d8ec84",
       "urls": [
-        "bzzr://f412a6c4d51fab6c93726221cefaa61c251dc4e28fae7fc99cec21440000e462"
+        "bzzr://f412a6c4d51fab6c93726221cefaa61c251dc4e28fae7fc99cec21440000e462",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.24+commit.86c65c9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.24+commit.86c65c9.js"
       ]
     },
     {
@@ -995,9 +1268,12 @@
       "prerelease": "nightly.2016.5.25",
       "build": "commit.3c2056c",
       "longVersion": "0.3.2-nightly.2016.5.25+commit.3c2056c",
+      "sha256": "0x75f4518035a031a705cb23b964decdfefdfaf1181454e69b5011047fbc92c3d2",
       "keccak256": "0x50d43dbae57b67c95c1c0dac16eb780f7b4a95f276e7180bc33b3afa8ece8a3c",
       "urls": [
-        "bzzr://feef476b6793e3003fcfc018cf98ac53c9de940194602982b7fb07de13694afe"
+        "bzzr://feef476b6793e3003fcfc018cf98ac53c9de940194602982b7fb07de13694afe",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.25+commit.3c2056c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.25+commit.3c2056c.js"
       ]
     },
     {
@@ -1006,9 +1282,12 @@
       "prerelease": "nightly.2016.5.27",
       "build": "commit.4dc1cb1",
       "longVersion": "0.3.2-nightly.2016.5.27+commit.4dc1cb1",
+      "sha256": "0x91a9569b69fc7f6676014bbd265d29efb09338b96d5880943bd6f1836e213b0c",
       "keccak256": "0xc7e1f69fc0fd67be01a07ac60fdd085425d0a93f04affe696e24d2f9145ee742",
       "urls": [
-        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23"
+        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2-nightly.2016.5.27+commit.4dc1cb1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2-nightly.2016.5.27+commit.4dc1cb1.js"
       ]
     },
     {
@@ -1016,9 +1295,12 @@
       "version": "0.3.2",
       "build": "commit.81ae2a7",
       "longVersion": "0.3.2+commit.81ae2a7",
+      "sha256": "0xa6dd551109f4f316d9b6a469fa5066f94653db9682d28058eeeec49ae0eadfc4",
       "keccak256": "0x44064048f215bd393fa394964d6c7e29d31c98053312b0536ce4ba3c5948c25b",
       "urls": [
-        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5"
+        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.2+commit.81ae2a7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.2+commit.81ae2a7.js"
       ]
     },
     {
@@ -1027,9 +1309,12 @@
       "prerelease": "nightly.2016.5.28",
       "build": "commit.eb57a0c",
       "longVersion": "0.3.3-nightly.2016.5.28+commit.eb57a0c",
+      "sha256": "0xf9e7c89c42938aafd676b2a99ac697a2d7ed9af51312a9ac6ccb355e86c8e345",
       "keccak256": "0x30f3d3e92f3e4de23489aa99951d1dd8ecbc2912a9f95ad4cd408bb81c4a8f73",
       "urls": [
-        "bzzr://da158fda0b357e429c7fbcf2295e2e77e346dc2cd19ca60c7bf3c2252fa316c7"
+        "bzzr://da158fda0b357e429c7fbcf2295e2e77e346dc2cd19ca60c7bf3c2252fa316c7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.3-nightly.2016.5.28+commit.eb57a0c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.3-nightly.2016.5.28+commit.eb57a0c.js"
       ]
     },
     {
@@ -1038,9 +1323,12 @@
       "prerelease": "nightly.2016.5.30",
       "build": "commit.4be92c0",
       "longVersion": "0.3.3-nightly.2016.5.30+commit.4be92c0",
+      "sha256": "0x6961a9da4c6fe3d7246ac11d8815a7bab8e1ae22a0ca0a06ede8c5afd5711841",
       "keccak256": "0x5ee190efe0d9a9668d9e8c141827e0c743b777ba0eec9f3722defadd53e9d5a7",
       "urls": [
-        "bzzr://f8e63d3aaceb1460fb4fba5b33507653b345aa7badeb23073f90aa947b58a44e"
+        "bzzr://f8e63d3aaceb1460fb4fba5b33507653b345aa7badeb23073f90aa947b58a44e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.3-nightly.2016.5.30+commit.4be92c0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.3-nightly.2016.5.30+commit.4be92c0.js"
       ]
     },
     {
@@ -1049,9 +1337,12 @@
       "prerelease": "nightly.2016.5.31",
       "build": "commit.7dab890",
       "longVersion": "0.3.3-nightly.2016.5.31+commit.7dab890",
+      "sha256": "0xc49cc2e003871c9255dfdf4afcd79b8d5b30a46236b71c7379ef442d12ad2fee",
       "keccak256": "0x14496dd7e58f65f6d1a14efe54f0ecb45d4784d0f7e86f64b6ae09dff054bee6",
       "urls": [
-        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216"
+        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.3-nightly.2016.5.31+commit.7dab890.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.3-nightly.2016.5.31+commit.7dab890.js"
       ]
     },
     {
@@ -1059,9 +1350,12 @@
       "version": "0.3.3",
       "build": "commit.4dc1cb1",
       "longVersion": "0.3.3+commit.4dc1cb1",
+      "sha256": "0x91a9569b69fc7f6676014bbd265d29efb09338b96d5880943bd6f1836e213b0c",
       "keccak256": "0xc7e1f69fc0fd67be01a07ac60fdd085425d0a93f04affe696e24d2f9145ee742",
       "urls": [
-        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23"
+        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.3+commit.4dc1cb1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.3+commit.4dc1cb1.js"
       ]
     },
     {
@@ -1070,9 +1364,12 @@
       "prerelease": "nightly.2016.6.4",
       "build": "commit.602bcd3",
       "longVersion": "0.3.4-nightly.2016.6.4+commit.602bcd3",
+      "sha256": "0x41e7095d8be15f2bde31ff030ebd08e481dddff425622a930074eb39ec808648",
       "keccak256": "0x089e90185871c24b23b3394fb5944c4b958005142c620c1209b0d9cdf3009aa5",
       "urls": [
-        "bzzr://c553878ae9a42dca9f43cb09ea424d936b674f4831e356ed37a33574e637f700"
+        "bzzr://c553878ae9a42dca9f43cb09ea424d936b674f4831e356ed37a33574e637f700",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4-nightly.2016.6.4+commit.602bcd3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4-nightly.2016.6.4+commit.602bcd3.js"
       ]
     },
     {
@@ -1081,9 +1378,12 @@
       "prerelease": "nightly.2016.6.5",
       "build": "commit.a0fc04",
       "longVersion": "0.3.4-nightly.2016.6.5+commit.a0fc04",
+      "sha256": "0x844e0b1d3e4602636a372acaa29c1376cec6a21eb2a2c8e94a1cbbe58f0fc3ac",
       "keccak256": "0x0833d27443c185f9c455c26db0cb11189b8b349670ae7f3c2f5f41940bee103c",
       "urls": [
-        "bzzr://2c59662e39f450f870ed874a86c14964353dc43de70e819b89fcca234fee880e"
+        "bzzr://2c59662e39f450f870ed874a86c14964353dc43de70e819b89fcca234fee880e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4-nightly.2016.6.5+commit.a0fc04.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4-nightly.2016.6.5+commit.a0fc04.js"
       ]
     },
     {
@@ -1092,9 +1392,12 @@
       "prerelease": "nightly.2016.6.6",
       "build": "commit.e97ac4f",
       "longVersion": "0.3.4-nightly.2016.6.6+commit.e97ac4f",
+      "sha256": "0xbbf16853b3b5b4dac3cc42a77838cd4cf3a6ef75c6a8a43bf4b0b1f6433c7bcf",
       "keccak256": "0xa0f6ea439a311e718ffb1c23c916de1ce7cefb073a0624b663e50e44d0067300",
       "urls": [
-        "bzzr://3262712f165c7125d20d46282045a951540fa12145de2879a3fe18540301e551"
+        "bzzr://3262712f165c7125d20d46282045a951540fa12145de2879a3fe18540301e551",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4-nightly.2016.6.6+commit.e97ac4f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4-nightly.2016.6.6+commit.e97ac4f.js"
       ]
     },
     {
@@ -1103,9 +1406,12 @@
       "prerelease": "nightly.2016.6.8",
       "build": "commit.ccddd6f",
       "longVersion": "0.3.4-nightly.2016.6.8+commit.ccddd6f",
+      "sha256": "0x10f1818a2ab33b2c97341bfda3005449c8021622a1e12826784612c2b6b7544f",
       "keccak256": "0xe12afc1c789ce1411099d38d7d7753a84639667c5ecd3baa2f0ed03b39566f9f",
       "urls": [
-        "bzzr://655262be96635213d044d344bbb5158ec70d036bbc3efe068bf89361eaa5cd80"
+        "bzzr://655262be96635213d044d344bbb5158ec70d036bbc3efe068bf89361eaa5cd80",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4-nightly.2016.6.8+commit.ccddd6f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4-nightly.2016.6.8+commit.ccddd6f.js"
       ]
     },
     {
@@ -1114,9 +1420,12 @@
       "prerelease": "nightly.2016.6.8",
       "build": "commit.d593166",
       "longVersion": "0.3.4-nightly.2016.6.8+commit.d593166",
+      "sha256": "0xd8227ec5ed2274b5704f50811cfd0ca86f86ff2f5fa72ff34d17672415d3a063",
       "keccak256": "0x4f6f8c14187b2ea7e56bb909dbfca8ef4fe821e5e20fc32e9a78bf7fb2d939d3",
       "urls": [
-        "bzzr://22292f4af992a7df152a7f9cd4c6d193a626413e3a97b656d087ab7200beeedb"
+        "bzzr://22292f4af992a7df152a7f9cd4c6d193a626413e3a97b656d087ab7200beeedb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4-nightly.2016.6.8+commit.d593166.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4-nightly.2016.6.8+commit.d593166.js"
       ]
     },
     {
@@ -1125,9 +1434,12 @@
       "prerelease": "nightly.2016.6.8",
       "build": "commit.93790d",
       "longVersion": "0.3.4-nightly.2016.6.8+commit.93790d",
+      "sha256": "0x10f1818a2ab33b2c97341bfda3005449c8021622a1e12826784612c2b6b7544f",
       "keccak256": "0xe12afc1c789ce1411099d38d7d7753a84639667c5ecd3baa2f0ed03b39566f9f",
       "urls": [
-        "bzzr://655262be96635213d044d344bbb5158ec70d036bbc3efe068bf89361eaa5cd80"
+        "bzzr://655262be96635213d044d344bbb5158ec70d036bbc3efe068bf89361eaa5cd80",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4-nightly.2016.6.8+commit.93790d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4-nightly.2016.6.8+commit.93790d.js"
       ]
     },
     {
@@ -1135,9 +1447,12 @@
       "version": "0.3.4",
       "build": "commit.7dab890",
       "longVersion": "0.3.4+commit.7dab890",
+      "sha256": "0xc49cc2e003871c9255dfdf4afcd79b8d5b30a46236b71c7379ef442d12ad2fee",
       "keccak256": "0x14496dd7e58f65f6d1a14efe54f0ecb45d4784d0f7e86f64b6ae09dff054bee6",
       "urls": [
-        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216"
+        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.4+commit.7dab890.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.4+commit.7dab890.js"
       ]
     },
     {
@@ -1146,9 +1461,12 @@
       "prerelease": "nightly.2016.6.14",
       "build": "commit.371690f",
       "longVersion": "0.3.5-nightly.2016.6.14+commit.371690f",
+      "sha256": "0x3f7c8cf19ebacb1d38997424b5b23c92059ac0f74340e09e9630cb6a6805d225",
       "keccak256": "0xdccd9e4f31ae7869f37f28233a0334e81b56a6ce33fd44ce0bfd5ee113b8ffb2",
       "urls": [
-        "bzzr://95a45f6fa79667e6fef2affe32807d1bcb8262b3bfd848cd1e69707d3b508bb7"
+        "bzzr://95a45f6fa79667e6fef2affe32807d1bcb8262b3bfd848cd1e69707d3b508bb7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.6.14+commit.371690f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.6.14+commit.371690f.js"
       ]
     },
     {
@@ -1157,9 +1475,12 @@
       "prerelease": "nightly.2016.6.19",
       "build": "commit.5917c8e",
       "longVersion": "0.3.5-nightly.2016.6.19+commit.5917c8e",
+      "sha256": "0x00ab1b2d2beeb43eacd02ce5fba4dc0e23c86ff207c965a9bbbd0b374c874f0a",
       "keccak256": "0x6d238eb8d3e81b69e449af4843e84c47fed762c1ed860e5a23c1ebd9359aea88",
       "urls": [
-        "bzzr://371398c2d4eb5d37b11657c986940e921227e8de42b51b98429a6a3de38a7cb2"
+        "bzzr://371398c2d4eb5d37b11657c986940e921227e8de42b51b98429a6a3de38a7cb2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.6.19+commit.5917c8e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.6.19+commit.5917c8e.js"
       ]
     },
     {
@@ -1168,9 +1489,12 @@
       "prerelease": "nightly.2016.6.20",
       "build": "commit.9da08ac",
       "longVersion": "0.3.5-nightly.2016.6.20+commit.9da08ac",
+      "sha256": "0x1d9504a5bc5d92befbf7024873e561ea5eb5b94368b4b638ef9d8da9284131fe",
       "keccak256": "0xa518196452974241f4d14aee8c20852040d2ff991ba5cbbd810c7680de5a9a83",
       "urls": [
-        "bzzr://40b339d28b408f50726f2e1654e67350c8b59e44576e85c374c0295ca772c6a5"
+        "bzzr://40b339d28b408f50726f2e1654e67350c8b59e44576e85c374c0295ca772c6a5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.6.20+commit.9da08ac.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.6.20+commit.9da08ac.js"
       ]
     },
     {
@@ -1179,9 +1503,12 @@
       "prerelease": "nightly.2016.6.21",
       "build": "commit.b23c300",
       "longVersion": "0.3.5-nightly.2016.6.21+commit.b23c300",
+      "sha256": "0x3a74ac555a0564a5248a27b6a6b6c5bda3b0a6479e8fa2edec5f90438123e2f7",
       "keccak256": "0x190b4cb86da0652deb7dd71c6947d164f3a23ddd36351aa74573dc9c9060aad8",
       "urls": [
-        "bzzr://cc6a2642c8cc80d436f52f209f1cf007106dfe56e99814ecf46091b75980f010"
+        "bzzr://cc6a2642c8cc80d436f52f209f1cf007106dfe56e99814ecf46091b75980f010",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.6.21+commit.b23c300.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.6.21+commit.b23c300.js"
       ]
     },
     {
@@ -1190,9 +1517,12 @@
       "prerelease": "nightly.2016.6.27",
       "build": "commit.2ccfea8",
       "longVersion": "0.3.5-nightly.2016.6.27+commit.2ccfea8",
+      "sha256": "0xc4066e3a29cb222e726e90428596f75e4b5fc22cc21f580101d095d82e17c4ce",
       "keccak256": "0x1d37149521cb1078fb44046fc6e08774e8c5622f5601c89e749f3b175e156ddd",
       "urls": [
-        "bzzr://15c26f2bb3c161a935bc6725d0d648428a0c72d3c63934344573a9c6cdf49e9e"
+        "bzzr://15c26f2bb3c161a935bc6725d0d648428a0c72d3c63934344573a9c6cdf49e9e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.6.27+commit.2ccfea8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.6.27+commit.2ccfea8.js"
       ]
     },
     {
@@ -1201,9 +1531,12 @@
       "prerelease": "nightly.2016.7.1",
       "build": "commit.48238c9",
       "longVersion": "0.3.5-nightly.2016.7.1+commit.48238c9",
+      "sha256": "0x29d872bc3a58ded317e6ef7b0528d8e24c74c11b9078dbe36400a710e0385bfd",
       "keccak256": "0xab46d1d570942bd31e24a53469a699d1314806cf6cf659b8a188af7179a6da5e",
       "urls": [
-        "bzzr://4c5a8418a4dd5223bd5fa3b3a751f0877ea3b6a0ca7143696b54b488b6b064bb"
+        "bzzr://4c5a8418a4dd5223bd5fa3b3a751f0877ea3b6a0ca7143696b54b488b6b064bb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.7.1+commit.48238c9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.7.1+commit.48238c9.js"
       ]
     },
     {
@@ -1212,9 +1545,12 @@
       "prerelease": "nightly.2016.7.19",
       "build": "commit.427deb4",
       "longVersion": "0.3.5-nightly.2016.7.19+commit.427deb4",
+      "sha256": "0x17ba00cb71c45bcb3b2d1cbb75abc82439ad75b3073a23beb69f6e3e4844d3da",
       "keccak256": "0xb8fea6e749581356fd8c64962d7ac6fb888c826894de3749bd507ee28926ab10",
       "urls": [
-        "bzzr://a2b92796642a552c96e91f31cdd1854e56953e53ae7b3d90e4d289f671b1ba9e"
+        "bzzr://a2b92796642a552c96e91f31cdd1854e56953e53ae7b3d90e4d289f671b1ba9e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.7.19+commit.427deb4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.7.19+commit.427deb4.js"
       ]
     },
     {
@@ -1223,9 +1559,12 @@
       "prerelease": "nightly.2016.7.21",
       "build": "commit.6610add",
       "longVersion": "0.3.5-nightly.2016.7.21+commit.6610add",
+      "sha256": "0xdefca7ed84bfbd7272d19e9192ff4339789d02439092a6bd8dcfbe52007f57a3",
       "keccak256": "0x39630c76a46a1383ae981bb6f30da89e0a3b3d75d5643d23e8caa8338d29fc12",
       "urls": [
-        "bzzr://db7a2290bd3a8a87a3cd956436001395813e19d611ec28b18393c6b9ab761dae"
+        "bzzr://db7a2290bd3a8a87a3cd956436001395813e19d611ec28b18393c6b9ab761dae",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.7.21+commit.6610add.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.7.21+commit.6610add.js"
       ]
     },
     {
@@ -1234,9 +1573,12 @@
       "prerelease": "nightly.2016.8.3",
       "build": "commit.3b21d98",
       "longVersion": "0.3.5-nightly.2016.8.3+commit.3b21d98",
+      "sha256": "0x90f6d03989d2ba9af752022a3213f5b00c093caa2cfe073c3ca0f05b20c13967",
       "keccak256": "0x8c69c60a349cf3e6715b7cbf83c5e8a49aba838d45129d95b55681a89b54ad2d",
       "urls": [
-        "bzzr://1c0ba190b8700eb24630b041dec406da0700ed60f557f32019170870bf0d62b4"
+        "bzzr://1c0ba190b8700eb24630b041dec406da0700ed60f557f32019170870bf0d62b4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.3+commit.3b21d98.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.3+commit.3b21d98.js"
       ]
     },
     {
@@ -1245,9 +1587,12 @@
       "prerelease": "nightly.2016.8.4",
       "build": "commit.b83acfa",
       "longVersion": "0.3.5-nightly.2016.8.4+commit.b83acfa",
+      "sha256": "0x7273fca7d805b39e214e0c7037dd06f299966dea4377ce89965eb5fa3fe9c545",
       "keccak256": "0xf3a268be89a29f9ea1827098f15227443cee10e4a48224df04524dc0c5cea6fd",
       "urls": [
-        "bzzr://bd61f26efb5ab70fed4536e43d6390fdc5e3bbad35d778929852e17ba972d6c8"
+        "bzzr://bd61f26efb5ab70fed4536e43d6390fdc5e3bbad35d778929852e17ba972d6c8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.4+commit.b83acfa.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.4+commit.b83acfa.js"
       ]
     },
     {
@@ -1256,9 +1601,12 @@
       "prerelease": "nightly.2016.8.5",
       "build": "commit.3c93a22",
       "longVersion": "0.3.5-nightly.2016.8.5+commit.3c93a22",
+      "sha256": "0x6233a423c056ef7db9f943cef55d3f209b78e931071519afe8ff2c9abe612805",
       "keccak256": "0x5c547d48321c4754e700aff0bb457b984391fd354c5e517f9097fdb4121f8f78",
       "urls": [
-        "bzzr://f4f29751cbf20f5113d14cd4d3dbd6ad6f989f6f32b2613fd07c50a030494cb3"
+        "bzzr://f4f29751cbf20f5113d14cd4d3dbd6ad6f989f6f32b2613fd07c50a030494cb3",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.5+commit.3c93a22.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.5+commit.3c93a22.js"
       ]
     },
     {
@@ -1267,9 +1615,12 @@
       "prerelease": "nightly.2016.8.5",
       "build": "commit.4542b7f",
       "longVersion": "0.3.5-nightly.2016.8.5+commit.4542b7f",
+      "sha256": "0x32a49a03a93f638557e8bb1e40658060dc970e52425c2fc89887e70b2734e635",
       "keccak256": "0x39198be14bcc06d084c566b5266c0e369c2994eedf6b4d8ed2bfdf97c70bcef9",
       "urls": [
-        "bzzr://c18444aa5ea66c67976d1a0b0f39e2a9f2e49c0137806583e2002381f3040cd4"
+        "bzzr://c18444aa5ea66c67976d1a0b0f39e2a9f2e49c0137806583e2002381f3040cd4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.5+commit.4542b7f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.5+commit.4542b7f.js"
       ]
     },
     {
@@ -1278,9 +1629,12 @@
       "prerelease": "nightly.2016.8.5",
       "build": "commit.ff60ce9",
       "longVersion": "0.3.5-nightly.2016.8.5+commit.ff60ce9",
+      "sha256": "0xd77cd93f670cc339517ff4d9f9b9abaf7324cd3c2f39c7a2b2d80a322cddf710",
       "keccak256": "0x0ef48a43ae676add07b1c4bf1ca6a1365523ccbcecc9a1060b8429d4db7b781a",
       "urls": [
-        "bzzr://f17c0dfd5f3b52053744e3d21649f75e6c51b314e841f932bdb460513af2a3e2"
+        "bzzr://f17c0dfd5f3b52053744e3d21649f75e6c51b314e841f932bdb460513af2a3e2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.5+commit.ff60ce9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.5+commit.ff60ce9.js"
       ]
     },
     {
@@ -1289,9 +1643,12 @@
       "prerelease": "nightly.2016.8.6",
       "build": "commit.e3c1bf7",
       "longVersion": "0.3.5-nightly.2016.8.6+commit.e3c1bf7",
+      "sha256": "0x506ddaa6e4cdd200a731313fa8ee08fc7c8d33390e864589c04062486f2339e8",
       "keccak256": "0xe4755e9e63763cd841292288bbb372c353491b79755ede134302321053d20db4",
       "urls": [
-        "bzzr://6b0b6d36c5db8606f9bc1f0a1de9b6fb101f88aeb260060b557729a00ddc2424"
+        "bzzr://6b0b6d36c5db8606f9bc1f0a1de9b6fb101f88aeb260060b557729a00ddc2424",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.6+commit.e3c1bf7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.6+commit.e3c1bf7.js"
       ]
     },
     {
@@ -1300,9 +1657,12 @@
       "prerelease": "nightly.2016.8.7",
       "build": "commit.f7af7de",
       "longVersion": "0.3.5-nightly.2016.8.7+commit.f7af7de",
+      "sha256": "0x4bae570aaecd1cf8ed82953fdbfa35d0151416017103f949d58d213a3c2afbb8",
       "keccak256": "0x5f98684c7f011ee13f870671849e846c893e9179c5e86ee3340cd8467c84b48f",
       "urls": [
-        "bzzr://612dd41e8b4993055eb5984f7de323a91ce2d3288160a00126fb233120c6713c"
+        "bzzr://612dd41e8b4993055eb5984f7de323a91ce2d3288160a00126fb233120c6713c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.7+commit.f7af7de.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.7+commit.f7af7de.js"
       ]
     },
     {
@@ -1311,9 +1671,12 @@
       "prerelease": "nightly.2016.8.8",
       "build": "commit.b13e581",
       "longVersion": "0.3.5-nightly.2016.8.8+commit.b13e581",
+      "sha256": "0xae32873b691e9b6325210f15ae0e137c6db95168b2a5f293c007be0ac64d7941",
       "keccak256": "0x8357db2c7b425a685fc6cefe46231398825dbfb73c65f8d450b7773d119f424f",
       "urls": [
-        "bzzr://d02f684350666829cfb6cb4ba4601a5e5c76a601fc7f3c22f9c4d2e58c9b3297"
+        "bzzr://d02f684350666829cfb6cb4ba4601a5e5c76a601fc7f3c22f9c4d2e58c9b3297",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.8+commit.b13e581.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.8+commit.b13e581.js"
       ]
     },
     {
@@ -1322,9 +1685,12 @@
       "prerelease": "nightly.2016.8.8",
       "build": "commit.539afbe",
       "longVersion": "0.3.5-nightly.2016.8.8+commit.539afbe",
+      "sha256": "0x5d1fbedf26d7f7f762f00e48b4cb7653e002fede762d88ee1e29b37f00fa6143",
       "keccak256": "0x4ea91be3fb98769417f8a803cd7b4ec01547d98ab62c3515288d9e8f6171494b",
       "urls": [
-        "bzzr://5bed380d76833b1089872458c2089fb5c554c5d157ac906c8b0d372d334ac8eb"
+        "bzzr://5bed380d76833b1089872458c2089fb5c554c5d157ac906c8b0d372d334ac8eb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.8+commit.539afbe.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.8+commit.539afbe.js"
       ]
     },
     {
@@ -1333,9 +1699,12 @@
       "prerelease": "nightly.2016.8.8",
       "build": "commit.c3ed550",
       "longVersion": "0.3.5-nightly.2016.8.8+commit.c3ed550",
+      "sha256": "0xa3b4ccbb9f067b006bdd09be1c2fd42c95cea1cd577223bf8c5f66cf870b794f",
       "keccak256": "0x9cdeb8e6a6e278eb0279ef3bd501e88e0d9a8ab5832b648be5ccfe4bb190e386",
       "urls": [
-        "bzzr://b41dc93f2b2b8ffbe8e75cd7a81acc94ec9af105c1ed0633a296d9778dd89953"
+        "bzzr://b41dc93f2b2b8ffbe8e75cd7a81acc94ec9af105c1ed0633a296d9778dd89953",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.8+commit.c3ed550.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.8+commit.c3ed550.js"
       ]
     },
     {
@@ -1344,9 +1713,12 @@
       "prerelease": "nightly.2016.8.8",
       "build": "commit.2fcc6ec",
       "longVersion": "0.3.5-nightly.2016.8.8+commit.2fcc6ec",
+      "sha256": "0xba6bdc053e5dc08842543c4df3289d55d354c5e92c0a11835f3b691a6dd76b5d",
       "keccak256": "0x36f534c9442aab9688ab5d601ab7d116c4ff21599883a7332a0ab91e4e2c9efe",
       "urls": [
-        "bzzr://543e8bc5b103e41a0fe8de4148297ca7713d945ac9ba5bbf020cc2a5075dcffb"
+        "bzzr://543e8bc5b103e41a0fe8de4148297ca7713d945ac9ba5bbf020cc2a5075dcffb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.8+commit.2fcc6ec.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.8+commit.2fcc6ec.js"
       ]
     },
     {
@@ -1355,9 +1727,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.fc60839",
       "longVersion": "0.3.5-nightly.2016.8.10+commit.fc60839",
+      "sha256": "0x924af8ddd30f9be9ee46d3cddabc2ce8395a8bf1f620ab05848c7be941930d2a",
       "keccak256": "0x170aaf57cce5775e54d911e667f6fe429b229642d6bd2af64cb81e15c340b1d5",
       "urls": [
-        "bzzr://779e608822be84bea08e72d7e2e21afe77592f46865618e4f3bee756d0d75bb7"
+        "bzzr://779e608822be84bea08e72d7e2e21afe77592f46865618e4f3bee756d0d75bb7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.10+commit.fc60839.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.10+commit.fc60839.js"
       ]
     },
     {
@@ -1366,9 +1741,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.e6a031d",
       "longVersion": "0.3.5-nightly.2016.8.10+commit.e6a031d",
+      "sha256": "0xe526fe0ce16b25c5b7c801e37da313f319491ef358f7a7c00f2caa42f3a4848b",
       "keccak256": "0xb35ead8bcc99a124a721833d8d6f1d1c275f7585d1c356c307ca455aadc1eca5",
       "urls": [
-        "bzzr://302edd503fca336fe7d0cb2b17068d749558d264606776fa169cd485016716e8"
+        "bzzr://302edd503fca336fe7d0cb2b17068d749558d264606776fa169cd485016716e8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.10+commit.e6a031d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.10+commit.e6a031d.js"
       ]
     },
     {
@@ -1377,9 +1755,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.cacc3b6",
       "longVersion": "0.3.5-nightly.2016.8.10+commit.cacc3b6",
+      "sha256": "0x5da97b472ddf8be04645ecb1bd491e366adbf3f510bfbc21650b24a0ff4d4c17",
       "keccak256": "0x6904df8575c6c7bcdcc3343d0205a0798ad3428eef598c528434f91cef8b8b70",
       "urls": [
-        "bzzr://eb32ab0bf958b70199e5acd0c2f9ed2a69f2cfcd1fe938ff2c02fb0288810d3c"
+        "bzzr://eb32ab0bf958b70199e5acd0c2f9ed2a69f2cfcd1fe938ff2c02fb0288810d3c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5-nightly.2016.8.10+commit.cacc3b6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5-nightly.2016.8.10+commit.cacc3b6.js"
       ]
     },
     {
@@ -1387,9 +1768,12 @@
       "version": "0.3.5",
       "build": "commit.5f97274",
       "longVersion": "0.3.5+commit.5f97274",
+      "sha256": "0x3af892fabc38b975b96a242b13e0b6465d9c09f505ea11932c60b982c0d37705",
       "keccak256": "0x814bf4e5eacbb1849ea12377f5935b1fd846ff1af5ffa2afeef2619f94273994",
       "urls": [
-        "bzzr://18acaee3f543de385d445ad0e0f96b506a5a78ea36feb22e79b984f0ea9500de"
+        "bzzr://18acaee3f543de385d445ad0e0f96b506a5a78ea36feb22e79b984f0ea9500de",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.5+commit.5f97274.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.5+commit.5f97274.js"
       ]
     },
     {
@@ -1398,9 +1782,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.55858de",
       "longVersion": "0.3.6-nightly.2016.8.10+commit.55858de",
+      "sha256": "0x7c91b2c8f9b228a0696b31e2d972cb35b617da7cd351895ac1086e10a09336b2",
       "keccak256": "0xe56b296cd823483b2137ffa47eb6a1749a8b69c7d54dc051104b94da6049a987",
       "urls": [
-        "bzzr://95cb5155dec82805ccf1cd4aeaa60f980d270766852d23e78c54b336bba67f12"
+        "bzzr://95cb5155dec82805ccf1cd4aeaa60f980d270766852d23e78c54b336bba67f12",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.10+commit.55858de.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.10+commit.55858de.js"
       ]
     },
     {
@@ -1409,9 +1796,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.e2a46b6",
       "longVersion": "0.3.6-nightly.2016.8.10+commit.e2a46b6",
+      "sha256": "0x8944c7493af67aba5ab623eb1980e1e2570a9453c7d16e637ea76965f85e4b73",
       "keccak256": "0x92864619b8fc23eef5b1f345a473a2fdb309a2c993dda54f7d8f88b13fc7f422",
       "urls": [
-        "bzzr://d0617e3fd320de4900c59f4769b407d86ceedd24ca127761ab10ff3541738a63"
+        "bzzr://d0617e3fd320de4900c59f4769b407d86ceedd24ca127761ab10ff3541738a63",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.10+commit.e2a46b6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.10+commit.e2a46b6.js"
       ]
     },
     {
@@ -1420,9 +1810,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.5a37403",
       "longVersion": "0.3.6-nightly.2016.8.10+commit.5a37403",
+      "sha256": "0xef67a7bb0a240f36fcdd6a5641a05b2742c856a796d644cfc3d6be0c1e730961",
       "keccak256": "0x9f0aab369eba0ee040e48a1fe8a0bc32c5f3c30738086a109384aa004982ce1a",
       "urls": [
-        "bzzr://b529c664ed0eb282ca2401ec5b6b5a5991b8fad6e5a7674d90690a688b78b3ec"
+        "bzzr://b529c664ed0eb282ca2401ec5b6b5a5991b8fad6e5a7674d90690a688b78b3ec",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.10+commit.5a37403.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.10+commit.5a37403.js"
       ]
     },
     {
@@ -1431,9 +1824,12 @@
       "prerelease": "nightly.2016.8.10",
       "build": "commit.b7c26f4",
       "longVersion": "0.3.6-nightly.2016.8.10+commit.b7c26f4",
+      "sha256": "0x87d194a0cf6abadc8ff77323639e5fe0441265dd63d0d756924fbaa133c938aa",
       "keccak256": "0xa8d415da7b11a4862b3a41c64c8c3de36b714d1098a1b2f3fabca7c66eedca7d",
       "urls": [
-        "bzzr://488053f2ef36dc8120764d897ed3c3ba1c63035c0030b50675eda623376eafa0"
+        "bzzr://488053f2ef36dc8120764d897ed3c3ba1c63035c0030b50675eda623376eafa0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.10+commit.b7c26f4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.10+commit.b7c26f4.js"
       ]
     },
     {
@@ -1442,9 +1838,12 @@
       "prerelease": "nightly.2016.8.11",
       "build": "commit.7c15fa6",
       "longVersion": "0.3.6-nightly.2016.8.11+commit.7c15fa6",
+      "sha256": "0x913a88cee49f91cbbcd1c993cf8ac0910cf6d263c82ead96357f2b748e739675",
       "keccak256": "0x5e17be46ee4eaae979757501958f9571c54b0427bb50d212cd1d167c208e5aa2",
       "urls": [
-        "bzzr://212334c88f5dbfd68f35f458268117bd28a48afcc9893985abc276c4d8369337"
+        "bzzr://212334c88f5dbfd68f35f458268117bd28a48afcc9893985abc276c4d8369337",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.11+commit.7c15fa6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.11+commit.7c15fa6.js"
       ]
     },
     {
@@ -1453,9 +1852,12 @@
       "prerelease": "nightly.2016.8.12",
       "build": "commit.9e03bda",
       "longVersion": "0.3.6-nightly.2016.8.12+commit.9e03bda",
+      "sha256": "0xc5b3e85ea8f0144be8c7a2938f15ca8453c20a2eceb0fedce135cfba08d38bfd",
       "keccak256": "0x3d06695f3199dddb04ec320071b1387326cd08089a543a50fd464454c1cefa89",
       "urls": [
-        "bzzr://9d53dc09b854f40f7571e69a845e13789c5e6dc7de1c97c5ff10ac74518bbe39"
+        "bzzr://9d53dc09b854f40f7571e69a845e13789c5e6dc7de1c97c5ff10ac74518bbe39",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.12+commit.9e03bda.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.12+commit.9e03bda.js"
       ]
     },
     {
@@ -1464,9 +1866,12 @@
       "prerelease": "nightly.2016.8.15",
       "build": "commit.868a167",
       "longVersion": "0.3.6-nightly.2016.8.15+commit.868a167",
+      "sha256": "0xc88a1fb9fc0221bfa6e76391af28d29b168ae4af924586553d21a528484196f3",
       "keccak256": "0x5e60afff6d4716500b9c6c95b7febb207cdd7478d4e164bfbfe28813c7111af6",
       "urls": [
-        "bzzr://299fc3e0e1747df8fb357f866562d2a7854fe5b661d891a5547c2bca2e2f0553"
+        "bzzr://299fc3e0e1747df8fb357f866562d2a7854fe5b661d891a5547c2bca2e2f0553",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.15+commit.868a167.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.15+commit.868a167.js"
       ]
     },
     {
@@ -1475,9 +1880,12 @@
       "prerelease": "nightly.2016.8.16",
       "build": "commit.970260b",
       "longVersion": "0.3.6-nightly.2016.8.16+commit.970260b",
+      "sha256": "0xf9dd9bb6cbded9bca18551a404ee6656daf46145fed82b59253253d4fa725ce0",
       "keccak256": "0x4f55a9a793fdde73c763f5d8bd83a5ace4e0027879cf808d1374f37a8e9ce39a",
       "urls": [
-        "bzzr://4dd4542dc36ccd79fddd66557a98d60870abc3319f453a1fbff17ee867681422"
+        "bzzr://4dd4542dc36ccd79fddd66557a98d60870abc3319f453a1fbff17ee867681422",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.16+commit.970260b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.16+commit.970260b.js"
       ]
     },
     {
@@ -1486,9 +1894,12 @@
       "prerelease": "nightly.2016.8.17",
       "build": "commit.c499470",
       "longVersion": "0.3.6-nightly.2016.8.17+commit.c499470",
+      "sha256": "0x7d50bfbb3b3e27e2e2fffc8dfa0e52b3d30680dc77e4764bd234297c8b2adff7",
       "keccak256": "0xe97dd0725fdd04e0e92bfece025b44971d91e114dcb195a5454337f8b53e2093",
       "urls": [
-        "bzzr://de80bc9801dbe2327159f78d42991ac5c46c8e4546845e1f49e37cdc3ae4833b"
+        "bzzr://de80bc9801dbe2327159f78d42991ac5c46c8e4546845e1f49e37cdc3ae4833b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.17+commit.c499470.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.17+commit.c499470.js"
       ]
     },
     {
@@ -1497,9 +1908,12 @@
       "prerelease": "nightly.2016.8.19",
       "build": "commit.32c93cf",
       "longVersion": "0.3.6-nightly.2016.8.19+commit.32c93cf",
+      "sha256": "0xdc948190e9f9fadde2113b958340e49bf92f93106c8a631b13211d22b5ae6969",
       "keccak256": "0xd8b3fde04b75fc82fbd66adf46db650cd8599d1eef0051ec1056db554705ef11",
       "urls": [
-        "bzzr://c0fde4a7ee7bc67741fdff85e6431e19cf3dae3c62e5627ef01b57979284d731"
+        "bzzr://c0fde4a7ee7bc67741fdff85e6431e19cf3dae3c62e5627ef01b57979284d731",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.19+commit.32c93cf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.19+commit.32c93cf.js"
       ]
     },
     {
@@ -1508,9 +1922,12 @@
       "prerelease": "nightly.2016.8.20",
       "build": "commit.d736fd",
       "longVersion": "0.3.6-nightly.2016.8.20+commit.d736fd",
+      "sha256": "0x3b8b1e25febbdea63121414c0940154fb1e8db2f880525beb435a2838b8d742d",
       "keccak256": "0xf394e7c3233ab57a442dc1c91bb4c4d5e214472d075e8eacd890f8b7c23ba79f",
       "urls": [
-        "bzzr://d254a7edd27c4b38c1c104bc1b93ba445913e97c3e5d2854b93ebfb6f9297a7e"
+        "bzzr://d254a7edd27c4b38c1c104bc1b93ba445913e97c3e5d2854b93ebfb6f9297a7e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.20+commit.d736fd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.20+commit.d736fd.js"
       ]
     },
     {
@@ -1519,9 +1936,12 @@
       "prerelease": "nightly.2016.8.22",
       "build": "commit.7183658",
       "longVersion": "0.3.6-nightly.2016.8.22+commit.7183658",
+      "sha256": "0xe6f4f3ebd438cd95febfe4646b9d7ed10801fd89d3e0cd14342d471c9696a680",
       "keccak256": "0xc7a443e86a4cf84e301bee58b1f19bff697259490063f8feb9d131e3ce261ea5",
       "urls": [
-        "bzzr://1309b21812bea4e7d81e2124329be9a298bf21363f4487002d787b12e533d53a"
+        "bzzr://1309b21812bea4e7d81e2124329be9a298bf21363f4487002d787b12e533d53a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.22+commit.7183658.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.22+commit.7183658.js"
       ]
     },
     {
@@ -1530,9 +1950,12 @@
       "prerelease": "nightly.2016.8.23",
       "build": "commit.de535a7",
       "longVersion": "0.3.6-nightly.2016.8.23+commit.de535a7",
+      "sha256": "0xa001eced7329e4b59cce04dbd12b4d9bb6ed40261655af003c56571018ec5e1b",
       "keccak256": "0xc8cfbccdce7880d850591554d728a1926112eb50afdb9274c87acdc23723a373",
       "urls": [
-        "bzzr://c8541c2b4e21e16f3f39f0e19478c5f1b45dee97503298550204bf21cd54006d"
+        "bzzr://c8541c2b4e21e16f3f39f0e19478c5f1b45dee97503298550204bf21cd54006d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.23+commit.de535a7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.23+commit.de535a7.js"
       ]
     },
     {
@@ -1541,9 +1964,12 @@
       "prerelease": "nightly.2016.8.24",
       "build": "commit.e20afc7",
       "longVersion": "0.3.6-nightly.2016.8.24+commit.e20afc7",
+      "sha256": "0x3b143b7d00a92d240fcd424dc968e29505bd05604c8b6be059238b6b0cc898fe",
       "keccak256": "0xceb58b6969d17c99bd5d5876950f992a5d6dfb6f9c6eab5233f792fc876ff75c",
       "urls": [
-        "bzzr://97e5e466b7f247d015b94d213c9aa1459972c1f7bdca7d40137bc5762736dc58"
+        "bzzr://97e5e466b7f247d015b94d213c9aa1459972c1f7bdca7d40137bc5762736dc58",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.24+commit.e20afc7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.24+commit.e20afc7.js"
       ]
     },
     {
@@ -1552,9 +1978,12 @@
       "prerelease": "nightly.2016.8.26",
       "build": "commit.3eeefb5",
       "longVersion": "0.3.6-nightly.2016.8.26+commit.3eeefb5",
+      "sha256": "0x178335e90508663ee878b366c94e789e24ff086814ec4429a0cc257fbf204cef",
       "keccak256": "0x5e7a98acf9284fdff76d57cb1ed33389cfbe23e03c146927a3369fecb57d9b66",
       "urls": [
-        "bzzr://f2622867fefd539b869c6e4a87886b9e1af332f7d90293f89601308e36db6763"
+        "bzzr://f2622867fefd539b869c6e4a87886b9e1af332f7d90293f89601308e36db6763",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.26+commit.3eeefb5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.26+commit.3eeefb5.js"
       ]
     },
     {
@@ -1563,9 +1992,12 @@
       "prerelease": "nightly.2016.8.27",
       "build": "commit.91d4fa4",
       "longVersion": "0.3.6-nightly.2016.8.27+commit.91d4fa4",
+      "sha256": "0xad641b58b0e23538a6637ffc3d09e2437c9ceb36ef57ace19fb159854bd3f2b5",
       "keccak256": "0xa1f0d10ecc53ef85d50056407a9c5a421180dcd6d55043f286509c463d5cbc76",
       "urls": [
-        "bzzr://81215d492250c766eeaa7558780ecb7399812393fd572543ff08730b1f9cc179"
+        "bzzr://81215d492250c766eeaa7558780ecb7399812393fd572543ff08730b1f9cc179",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.27+commit.91d4fa4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.27+commit.91d4fa4.js"
       ]
     },
     {
@@ -1574,9 +2006,12 @@
       "prerelease": "nightly.2016.8.29",
       "build": "commit.b8060c5",
       "longVersion": "0.3.6-nightly.2016.8.29+commit.b8060c5",
+      "sha256": "0x1fcae8b7f04a5a1aae3cc5a3be805e53e94169944a4c495f288734dea78774cf",
       "keccak256": "0xc89a202c173a8631d821b2a03956f47b8139c090f4b98b2257431734b4eab770",
       "urls": [
-        "bzzr://fdf71a1adf267ba907c7da683adb423cc29014c0aefd9166f84cbf1b69511eb0"
+        "bzzr://fdf71a1adf267ba907c7da683adb423cc29014c0aefd9166f84cbf1b69511eb0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.29+commit.b8060c5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.29+commit.b8060c5.js"
       ]
     },
     {
@@ -1585,9 +2020,12 @@
       "prerelease": "nightly.2016.8.30",
       "build": "commit.cf974fd",
       "longVersion": "0.3.6-nightly.2016.8.30+commit.cf974fd",
+      "sha256": "0xf856cf0aaa21ef221fd10448c299254c1bc23cbceb1eb9a5d65b9a9eb284815e",
       "keccak256": "0xfc510185e5684b27cb1562a7f62f51cae8acc709432322a3958d280ce50a5d6b",
       "urls": [
-        "bzzr://cdfda44fabc968d311dd15c06d4a0b5b209299dc4b6725dc47b3612ee12b324e"
+        "bzzr://cdfda44fabc968d311dd15c06d4a0b5b209299dc4b6725dc47b3612ee12b324e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.30+commit.cf974fd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.30+commit.cf974fd.js"
       ]
     },
     {
@@ -1596,9 +2034,12 @@
       "prerelease": "nightly.2016.8.31",
       "build": "commit.3ccd198",
       "longVersion": "0.3.6-nightly.2016.8.31+commit.3ccd198",
+      "sha256": "0xd32578dca1af62f09f45d1d49879cd873d92eda3ea11d634fdb61e2c57410582",
       "keccak256": "0xa35708f7de1484828e006d644d1252cd506d5e3f6d107ded13a9e86a161dd672",
       "urls": [
-        "bzzr://164b6a0bb7e496c371f2618c55d993c51fc2054dc0e2a57ef5ac62219e16c564"
+        "bzzr://164b6a0bb7e496c371f2618c55d993c51fc2054dc0e2a57ef5ac62219e16c564",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.8.31+commit.3ccd198.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.8.31+commit.3ccd198.js"
       ]
     },
     {
@@ -1607,9 +2048,12 @@
       "prerelease": "nightly.2016.9.1",
       "build": "commit.b5d941d",
       "longVersion": "0.3.6-nightly.2016.9.1+commit.b5d941d",
+      "sha256": "0x49b38c7044d6b433897b0a7357b0d013ec0b89594e113f166d1b2a2b90145de7",
       "keccak256": "0x319dc30739a506711fc564399554a8cbcea99893364885f9d97db1a3d9c2a872",
       "urls": [
-        "bzzr://aba902440367c42b0a9c2e31ac866925533da0c2d5f18ff233c3c98c71985fae"
+        "bzzr://aba902440367c42b0a9c2e31ac866925533da0c2d5f18ff233c3c98c71985fae",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.9.1+commit.b5d941d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.9.1+commit.b5d941d.js"
       ]
     },
     {
@@ -1618,9 +2062,12 @@
       "prerelease": "nightly.2016.9.2",
       "build": "commit.341c943",
       "longVersion": "0.3.6-nightly.2016.9.2+commit.341c943",
+      "sha256": "0x151d429eafe4d94a61845dc51f065e4879069943ce98e22360dc77d4b69a6527",
       "keccak256": "0x2c8f16d50a0ef98268a6646a79e060498605c17ceb740da228415720497e6313",
       "urls": [
-        "bzzr://39bdd8f3374e73fa3e6f8f0545ba20071f225977d5c5acde592c0d268158e4f1"
+        "bzzr://39bdd8f3374e73fa3e6f8f0545ba20071f225977d5c5acde592c0d268158e4f1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.9.2+commit.341c943.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.9.2+commit.341c943.js"
       ]
     },
     {
@@ -1629,9 +2076,12 @@
       "prerelease": "nightly.2016.9.5",
       "build": "commit.873d8bb",
       "longVersion": "0.3.6-nightly.2016.9.5+commit.873d8bb",
+      "sha256": "0x370e906919c50998dfcb9db995413da1d65df341582af33f206758545053fd12",
       "keccak256": "0x2f60875fb1ac841f01349af5d29e62a90c5e82765e9246fd6397e94f4b7bdcf2",
       "urls": [
-        "bzzr://25cd6058fae8b2e95da9d810907d4b7e72e36a6a0616070e9e4c1df9b88ce881"
+        "bzzr://25cd6058fae8b2e95da9d810907d4b7e72e36a6a0616070e9e4c1df9b88ce881",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.9.5+commit.873d8bb.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.9.5+commit.873d8bb.js"
       ]
     },
     {
@@ -1640,9 +2090,12 @@
       "prerelease": "nightly.2016.9.6",
       "build": "commit.114502f",
       "longVersion": "0.3.6-nightly.2016.9.6+commit.114502f",
+      "sha256": "0x8d90481b881e58ad4f7a90f108b94064f856956aadd6e05d96cda5dc352dce1b",
       "keccak256": "0x26c168ff5e5e6504ca1282e498a61ba210bcad24a31ce748541f01ecebb84d87",
       "urls": [
-        "bzzr://4cfde586b16d48b82c2e465fdf44865edbbe3779fd7277a120bd3ebffbaf3950"
+        "bzzr://4cfde586b16d48b82c2e465fdf44865edbbe3779fd7277a120bd3ebffbaf3950",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.9.6+commit.114502f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.9.6+commit.114502f.js"
       ]
     },
     {
@@ -1651,9 +2104,12 @@
       "prerelease": "nightly.2016.9.7",
       "build": "commit.24524d6",
       "longVersion": "0.3.6-nightly.2016.9.7+commit.24524d6",
+      "sha256": "0x7a56a3725819b91f790052e8b8d869784aee8100af4242ca3122020008bf35b4",
       "keccak256": "0x5886727970da24b78a4ff10fae5370f3c98a7803eb0aa56ae06f2b5dbed23ecd",
       "urls": [
-        "bzzr://4bb8949a5db01d46d9c0c5639ec23a5e5193d186746c971c4864f28baddebc94"
+        "bzzr://4bb8949a5db01d46d9c0c5639ec23a5e5193d186746c971c4864f28baddebc94",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.9.7+commit.24524d6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.9.7+commit.24524d6.js"
       ]
     },
     {
@@ -1662,9 +2118,12 @@
       "prerelease": "nightly.2016.9.8",
       "build": "commit.f5a513a",
       "longVersion": "0.3.6-nightly.2016.9.8+commit.f5a513a",
+      "sha256": "0x184a1f1fe9430008b49d9af5ff8e40214c7cb7f116a6ba57cbe7513050dfa505",
       "keccak256": "0x3b0ad3ceb01a7b6c64757ce534ae1407536fce7f9703d3ea6923d03ed6ae2efe",
       "urls": [
-        "bzzr://390a81b677fd88ecbfb7de6fc75df81de14a6e50f411b9299daae343a82c16d1"
+        "bzzr://390a81b677fd88ecbfb7de6fc75df81de14a6e50f411b9299daae343a82c16d1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6-nightly.2016.9.8+commit.f5a513a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6-nightly.2016.9.8+commit.f5a513a.js"
       ]
     },
     {
@@ -1672,9 +2131,12 @@
       "version": "0.3.6",
       "build": "commit.3fc68da",
       "longVersion": "0.3.6+commit.3fc68da",
+      "sha256": "0xe6092a90398b8519fe2ad7c582074b806e365ebd55fc86d7d2d5c27513732373",
       "keccak256": "0xca308f787d878ece018898f1a731de2760c23d95dea77345263d28a286010e22",
       "urls": [
-        "bzzr://980e9ced0a6e1c174fa9f2244536f1ef1017b1cb2758bfd5993c54bc6c0debe7"
+        "bzzr://980e9ced0a6e1c174fa9f2244536f1ef1017b1cb2758bfd5993c54bc6c0debe7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.3.6+commit.3fc68da.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.3.6+commit.3fc68da.js"
       ]
     },
     {
@@ -1682,9 +2144,12 @@
       "version": "0.4.0",
       "build": "commit.acd334c9",
       "longVersion": "0.4.0+commit.acd334c9",
+      "sha256": "0xab1feba0069ac1adb8d09998871bce9af96fb88ee88d8e39235edc80a448afb7",
       "keccak256": "0xf39fe2338b22783588c6f69980ed87783808e3f853e976b46f4d2ad8570b5887",
       "urls": [
-        "bzzr://1cb0fa22a5e12c6698b4dc03cd6e98bae2e3a3dd664c29b9108838d6a3d90d34"
+        "bzzr://1cb0fa22a5e12c6698b4dc03cd6e98bae2e3a3dd664c29b9108838d6a3d90d34",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.0+commit.acd334c9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.0+commit.acd334c9.js"
       ]
     },
     {
@@ -1693,9 +2158,12 @@
       "prerelease": "nightly.2016.9.9",
       "build": "commit.79867f4",
       "longVersion": "0.4.1-nightly.2016.9.9+commit.79867f4",
+      "sha256": "0x4efeabcfd9ca1addede1e3e191ce6f37ff48bccb8639a6466bfc66e47f5d0a68",
       "keccak256": "0x92e7c8dec3491faab53b9c0403fc59024caaedde033e2eb141db679f33ead0ea",
       "urls": [
-        "bzzr://bf2f6a91eabb931d280bbf4b2a82e8ed832ac8f7dc70fb40253b6699d5693090"
+        "bzzr://bf2f6a91eabb931d280bbf4b2a82e8ed832ac8f7dc70fb40253b6699d5693090",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.1-nightly.2016.9.9+commit.79867f4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.1-nightly.2016.9.9+commit.79867f4.js"
       ]
     },
     {
@@ -1703,9 +2171,12 @@
       "version": "0.4.1",
       "build": "commit.4fc6fc2c",
       "longVersion": "0.4.1+commit.4fc6fc2c",
+      "sha256": "0x4b50704e5b245c97da025c5adcd893a19c4e2dfd87aec064b7e45069b7b8333f",
       "keccak256": "0x415b193456056970a77c5ca6a7a611319ce197bdc845288a143fab1b56f032d0",
       "urls": [
-        "bzzr://99bb321a5e5a90a7b192f409211960f8d971221fd0a0b2d4319133da36ef8882"
+        "bzzr://99bb321a5e5a90a7b192f409211960f8d971221fd0a0b2d4319133da36ef8882",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.1+commit.4fc6fc2c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.1+commit.4fc6fc2c.js"
       ]
     },
     {
@@ -1714,9 +2185,12 @@
       "prerelease": "nightly.2016.9.9",
       "build": "commit.51a98ab",
       "longVersion": "0.4.2-nightly.2016.9.9+commit.51a98ab",
+      "sha256": "0xae1417a27a3c13ce154ae948040cde94737c03fc052eb59e39caf9408be429ce",
       "keccak256": "0x71ec1424ba2cf9aa534ec8e77d0b98149e4dbdf2b76b0ffd3cca1dec9d898bad",
       "urls": [
-        "bzzr://2b125783e8ed8bef47d6fbab14736069ea0e00a76592f7d0b84d82e4e7d9c69d"
+        "bzzr://2b125783e8ed8bef47d6fbab14736069ea0e00a76592f7d0b84d82e4e7d9c69d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.9+commit.51a98ab.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.9+commit.51a98ab.js"
       ]
     },
     {
@@ -1725,9 +2199,12 @@
       "prerelease": "nightly.2016.9.12",
       "build": "commit.149dba9",
       "longVersion": "0.4.2-nightly.2016.9.12+commit.149dba9",
+      "sha256": "0xcdb9398fa8e885941f33842b978a1f831494d690a110c50c252daef8d7794fd8",
       "keccak256": "0x1243fdb7e1d96caf2a00c383f0300bd57a8a95418d8f6b5996be1b5dc7d4901a",
       "urls": [
-        "bzzr://68edba905b229fc3972552c91d1cc32ca8910c2ca23c0f8d0903afb14f9b2f71"
+        "bzzr://68edba905b229fc3972552c91d1cc32ca8910c2ca23c0f8d0903afb14f9b2f71",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.12+commit.149dba9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.12+commit.149dba9.js"
       ]
     },
     {
@@ -1736,9 +2213,12 @@
       "prerelease": "nightly.2016.9.13",
       "build": "commit.2bee7e9",
       "longVersion": "0.4.2-nightly.2016.9.13+commit.2bee7e9",
+      "sha256": "0x9c6413dc985cfa731795504415fd6413e0ee95c187551bff8572c4e6fe6f89c4",
       "keccak256": "0x8da9c3693c4090b428a08d1f9380fc3c03ab8cdc7a3f539bd453a855b29ee3d3",
       "urls": [
-        "bzzr://38e2d26bcb70d3fbbe01346f84ec6a22215caa4098fdc8e7daadba6a41b2960f"
+        "bzzr://38e2d26bcb70d3fbbe01346f84ec6a22215caa4098fdc8e7daadba6a41b2960f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.13+commit.2bee7e9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.13+commit.2bee7e9.js"
       ]
     },
     {
@@ -1747,9 +2227,12 @@
       "prerelease": "nightly.2016.9.15",
       "build": "commit.6a80511",
       "longVersion": "0.4.2-nightly.2016.9.15+commit.6a80511",
+      "sha256": "0x7a31f86357d045c80b5fb8464031d49bc6ed8ff36b6aa71367bfd71144f5fef5",
       "keccak256": "0xe7244f1450fb75b9efd863a1b056b49ebb6dc232b7bbbfeebf33350fae46e789",
       "urls": [
-        "bzzr://6834915de9650f23babbb64a11fc47bfbdb3edee085a12e012950dc8c558a79b"
+        "bzzr://6834915de9650f23babbb64a11fc47bfbdb3edee085a12e012950dc8c558a79b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.15+commit.6a80511.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.15+commit.6a80511.js"
       ]
     },
     {
@@ -1758,9 +2241,12 @@
       "prerelease": "nightly.2016.9.15",
       "build": "commit.8a4f8c2",
       "longVersion": "0.4.2-nightly.2016.9.15+commit.8a4f8c2",
+      "sha256": "0xf233dbc3a2f6e16c65347e588671a1964cdda83870181a9de79470a972294d19",
       "keccak256": "0x19df380eb5e05f2e06e0e65ab079db50f9e3ce71f446ced0f20bb07c23b696e3",
       "urls": [
-        "bzzr://76469bdc088b6b397b763321fdfbaf7991e2736bdbaabb03233a1d0e9dc30ee0"
+        "bzzr://76469bdc088b6b397b763321fdfbaf7991e2736bdbaabb03233a1d0e9dc30ee0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.15+commit.8a4f8c2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.15+commit.8a4f8c2.js"
       ]
     },
     {
@@ -1769,9 +2255,12 @@
       "prerelease": "nightly.2016.9.17",
       "build": "commit.60f432e8",
       "longVersion": "0.4.2-nightly.2016.9.17+commit.60f432e8",
+      "sha256": "0xd6cd7d293a9b48f55f67f7852489e0561fa57a6a67f17052020e51ba7aefc48d",
       "keccak256": "0x0bcb25fd69cbb24655466c203c866e3cc4d92d9551bab4c53f420ab025eac337",
       "urls": [
-        "bzzr://2efa3a6cb5c030bb53bc03c4cf78e2dd48a5d4872bd0f4a3c337ec19b2dc933f"
+        "bzzr://2efa3a6cb5c030bb53bc03c4cf78e2dd48a5d4872bd0f4a3c337ec19b2dc933f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.17+commit.60f432e8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.17+commit.60f432e8.js"
       ]
     },
     {
@@ -1780,9 +2269,12 @@
       "prerelease": "nightly.2016.9.17",
       "build": "commit.62f13ad8",
       "longVersion": "0.4.2-nightly.2016.9.17+commit.62f13ad8",
+      "sha256": "0xa8b2cabf7ce13397b1d6f00d294b01bcffed11e06446bf6d8b0d4caa73a1348a",
       "keccak256": "0x853dd52bc89a2bfef3a2ce38c09d56b822822f5145c30e0753a6520a08816dce",
       "urls": [
-        "bzzr://efa398a84d2cbe23036ba95ee12afa2f31721ea7124e4c40a391cbde2bb4f4c4"
+        "bzzr://efa398a84d2cbe23036ba95ee12afa2f31721ea7124e4c40a391cbde2bb4f4c4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.17+commit.62f13ad8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.17+commit.62f13ad8.js"
       ]
     },
     {
@@ -1791,9 +2283,12 @@
       "prerelease": "nightly.2016.9.17",
       "build": "commit.a78e7794",
       "longVersion": "0.4.2-nightly.2016.9.17+commit.a78e7794",
+      "sha256": "0xe550e3352b9e9ceb53254c705bdf3b0aacae04a07c396d24b2a645906161f75e",
       "keccak256": "0xd1bb55279a6297283df0065f0c735602dd3e71a4397b75783b1e22af3c797d19",
       "urls": [
-        "bzzr://d8fe745cc4d7ff97f151cb849cc1944138dc3821cb352472cc3bf01ee1cad4a8"
+        "bzzr://d8fe745cc4d7ff97f151cb849cc1944138dc3821cb352472cc3bf01ee1cad4a8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.17+commit.a78e7794.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.17+commit.a78e7794.js"
       ]
     },
     {
@@ -1802,9 +2297,12 @@
       "prerelease": "nightly.2016.9.17",
       "build": "commit.bc8476a",
       "longVersion": "0.4.2-nightly.2016.9.17+commit.bc8476a",
+      "sha256": "0x68f54173c89da2150ac453853d5d756b6d4bfea879b37470fb7fe2ceb0e325fb",
       "keccak256": "0xa21d556c01a5b92f0a3ec60c60ee5bb5d5ad62ec2bab23c9bd2ed3c3a5935105",
       "urls": [
-        "bzzr://6364260c647e9c68773bb02dadd1d78caa37e4e29b2da6474c9c15a458428c20"
+        "bzzr://6364260c647e9c68773bb02dadd1d78caa37e4e29b2da6474c9c15a458428c20",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.17+commit.bc8476a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.17+commit.bc8476a.js"
       ]
     },
     {
@@ -1813,9 +2311,12 @@
       "prerelease": "nightly.2016.9.17",
       "build": "commit.212e0160",
       "longVersion": "0.4.2-nightly.2016.9.17+commit.212e0160",
+      "sha256": "0x76600e972cf43b7d8610cd1351ac2edb80830ac4065f705f0f3506681105f54e",
       "keccak256": "0x8431790f172fde38b9e3b8e632f5f5dbb9c49d3e254d24252c20ef0d903bd160",
       "urls": [
-        "bzzr://8e7cbde5a72e500c6c0185b7d580e7270e337fda18007f84ef0760cec639c063"
+        "bzzr://8e7cbde5a72e500c6c0185b7d580e7270e337fda18007f84ef0760cec639c063",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2-nightly.2016.9.17+commit.212e0160.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2-nightly.2016.9.17+commit.212e0160.js"
       ]
     },
     {
@@ -1823,9 +2324,12 @@
       "version": "0.4.2",
       "build": "commit.af6afb04",
       "longVersion": "0.4.2+commit.af6afb04",
+      "sha256": "0x61f379fe68599eab8fb6ee17f5b22656498ebff911e22a2112ad08454e8c3021",
       "keccak256": "0x31c896ccaaca3c28b2f7a5d7af64a119449d64b7869df8279f6932b50b365493",
       "urls": [
-        "bzzr://a5a3c021de2cb151dee1900070bad5df098f5c5c503088fd2f423b6391496bba"
+        "bzzr://a5a3c021de2cb151dee1900070bad5df098f5c5c503088fd2f423b6391496bba",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.2+commit.af6afb04.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.2+commit.af6afb04.js"
       ]
     },
     {
@@ -1834,9 +2338,12 @@
       "prerelease": "nightly.2016.9.30",
       "build": "commit.d5cfb17b",
       "longVersion": "0.4.3-nightly.2016.9.30+commit.d5cfb17b",
+      "sha256": "0x16a2ae17a7187b78c7916d65a002a74541d20a6306793ab118bb7b07d0811fdc",
       "keccak256": "0x1c15a96e2770b1fc9b35f6df84495c7617c706ebb2525d6d5d535fb4268a83a9",
       "urls": [
-        "bzzr://fa006b14e97633f005f325b8de0b86412ab2210646ee54f97fdbf0ee52545445"
+        "bzzr://fa006b14e97633f005f325b8de0b86412ab2210646ee54f97fdbf0ee52545445",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.9.30+commit.d5cfb17b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.9.30+commit.d5cfb17b.js"
       ]
     },
     {
@@ -1845,9 +2352,12 @@
       "prerelease": "nightly.2016.10.10",
       "build": "commit.119bd4ad",
       "longVersion": "0.4.3-nightly.2016.10.10+commit.119bd4ad",
+      "sha256": "0x274fbb996cdc4682c6d8312efc1fc8bec5f77af76bab9a287900be4a8dda35c7",
       "keccak256": "0x9b7c7c122923cc27f3e09ee24027e2a5f0eecb3b1dfd2998b9ce755f7373cc46",
       "urls": [
-        "bzzr://dead9fdcbe64fa7a239bd0eada3a1cea7d17e3f66014efb902f3dae708fef4ce"
+        "bzzr://dead9fdcbe64fa7a239bd0eada3a1cea7d17e3f66014efb902f3dae708fef4ce",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.10+commit.119bd4ad.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.10+commit.119bd4ad.js"
       ]
     },
     {
@@ -1856,9 +2366,12 @@
       "prerelease": "nightly.2016.10.11",
       "build": "commit.aa18a6bd",
       "longVersion": "0.4.3-nightly.2016.10.11+commit.aa18a6bd",
+      "sha256": "0x7f715c7682140d286c0084d1780251c5fa90df07a2f4a5ea78b079bcdaa14407",
       "keccak256": "0x885481922567c63d3cc2cfc79c0e08a8ccdd05b54912bbe8cea3d9ff15418c4b",
       "urls": [
-        "bzzr://85030bad5ca06b4b65ccd9698b8723428ce37dbc299bccd22d49ed0b42723700"
+        "bzzr://85030bad5ca06b4b65ccd9698b8723428ce37dbc299bccd22d49ed0b42723700",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.11+commit.aa18a6bd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.11+commit.aa18a6bd.js"
       ]
     },
     {
@@ -1867,9 +2380,12 @@
       "prerelease": "nightly.2016.10.12",
       "build": "commit.def3f3ea",
       "longVersion": "0.4.3-nightly.2016.10.12+commit.def3f3ea",
+      "sha256": "0xddbe1f050c9a5ea6b18bd76b09f7ec5bbc28c784a1f0c34c09ae6f9eb4263a59",
       "keccak256": "0xde0145a4afbf8eee1f077f2e28b5b3dc838139b62cd42706a7186b6d03671d11",
       "urls": [
-        "bzzr://9c66292e62a5fe01b3d3ea67344558fede467d86b17bd6a2c6db71e54ac7590e"
+        "bzzr://9c66292e62a5fe01b3d3ea67344558fede467d86b17bd6a2c6db71e54ac7590e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.12+commit.def3f3ea.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.12+commit.def3f3ea.js"
       ]
     },
     {
@@ -1878,9 +2394,12 @@
       "prerelease": "nightly.2016.10.13",
       "build": "commit.2951c1eb",
       "longVersion": "0.4.3-nightly.2016.10.13+commit.2951c1eb",
+      "sha256": "0x1a3fb42cdd5941a453814f096899d7359725ff0992311855f6b09744cd757554",
       "keccak256": "0x81a4bc90acf35e3a86c645e29a29811b243f5c965b954ada640b2884b79b66be",
       "urls": [
-        "bzzr://61bdbdb7bc73509b90de3feb9ddd8506cf8ef442bb37b6b788374dc6e2e294f9"
+        "bzzr://61bdbdb7bc73509b90de3feb9ddd8506cf8ef442bb37b6b788374dc6e2e294f9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.13+commit.2951c1eb.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.13+commit.2951c1eb.js"
       ]
     },
     {
@@ -1889,9 +2408,12 @@
       "prerelease": "nightly.2016.10.14",
       "build": "commit.635b6e0",
       "longVersion": "0.4.3-nightly.2016.10.14+commit.635b6e0",
+      "sha256": "0x4e25e34e8fc70a483bf02ffe3c951c46d8ec91aeb91cc5a7761cdfad9ef95806",
       "keccak256": "0x0bc4bff6fbafe09f54ea69d628b0465040e2feca302790e7d88e997cf9570722",
       "urls": [
-        "bzzr://7f3aad5a36603b6fe8391c7c3d457bb797678b00933e8780afdf0e98064f387c"
+        "bzzr://7f3aad5a36603b6fe8391c7c3d457bb797678b00933e8780afdf0e98064f387c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.14+commit.635b6e0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.14+commit.635b6e0.js"
       ]
     },
     {
@@ -1900,9 +2422,12 @@
       "prerelease": "nightly.2016.10.15",
       "build": "commit.482807f6",
       "longVersion": "0.4.3-nightly.2016.10.15+commit.482807f6",
+      "sha256": "0x548f60bba9204a712c73c16e602bade383923c58cdb2be0934b2cb3bff365653",
       "keccak256": "0x6e154734da6dc3c2470612a7dd339c5406bcce6e7ebf8f42b7e6f99a124d69f0",
       "urls": [
-        "bzzr://e892ec10727fefd40410b195f25e1bd50c217ba5e6eb6fa6645a20513f909d0f"
+        "bzzr://e892ec10727fefd40410b195f25e1bd50c217ba5e6eb6fa6645a20513f909d0f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.15+commit.482807f6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.15+commit.482807f6.js"
       ]
     },
     {
@@ -1911,9 +2436,12 @@
       "prerelease": "nightly.2016.10.17",
       "build": "commit.7d32937",
       "longVersion": "0.4.3-nightly.2016.10.17+commit.7d32937",
+      "sha256": "0x3111383c2e04f7689dc005be9e487af24c99dbf283c51c180eafdf15d457d8ba",
       "keccak256": "0x4a5e312ae2925d170cbc1106a67750944350ded8eec3a284fef8b53dddfd384f",
       "urls": [
-        "bzzr://1e6dee9a77400ad71687d4df96f24cc0d79d67ab599b55ee93ffbd5c6dbcd945"
+        "bzzr://1e6dee9a77400ad71687d4df96f24cc0d79d67ab599b55ee93ffbd5c6dbcd945",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.17+commit.7d32937.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.17+commit.7d32937.js"
       ]
     },
     {
@@ -1922,9 +2450,12 @@
       "prerelease": "nightly.2016.10.18",
       "build": "commit.a9eb645",
       "longVersion": "0.4.3-nightly.2016.10.18+commit.a9eb645",
+      "sha256": "0x93a83c643ad939637d16371f78f38e9c004554b9271b5311dce4c16f862f063c",
       "keccak256": "0x1c8a65610383be20c4988052d87bdacc434ec2f668a9689b2cc1462721703f60",
       "urls": [
-        "bzzr://fcf470331352ee04c9f6da950a3e3871db0b9635423029482fb2a336c5b3dbab"
+        "bzzr://fcf470331352ee04c9f6da950a3e3871db0b9635423029482fb2a336c5b3dbab",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.18+commit.a9eb645.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.18+commit.a9eb645.js"
       ]
     },
     {
@@ -1933,9 +2464,12 @@
       "prerelease": "nightly.2016.10.19",
       "build": "commit.fd6f2b5",
       "longVersion": "0.4.3-nightly.2016.10.19+commit.fd6f2b5",
+      "sha256": "0xd3139c6789e7e51468fcff069fa2a932a32f5962d3f222ac90d52915513316f6",
       "keccak256": "0xd04b5d44a54f3185d92b39f59dd91d9e30c1795dfe12d88f4779629879ea4598",
       "urls": [
-        "bzzr://cad1705a03ca0e1aaabdf4c39e7bfc75a547ec58ec254f058544dd84e0d34375"
+        "bzzr://cad1705a03ca0e1aaabdf4c39e7bfc75a547ec58ec254f058544dd84e0d34375",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.19+commit.fd6f2b5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.19+commit.fd6f2b5.js"
       ]
     },
     {
@@ -1944,9 +2478,12 @@
       "prerelease": "nightly.2016.10.20",
       "build": "commit.9d304501",
       "longVersion": "0.4.3-nightly.2016.10.20+commit.9d304501",
+      "sha256": "0x8ed67232ea009840b86623086b3ba22fa2c9e5fff688ed0d4c2821d894ee8fc6",
       "keccak256": "0x713d278bba46ba18cd5c4ac0c06d32410e67a50ade80faea0bf8e60142a13af9",
       "urls": [
-        "bzzr://a3b10405d71a673fd7780772b2d592f067e2775c8b34c794b0c8797f62142414"
+        "bzzr://a3b10405d71a673fd7780772b2d592f067e2775c8b34c794b0c8797f62142414",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.20+commit.9d304501.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.20+commit.9d304501.js"
       ]
     },
     {
@@ -1955,9 +2492,12 @@
       "prerelease": "nightly.2016.10.21",
       "build": "commit.984b8ac1",
       "longVersion": "0.4.3-nightly.2016.10.21+commit.984b8ac1",
+      "sha256": "0xdf84cea25611efc1652d57d8928409f28283f4734e52d9736e9e25998a2a95f4",
       "keccak256": "0xb8d7216408ff21e5798c2c07bfa302a94b4d4d22f87034aec56ac81508c1d26a",
       "urls": [
-        "bzzr://f197c9c853eb9a4c644ecb8f2a804e4a35dc874f63c4d852dcaf59499349b79c"
+        "bzzr://f197c9c853eb9a4c644ecb8f2a804e4a35dc874f63c4d852dcaf59499349b79c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.21+commit.984b8ac1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.21+commit.984b8ac1.js"
       ]
     },
     {
@@ -1966,9 +2506,12 @@
       "prerelease": "nightly.2016.10.24",
       "build": "commit.84b43b91",
       "longVersion": "0.4.3-nightly.2016.10.24+commit.84b43b91",
+      "sha256": "0xc9b121a8cc25021811079bf2cba6b26dc610c280fb58956c0c0fb8cf1b54e1cd",
       "keccak256": "0x90fc3fea19c9e94b0e32e2bf1b8594b2b444486df614935ed0b258f8a96cda48",
       "urls": [
-        "bzzr://1eb6520a43bbc06a9dc4410d628f3c0265e82c7f8eb70736f803d642f783859a"
+        "bzzr://1eb6520a43bbc06a9dc4410d628f3c0265e82c7f8eb70736f803d642f783859a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.24+commit.84b43b91.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.24+commit.84b43b91.js"
       ]
     },
     {
@@ -1977,9 +2520,12 @@
       "prerelease": "nightly.2016.10.25",
       "build": "commit.d190f016",
       "longVersion": "0.4.3-nightly.2016.10.25+commit.d190f016",
+      "sha256": "0xd7f3db1ef548ddf57e90c7053fbf134fc7d886840e9103b839c6f60cdf5baf1a",
       "keccak256": "0xe3d22a5ef8a06a060431ca47551878d535cad8f6942e67e720551e3759ce77fe",
       "urls": [
-        "bzzr://a38767a3d94669e2d598cc53c11eebc68086a249c81098ed941095368bca1b6a"
+        "bzzr://a38767a3d94669e2d598cc53c11eebc68086a249c81098ed941095368bca1b6a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3-nightly.2016.10.25+commit.d190f016.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3-nightly.2016.10.25+commit.d190f016.js"
       ]
     },
     {
@@ -1987,9 +2533,12 @@
       "version": "0.4.3",
       "build": "commit.2353da71",
       "longVersion": "0.4.3+commit.2353da71",
+      "sha256": "0x5b30f5eab232f6ee5e384048688bfd9dfe1d6dd6dcda137aff72bda3a84cf1d2",
       "keccak256": "0x5ed0545ab2103074ae6feb777ba73fec90516676acfb53d7669708a751016124",
       "urls": [
-        "bzzr://17e2104b517fca722b4a78190a777d7781e0fa5f1ceaaf034e4c8d62503ee54e"
+        "bzzr://17e2104b517fca722b4a78190a777d7781e0fa5f1ceaaf034e4c8d62503ee54e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.3+commit.2353da71.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.3+commit.2353da71.js"
       ]
     },
     {
@@ -1998,9 +2547,12 @@
       "prerelease": "nightly.2016.10.25",
       "build": "commit.f99a418b",
       "longVersion": "0.4.4-nightly.2016.10.25+commit.f99a418b",
+      "sha256": "0xab73111716382d21a7a07a8dfedfd970c9aa885a4329e4d52a03508da714dae8",
       "keccak256": "0x92cf26bb66862f3039f57a1444bc7e2f2e888c8ee46b5568ec390cb2746061ec",
       "urls": [
-        "bzzr://19c27e7a1a27ad4e3fb5bd6b6511c2dc4dbdba9b01326cb02577c9ab25be352c"
+        "bzzr://19c27e7a1a27ad4e3fb5bd6b6511c2dc4dbdba9b01326cb02577c9ab25be352c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.4-nightly.2016.10.25+commit.f99a418b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.4-nightly.2016.10.25+commit.f99a418b.js"
       ]
     },
     {
@@ -2009,9 +2561,12 @@
       "prerelease": "nightly.2016.10.26",
       "build": "commit.34e2209b",
       "longVersion": "0.4.4-nightly.2016.10.26+commit.34e2209b",
+      "sha256": "0x4c0181df3cdb16f2a9d8c04109372fb8695de0c3b282bc80f58936bfceff7dad",
       "keccak256": "0xe57e5020061d293b7a819319d504f1de74bda1cdba0b7c2a970f8b7d22f6958b",
       "urls": [
-        "bzzr://ec616fbc8be2e8cb41dd6af0a8649c2e4bbd30f6b41fd3904c68d00cff55c5e9"
+        "bzzr://ec616fbc8be2e8cb41dd6af0a8649c2e4bbd30f6b41fd3904c68d00cff55c5e9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.4-nightly.2016.10.26+commit.34e2209b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.4-nightly.2016.10.26+commit.34e2209b.js"
       ]
     },
     {
@@ -2020,9 +2575,12 @@
       "prerelease": "nightly.2016.10.27",
       "build": "commit.76e958f6",
       "longVersion": "0.4.4-nightly.2016.10.27+commit.76e958f6",
+      "sha256": "0x9d8ee3fef896c7dda9db683a0063d952b63bc7a6cb4e02e36ce077c50ab71121",
       "keccak256": "0x5538ce3e3c4554786876e18523cfeb4f43db8def5d95a7bb5decb57035464fb8",
       "urls": [
-        "bzzr://cbdead95bc26164a1fa9e26d72ff63699adc89a89a6420b1062d7d70bab68b1c"
+        "bzzr://cbdead95bc26164a1fa9e26d72ff63699adc89a89a6420b1062d7d70bab68b1c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.4-nightly.2016.10.27+commit.76e958f6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.4-nightly.2016.10.27+commit.76e958f6.js"
       ]
     },
     {
@@ -2031,9 +2589,12 @@
       "prerelease": "nightly.2016.10.28",
       "build": "commit.e85390cc",
       "longVersion": "0.4.4-nightly.2016.10.28+commit.e85390cc",
+      "sha256": "0xe463abcb9a5549e4aea4ecb8920514744fcbed9e34419bb40cf34d8ee4ff5061",
       "keccak256": "0x4ae7420ac2cf766172048ef225d1b5dcbd4474384f6dc7b5c54572ebb2a24b47",
       "urls": [
-        "bzzr://cf308fcd4a8c6bfb3145bb1c0e698822a9dc45cbb9d81c872b167082a8893711"
+        "bzzr://cf308fcd4a8c6bfb3145bb1c0e698822a9dc45cbb9d81c872b167082a8893711",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.4-nightly.2016.10.28+commit.e85390cc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.4-nightly.2016.10.28+commit.e85390cc.js"
       ]
     },
     {
@@ -2042,9 +2603,12 @@
       "prerelease": "nightly.2016.10.31",
       "build": "commit.1d3460c4",
       "longVersion": "0.4.4-nightly.2016.10.31+commit.1d3460c4",
+      "sha256": "0x414db3fb1e2567da8c77f32e72c24fe520306522e7e9c2ef1e60d8e6e1c00a01",
       "keccak256": "0x284e8c407035673684a1d0797e0e82f00437008b55f38412564f378b3459825a",
       "urls": [
-        "bzzr://98c809f31f6d2e473940151532037dfddcbab6bbcf1bbe0b2401447dd5860782"
+        "bzzr://98c809f31f6d2e473940151532037dfddcbab6bbcf1bbe0b2401447dd5860782",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.4-nightly.2016.10.31+commit.1d3460c4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.4-nightly.2016.10.31+commit.1d3460c4.js"
       ]
     },
     {
@@ -2052,9 +2616,12 @@
       "version": "0.4.4",
       "build": "commit.4633f3de",
       "longVersion": "0.4.4+commit.4633f3de",
+      "sha256": "0x3ae6316fa03d576f4acd3c003b09d2e1b144c1f46d2c999add1047b8fa027c0f",
       "keccak256": "0x2de6e0cfb7526987aa4e5fd3504fc2e0ebe5e3630a3cdaaed5efd8b90aa58a3b",
       "urls": [
-        "bzzr://573f6193469b559a4ad55e698473b8a296c70646f09472a78dbef05da6b7078d"
+        "bzzr://573f6193469b559a4ad55e698473b8a296c70646f09472a78dbef05da6b7078d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.4+commit.4633f3de.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.4+commit.4633f3de.js"
       ]
     },
     {
@@ -2063,9 +2630,12 @@
       "prerelease": "nightly.2016.11.1",
       "build": "commit.9cb1d30e",
       "longVersion": "0.4.5-nightly.2016.11.1+commit.9cb1d30e",
+      "sha256": "0x6d5ca7c1cb9a722ff3ff6162d603a79cecab71873819ff41d44c3b7ebb6a0e0d",
       "keccak256": "0x2423a1226d374e618c04c6e33b583e0b87aabb28d17c4ce7b2be467cd30c8cbc",
       "urls": [
-        "bzzr://899f75c1859e7e19aa1ceb3ad67d5b46921d082edf35c12767d6744cb0330d5b"
+        "bzzr://899f75c1859e7e19aa1ceb3ad67d5b46921d082edf35c12767d6744cb0330d5b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.1+commit.9cb1d30e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.1+commit.9cb1d30e.js"
       ]
     },
     {
@@ -2074,9 +2644,12 @@
       "prerelease": "nightly.2016.11.3",
       "build": "commit.90a4acc3",
       "longVersion": "0.4.5-nightly.2016.11.3+commit.90a4acc3",
+      "sha256": "0x3ef41fa78c78b35d7f9d18437818b714b002f8fdebc5fd1580a498f05724fb75",
       "keccak256": "0xdb5dba7f6c1ddac755434c4b195e43b30937d6c5611170344e8cd94a7d69aff6",
       "urls": [
-        "bzzr://9793907564758c64acdec8860a4d2869da8ea40d7f60e176c4b6aad26ca455dd"
+        "bzzr://9793907564758c64acdec8860a4d2869da8ea40d7f60e176c4b6aad26ca455dd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.3+commit.90a4acc3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.3+commit.90a4acc3.js"
       ]
     },
     {
@@ -2085,9 +2658,12 @@
       "prerelease": "nightly.2016.11.4",
       "build": "commit.d97d267a",
       "longVersion": "0.4.5-nightly.2016.11.4+commit.d97d267a",
+      "sha256": "0x11c904f1d8eeec03d288ef6087a9db41d9ad1282f1b163db2394564f08bbada0",
       "keccak256": "0xdb3002db667bdf27d95db1ad8828410be8b69785c21b6563a85b736cef94211f",
       "urls": [
-        "bzzr://b64c0f2c990936ecf68d4958d4a97582550e516da5d40bfa36696f0d08d764f3"
+        "bzzr://b64c0f2c990936ecf68d4958d4a97582550e516da5d40bfa36696f0d08d764f3",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.4+commit.d97d267a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.4+commit.d97d267a.js"
       ]
     },
     {
@@ -2096,9 +2672,12 @@
       "prerelease": "nightly.2016.11.8",
       "build": "commit.7a30e8cf",
       "longVersion": "0.4.5-nightly.2016.11.8+commit.7a30e8cf",
+      "sha256": "0x4859accb0926106870d0f9f7287e3dda000a34bd094e534f588ff4c127e952cd",
       "keccak256": "0xfd0ce780668df32582b318a5c46d06f12497e89e4e69b9035731c3c6883646e2",
       "urls": [
-        "bzzr://9d53508b2a1ca17abb71228a29bb18ee8eedca03a23d6ea24de6f99c02a082cc"
+        "bzzr://9d53508b2a1ca17abb71228a29bb18ee8eedca03a23d6ea24de6f99c02a082cc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.8+commit.7a30e8cf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.8+commit.7a30e8cf.js"
       ]
     },
     {
@@ -2107,9 +2686,12 @@
       "prerelease": "nightly.2016.11.9",
       "build": "commit.c82acfd3",
       "longVersion": "0.4.5-nightly.2016.11.9+commit.c82acfd3",
+      "sha256": "0x6c31b4ceb3cca126e94b6728bc8fda47ae85e411e93391c8225779c9b2056a84",
       "keccak256": "0x4232a539a9eb54b28d3c57f93a9f9dd44670a793dee694e892172cd71ea6fd77",
       "urls": [
-        "bzzr://02159abf02b3c76446924f6c8e95478557a067b6834ef2bc6f535d5a5ce33da8"
+        "bzzr://02159abf02b3c76446924f6c8e95478557a067b6834ef2bc6f535d5a5ce33da8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.9+commit.c82acfd3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.9+commit.c82acfd3.js"
       ]
     },
     {
@@ -2118,9 +2700,12 @@
       "prerelease": "nightly.2016.11.10",
       "build": "commit.a40dcfef",
       "longVersion": "0.4.5-nightly.2016.11.10+commit.a40dcfef",
+      "sha256": "0xff69ea10e1e89d9c5af9b2ef2457778490bf2cca740aa73ef54aabe353ee92ab",
       "keccak256": "0xa46a2921139e001ec0df633e64ba1a039389d4e8ce3d7f183a458fd94c542daf",
       "urls": [
-        "bzzr://e8cadfdff11214335434ca4bd5cd4739c488f4279db7cca60d1dede809acf453"
+        "bzzr://e8cadfdff11214335434ca4bd5cd4739c488f4279db7cca60d1dede809acf453",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.10+commit.a40dcfef.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.10+commit.a40dcfef.js"
       ]
     },
     {
@@ -2129,9 +2714,12 @@
       "prerelease": "nightly.2016.11.11",
       "build": "commit.6248e92d",
       "longVersion": "0.4.5-nightly.2016.11.11+commit.6248e92d",
+      "sha256": "0xcd7eeae8d4d3b48ad817c5b28350aeecd90b4a7db73e83d2e0baa63a0bd6ddb9",
       "keccak256": "0x90059a436e3df87c05ae44186cfced57bafa80fd8dbf38bce45aae9c25364e4a",
       "urls": [
-        "bzzr://756cd0b01c327a0ac1994fa5531410bf44ad9657ef3ecb32a9f98f3120c1d9a6"
+        "bzzr://756cd0b01c327a0ac1994fa5531410bf44ad9657ef3ecb32a9f98f3120c1d9a6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.11+commit.6248e92d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.11+commit.6248e92d.js"
       ]
     },
     {
@@ -2140,9 +2728,12 @@
       "prerelease": "nightly.2016.11.14",
       "build": "commit.4f546e65",
       "longVersion": "0.4.5-nightly.2016.11.14+commit.4f546e65",
+      "sha256": "0x91f81c195ec7a931af75e0fa784a270d58baead29e8b8b59a4693301357fc453",
       "keccak256": "0x3b9dce7d637c08a5143d178cdfb7511d007a6eb9f2a5693e356275bc3ddc7006",
       "urls": [
-        "bzzr://b4690fbd4964ac3691c5eecfc6e62826b624628782e5ee6622977e3b52e244cf"
+        "bzzr://b4690fbd4964ac3691c5eecfc6e62826b624628782e5ee6622977e3b52e244cf",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.14+commit.4f546e65.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.14+commit.4f546e65.js"
       ]
     },
     {
@@ -2151,9 +2742,12 @@
       "prerelease": "nightly.2016.11.15",
       "build": "commit.c1b1efaf",
       "longVersion": "0.4.5-nightly.2016.11.15+commit.c1b1efaf",
+      "sha256": "0x8bd877a91adaa8f9aeb539ebff80958fa3fedfff7b4a5ec92f385bf3ec95f2f7",
       "keccak256": "0xf2e80c6aaf79da381797b87fe5478ace1f7874f8f405f08c5e89563eba206982",
       "urls": [
-        "bzzr://6e6d4c1e88a43db174803a8846e7ec58bcf6c09a95f6df15a6a28334ef7d882d"
+        "bzzr://6e6d4c1e88a43db174803a8846e7ec58bcf6c09a95f6df15a6a28334ef7d882d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.15+commit.c1b1efaf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.15+commit.c1b1efaf.js"
       ]
     },
     {
@@ -2162,9 +2756,12 @@
       "prerelease": "nightly.2016.11.16",
       "build": "commit.c8116918",
       "longVersion": "0.4.5-nightly.2016.11.16+commit.c8116918",
+      "sha256": "0x2a7a085babdf17faed1fa0ac378670e595f6b8c354aba4fe242121c694486c56",
       "keccak256": "0xfb6fc96c6fa9deb50297a5d560594dda35ecd1f21a2ecd2f9dd71df18cb6490c",
       "urls": [
-        "bzzr://9336eaeb490fbcf613463575ba7034265746f2b14f4991038880f49136eaac55"
+        "bzzr://9336eaeb490fbcf613463575ba7034265746f2b14f4991038880f49136eaac55",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.16+commit.c8116918.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.16+commit.c8116918.js"
       ]
     },
     {
@@ -2173,9 +2770,12 @@
       "prerelease": "nightly.2016.11.17",
       "build": "commit.b46a14f4",
       "longVersion": "0.4.5-nightly.2016.11.17+commit.b46a14f4",
+      "sha256": "0x73981bcc91c595a3db2b48d7985b53b9addbe947281d0d7e2c714ce2a9b406a6",
       "keccak256": "0x139d7b90d61f5818a84bb1222236049ead456ec550d653f6902c0f2bc6bd5760",
       "urls": [
-        "bzzr://5fe7661ae0d7618371c63cca226286858bb3f997bb8153cb1fdc6782e13980c1"
+        "bzzr://5fe7661ae0d7618371c63cca226286858bb3f997bb8153cb1fdc6782e13980c1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.17+commit.b46a14f4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.17+commit.b46a14f4.js"
       ]
     },
     {
@@ -2184,9 +2784,12 @@
       "prerelease": "nightly.2016.11.21",
       "build": "commit.afda210a",
       "longVersion": "0.4.5-nightly.2016.11.21+commit.afda210a",
+      "sha256": "0xaf00eec04de425497ed1dc1b3bc3a917367d5b2c3fad2c72e005ec6b923967cb",
       "keccak256": "0xcfa8e0e6173d38f141284eaaee0b6033975a19d1aed9fe908ac732d1084a8853",
       "urls": [
-        "bzzr://515f5712807dddb5cf19f4d16bafabe07212e412bd649fc7c7589ae33b8c24f7"
+        "bzzr://515f5712807dddb5cf19f4d16bafabe07212e412bd649fc7c7589ae33b8c24f7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5-nightly.2016.11.21+commit.afda210a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5-nightly.2016.11.21+commit.afda210a.js"
       ]
     },
     {
@@ -2194,9 +2797,12 @@
       "version": "0.4.5",
       "build": "commit.b318366e",
       "longVersion": "0.4.5+commit.b318366e",
+      "sha256": "0x1425a06e0195580f7a8a0db7015f8e8b4402decea45bfbb19d5841b24e7ebf0f",
       "keccak256": "0x7b418a09602d0b4c5dcd23998d3843934f8fff43337a1f3bdf324fd402294aaa",
       "urls": [
-        "bzzr://de94c41f727124a5b02bd1db087e6bcba19a682c5d89bf3cdaa650e9fdd08403"
+        "bzzr://de94c41f727124a5b02bd1db087e6bcba19a682c5d89bf3cdaa650e9fdd08403",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.5+commit.b318366e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.5+commit.b318366e.js"
       ]
     },
     {
@@ -2205,9 +2811,12 @@
       "prerelease": "nightly.2016.11.21",
       "build": "commit.aa48008c",
       "longVersion": "0.4.6-nightly.2016.11.21+commit.aa48008c",
+      "sha256": "0x78494109146f3ef771eca0d8155c9c7a5b995bf7e17c1614ce6aa07dcea986b2",
       "keccak256": "0xc3a54c91d98ae526a29f2a953c430311d2b6d5989c7d077065c7a94be2e6fc70",
       "urls": [
-        "bzzr://f94c5d0ed6b049b0726107df5264c2b1d2fa9cd4fb263de2bcbd134afde20c43"
+        "bzzr://f94c5d0ed6b049b0726107df5264c2b1d2fa9cd4fb263de2bcbd134afde20c43",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.6-nightly.2016.11.21+commit.aa48008c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.6-nightly.2016.11.21+commit.aa48008c.js"
       ]
     },
     {
@@ -2216,9 +2825,12 @@
       "prerelease": "nightly.2016.11.22",
       "build": "commit.3d9a180c",
       "longVersion": "0.4.6-nightly.2016.11.22+commit.3d9a180c",
+      "sha256": "0x0f6ad73487d33eb19dd0f00a3b167410feb51e5b501dbcf9b3aaf85ed5160c5f",
       "keccak256": "0xa0b2fdeec331d0779fc8a1f39cf11c847b17e0b4717e70c35a0f57ee7feef448",
       "urls": [
-        "bzzr://8a2ce829a9a8591c82eb5a6a33a98e9bd7db5c244fbe9faa81b75e580d2de601"
+        "bzzr://8a2ce829a9a8591c82eb5a6a33a98e9bd7db5c244fbe9faa81b75e580d2de601",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.6-nightly.2016.11.22+commit.3d9a180c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.6-nightly.2016.11.22+commit.3d9a180c.js"
       ]
     },
     {
@@ -2226,9 +2838,12 @@
       "version": "0.4.6",
       "build": "commit.2dabbdf0",
       "longVersion": "0.4.6+commit.2dabbdf0",
+      "sha256": "0xeef2854dffd1b108b68c3d6b3b9aeac642fa34ed6538401840f1b8c0a1fa4f6e",
       "keccak256": "0x25d22483d6a6ba6fd44e5537f796f8bf2964bed34a8dfbe24080fb3b901fc707",
       "urls": [
-        "bzzr://b873fa122233c91b1531527c390f6ca49df4d2a2c5f75706f4b612a0c813cb6a"
+        "bzzr://b873fa122233c91b1531527c390f6ca49df4d2a2c5f75706f4b612a0c813cb6a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.6+commit.2dabbdf0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.6+commit.2dabbdf0.js"
       ]
     },
     {
@@ -2237,9 +2852,12 @@
       "prerelease": "nightly.2016.11.22",
       "build": "commit.1a205ebf",
       "longVersion": "0.4.7-nightly.2016.11.22+commit.1a205ebf",
+      "sha256": "0xa5fb2d25f65f5a353d71902f4843d5c05dce3d2974d1f608f8a896f7720a76e2",
       "keccak256": "0xff82281b250c640deda648aed3d048bb1cf460400709b5d27b7826b62d756742",
       "urls": [
-        "bzzr://579bba41d4f1e6a31ec57340f06ed8bed22a53c406122bc02adf250bb5aa4449"
+        "bzzr://579bba41d4f1e6a31ec57340f06ed8bed22a53c406122bc02adf250bb5aa4449",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.22+commit.1a205ebf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.22+commit.1a205ebf.js"
       ]
     },
     {
@@ -2248,9 +2866,12 @@
       "prerelease": "nightly.2016.11.23",
       "build": "commit.475009b9",
       "longVersion": "0.4.7-nightly.2016.11.23+commit.475009b9",
+      "sha256": "0x37c7c8ebf3261a589f31500ec81ff94d19fc83d5e3a343e0e18777c99fe99513",
       "keccak256": "0x200bd5377e860af5e6bdd82b594cf2aec918a8e3e5268b4830b8f06d83ad7587",
       "urls": [
-        "bzzr://8c0056a4656bed7c098f0f6d8332e2ad0f23d382c3e0c24f4d0ab3ea965a562a"
+        "bzzr://8c0056a4656bed7c098f0f6d8332e2ad0f23d382c3e0c24f4d0ab3ea965a562a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.23+commit.475009b9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.23+commit.475009b9.js"
       ]
     },
     {
@@ -2259,9 +2880,12 @@
       "prerelease": "nightly.2016.11.24",
       "build": "commit.851f8576",
       "longVersion": "0.4.7-nightly.2016.11.24+commit.851f8576",
+      "sha256": "0x7abe88dd36fbe1b2aa385fe05185ad85d0bc4ef8b670818b68929bc94e3afcde",
       "keccak256": "0x6cefdf3e17e449776fc2cf23e140d2194852f490aa60e77c5b92c00b936a45fa",
       "urls": [
-        "bzzr://d757c52f140e51293c784df770cee397ba546aa8248b482caa07aa92c730d0e1"
+        "bzzr://d757c52f140e51293c784df770cee397ba546aa8248b482caa07aa92c730d0e1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.24+commit.851f8576.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.24+commit.851f8576.js"
       ]
     },
     {
@@ -2270,9 +2894,12 @@
       "prerelease": "nightly.2016.11.25",
       "build": "commit.ba94b0ae",
       "longVersion": "0.4.7-nightly.2016.11.25+commit.ba94b0ae",
+      "sha256": "0xccd9ba67a7023a253b6beb8bad27d334ade249199227dfc080d607def5d935b1",
       "keccak256": "0x03284b61e326cda47323276fe603978aece296f81abf029e2c3432dc93585c62",
       "urls": [
-        "bzzr://982113587c50cadc225b9ffbe29fc6fe018a3505ef61181c48a9b7dbe9ffc23a"
+        "bzzr://982113587c50cadc225b9ffbe29fc6fe018a3505ef61181c48a9b7dbe9ffc23a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.25+commit.ba94b0ae.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.25+commit.ba94b0ae.js"
       ]
     },
     {
@@ -2281,9 +2908,12 @@
       "prerelease": "nightly.2016.11.26",
       "build": "commit.4a67a286",
       "longVersion": "0.4.7-nightly.2016.11.26+commit.4a67a286",
+      "sha256": "0xb8ef1ad0a711b51a1beb72358e9cf84a07d657d7ab7dae8180115db10ff485f3",
       "keccak256": "0x725b61792ed70f699beacc6ff2b038e9a79bcd1cb2cda19a2677b08bb86f76a5",
       "urls": [
-        "bzzr://f6aab62ce385c682be651288b0b44bcb833053ad84becb11a5eb1b7dd2643f07"
+        "bzzr://f6aab62ce385c682be651288b0b44bcb833053ad84becb11a5eb1b7dd2643f07",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.26+commit.4a67a286.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.26+commit.4a67a286.js"
       ]
     },
     {
@@ -2292,9 +2922,12 @@
       "prerelease": "nightly.2016.11.28",
       "build": "commit.dadb4818",
       "longVersion": "0.4.7-nightly.2016.11.28+commit.dadb4818",
+      "sha256": "0x3a3a308d73ab9939c3c41c55853ac25fa1720df00e5db315f4ee291c4b26e324",
       "keccak256": "0x8bdb1847999584e2a30803b115a96f8af42bbd81b36908b684dbb5656238d5a3",
       "urls": [
-        "bzzr://ca3c1478c981ec0780d4857ff982e8191726a2b552d18fe8133aa7afed2c9131"
+        "bzzr://ca3c1478c981ec0780d4857ff982e8191726a2b552d18fe8133aa7afed2c9131",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.28+commit.dadb4818.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.28+commit.dadb4818.js"
       ]
     },
     {
@@ -2303,9 +2936,12 @@
       "prerelease": "nightly.2016.11.29",
       "build": "commit.71cbc4a",
       "longVersion": "0.4.7-nightly.2016.11.29+commit.71cbc4a",
+      "sha256": "0x45e830cd64f68eaeeb5d0838a418efe30ebd424483d4eb3ab3a4ca737f931248",
       "keccak256": "0x3caa41a586e169ef66c4a8b6da45399aebe1226eec405469e67f999b36d26b6f",
       "urls": [
-        "bzzr://2519e98a22016dcf9f62201d7babf66ecd617223e95d5f8880b5bed9dc0c1e55"
+        "bzzr://2519e98a22016dcf9f62201d7babf66ecd617223e95d5f8880b5bed9dc0c1e55",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.29+commit.71cbc4a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.29+commit.71cbc4a.js"
       ]
     },
     {
@@ -2314,9 +2950,12 @@
       "prerelease": "nightly.2016.11.30",
       "build": "commit.e43a8ebc",
       "longVersion": "0.4.7-nightly.2016.11.30+commit.e43a8ebc",
+      "sha256": "0x5244059fd3e944258e33828055ef67ba97e1e2eb1c9cfa295709a18c27883404",
       "keccak256": "0x020db6709338faa3527e710ac899e328b17ffea1f35e5b9fc7930deaa3751f9f",
       "urls": [
-        "bzzr://e447d748326919bf72ac77696963769e92cd4b8d4a7effc7d0ec338346c8977f"
+        "bzzr://e447d748326919bf72ac77696963769e92cd4b8d4a7effc7d0ec338346c8977f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.11.30+commit.e43a8ebc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.11.30+commit.e43a8ebc.js"
       ]
     },
     {
@@ -2325,9 +2964,12 @@
       "prerelease": "nightly.2016.12.1",
       "build": "commit.67f274f6",
       "longVersion": "0.4.7-nightly.2016.12.1+commit.67f274f6",
+      "sha256": "0xfd511d46320441475af35fdfb8c32d420f1222504e550f0c888ae184a59393ee",
       "keccak256": "0x6b484be56879e19b51e2fc18b9cfa2552440bc8704a909f3cc85b7b362a628c5",
       "urls": [
-        "bzzr://3a1cd047780951298f51b546bd6881af84c63078e919dfa955f1e33b56e19b93"
+        "bzzr://3a1cd047780951298f51b546bd6881af84c63078e919dfa955f1e33b56e19b93",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.1+commit.67f274f6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.1+commit.67f274f6.js"
       ]
     },
     {
@@ -2336,9 +2978,12 @@
       "prerelease": "nightly.2016.12.2",
       "build": "commit.3a01a87a",
       "longVersion": "0.4.7-nightly.2016.12.2+commit.3a01a87a",
+      "sha256": "0x3e32d6139171bc324437d92b3bd71ffcfa6b0dd60f10ccd96420d5d2250411ff",
       "keccak256": "0x845861bd02e0417f12594920f8c3f6cade3a3185b0f39b9ace392b49b9241d6e",
       "urls": [
-        "bzzr://c75b43937f012d8b9358c3464efe6ebeaeaaf702b0f6930918db80e9b0054d55"
+        "bzzr://c75b43937f012d8b9358c3464efe6ebeaeaaf702b0f6930918db80e9b0054d55",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.2+commit.3a01a87a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.2+commit.3a01a87a.js"
       ]
     },
     {
@@ -2347,9 +2992,12 @@
       "prerelease": "nightly.2016.12.3",
       "build": "commit.9be2fb12",
       "longVersion": "0.4.7-nightly.2016.12.3+commit.9be2fb12",
+      "sha256": "0x8556387a0968967cddb9a48e3e28b26f7716fb5e29e7bf02945a3d30e2977067",
       "keccak256": "0x860d58660ad5ed99df5793bdf5cf77d803a2739687116dd91e6101926d8c310b",
       "urls": [
-        "bzzr://aba0e4b39623c0c9f7120108218662018de55aa4638a73297fb71ce806b25fab"
+        "bzzr://aba0e4b39623c0c9f7120108218662018de55aa4638a73297fb71ce806b25fab",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.3+commit.9be2fb12.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.3+commit.9be2fb12.js"
       ]
     },
     {
@@ -2358,9 +3006,12 @@
       "prerelease": "nightly.2016.12.5",
       "build": "commit.34327c5d",
       "longVersion": "0.4.7-nightly.2016.12.5+commit.34327c5d",
+      "sha256": "0x428ed385f4224bd2c4bbf1c3566aaa8afd99eb31acab814faa5f28e0a686415e",
       "keccak256": "0x1eab4ffbce75d8e9e820ee979bb24bbbc4b231ef0de3f9e9728652d2f5207733",
       "urls": [
-        "bzzr://a2baa986af8747c5cf116bd071320af4838dcd8acfc8ddc48e1c35e62da18a4c"
+        "bzzr://a2baa986af8747c5cf116bd071320af4838dcd8acfc8ddc48e1c35e62da18a4c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.5+commit.34327c5d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.5+commit.34327c5d.js"
       ]
     },
     {
@@ -2369,9 +3020,12 @@
       "prerelease": "nightly.2016.12.6",
       "build": "commit.b201e148",
       "longVersion": "0.4.7-nightly.2016.12.6+commit.b201e148",
+      "sha256": "0x8ba7542dced7b344750a30072d21d1114863e6c63ab05143c27379d38dc3d6f4",
       "keccak256": "0x2b346c8ff24b4c488d058136b20f0572e95d7ffe6ef068cd5b46b86064af57bc",
       "urls": [
-        "bzzr://c3fe972355a50c6101bf03513475bb13a4c684682e9094461e481193acb16785"
+        "bzzr://c3fe972355a50c6101bf03513475bb13a4c684682e9094461e481193acb16785",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.6+commit.b201e148.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.6+commit.b201e148.js"
       ]
     },
     {
@@ -2380,9 +3034,12 @@
       "prerelease": "nightly.2016.12.7",
       "build": "commit.fd7561ed",
       "longVersion": "0.4.7-nightly.2016.12.7+commit.fd7561ed",
+      "sha256": "0x1041aa69c07755b626126e848eb0536aa5feb9a174167c8657b101a10c4bbd62",
       "keccak256": "0x052cc7035608fc928d14000858f381b5f6b96cc9b7e417607275a493d0cb09a2",
       "urls": [
-        "bzzr://f7c037b1a9a3ee15a92800e6179c0e2ede1dca1f1adc5288fa8b29dd6f35a98f"
+        "bzzr://f7c037b1a9a3ee15a92800e6179c0e2ede1dca1f1adc5288fa8b29dd6f35a98f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.7+commit.fd7561ed.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.7+commit.fd7561ed.js"
       ]
     },
     {
@@ -2391,9 +3048,12 @@
       "prerelease": "nightly.2016.12.8",
       "build": "commit.89771a44",
       "longVersion": "0.4.7-nightly.2016.12.8+commit.89771a44",
+      "sha256": "0x77a84196214b888685b7880f3762cb59ae2dcc228fa88afad1dd9a7b7fb9579f",
       "keccak256": "0xb02ed90711e25413f1719f0cab667503fa9cc4e06872e4e7504d7f631da98236",
       "urls": [
-        "bzzr://38071b5fe24efeadb0b85ae771732702fcce696eb73f2ada8a08f6db431b73f1"
+        "bzzr://38071b5fe24efeadb0b85ae771732702fcce696eb73f2ada8a08f6db431b73f1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.8+commit.89771a44.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.8+commit.89771a44.js"
       ]
     },
     {
@@ -2402,9 +3062,12 @@
       "prerelease": "nightly.2016.12.11",
       "build": "commit.84d4f3da",
       "longVersion": "0.4.7-nightly.2016.12.11+commit.84d4f3da",
+      "sha256": "0xa2fb38a16b708dabb4bca90ac2c877b4f9676149d407ccde3f4acbaec137a8b8",
       "keccak256": "0x43c92a71444f505375f18c015e5e910c288be15fd6bbb56ccda50767c43bedbb",
       "urls": [
-        "bzzr://ad8781b35f01723b7e86f298b74d3ad5d3951a94a0484c79894130a461a1431f"
+        "bzzr://ad8781b35f01723b7e86f298b74d3ad5d3951a94a0484c79894130a461a1431f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.11+commit.84d4f3da.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.11+commit.84d4f3da.js"
       ]
     },
     {
@@ -2413,9 +3076,12 @@
       "prerelease": "nightly.2016.12.12",
       "build": "commit.e53fdb49",
       "longVersion": "0.4.7-nightly.2016.12.12+commit.e53fdb49",
+      "sha256": "0x2555175367408d3fa1a0ef7e59394d28554f66f9503dbfa19c786c383523ac06",
       "keccak256": "0x245c638164782e0ae7fabfb79ab2a8d150716db65ec22802ca9c5431ac3584f9",
       "urls": [
-        "bzzr://8d10463500d4490d9753c141518f4421ee20d7393933ed024babbf848d4b1a3c"
+        "bzzr://8d10463500d4490d9753c141518f4421ee20d7393933ed024babbf848d4b1a3c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.12+commit.e53fdb49.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.12+commit.e53fdb49.js"
       ]
     },
     {
@@ -2424,9 +3090,12 @@
       "prerelease": "nightly.2016.12.13",
       "build": "commit.9d607345",
       "longVersion": "0.4.7-nightly.2016.12.13+commit.9d607345",
+      "sha256": "0x373aeb21ecb1539cf1819b9f02214d41ee865e6d8c0654244ea8388bc27a8fbe",
       "keccak256": "0xdd349480278c9499627fcfd965877a807b991ddda7c34ab953d598939e0f39d5",
       "urls": [
-        "bzzr://2f9886a8dbc3fa5a6a5028e337cca5ab20054c1e4f0b30688e7be661a0bf4e05"
+        "bzzr://2f9886a8dbc3fa5a6a5028e337cca5ab20054c1e4f0b30688e7be661a0bf4e05",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.13+commit.9d607345.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.13+commit.9d607345.js"
       ]
     },
     {
@@ -2435,9 +3104,12 @@
       "prerelease": "nightly.2016.12.14",
       "build": "commit.e53d1255",
       "longVersion": "0.4.7-nightly.2016.12.14+commit.e53d1255",
+      "sha256": "0x66b645f398eee2b7787a7cdbb4791c8e02b35b1f725e84cc4747d28b35cecf3a",
       "keccak256": "0x08445822306cc488ebfa2db7903e4a0ca9806cca1c100bbd742903fd71bb7a49",
       "urls": [
-        "bzzr://cce0fb3275ffffe8d8cdc0a28b4fbbe13d09079c5e606b06eb009fe212a33d91"
+        "bzzr://cce0fb3275ffffe8d8cdc0a28b4fbbe13d09079c5e606b06eb009fe212a33d91",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.14+commit.e53d1255.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.14+commit.e53d1255.js"
       ]
     },
     {
@@ -2446,9 +3118,12 @@
       "prerelease": "nightly.2016.12.15",
       "build": "commit.688841ae",
       "longVersion": "0.4.7-nightly.2016.12.15+commit.688841ae",
+      "sha256": "0x3813adedcf8e19452e492429131371e3d092a4aca1982e70d93728ed650e6668",
       "keccak256": "0x015ace6c9dc677df55e4971763d9f41fc2d82c9bc04db555603241248994062a",
       "urls": [
-        "bzzr://109cd399615be3853d54a0f67a540eab75683ac76b7ceeea9eeee69bcb935b4c"
+        "bzzr://109cd399615be3853d54a0f67a540eab75683ac76b7ceeea9eeee69bcb935b4c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7-nightly.2016.12.15+commit.688841ae.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7-nightly.2016.12.15+commit.688841ae.js"
       ]
     },
     {
@@ -2456,9 +3131,12 @@
       "version": "0.4.7",
       "build": "commit.822622cf",
       "longVersion": "0.4.7+commit.822622cf",
+      "sha256": "0x7272fe089382706a4c18addf63eb875bfb0767d9195d2538ac86b55f7b9a46aa",
       "keccak256": "0x30094baecaf6c36245ac8d56b2972915c1054827fe5b0dc6d1245e9d2e19e357",
       "urls": [
-        "bzzr://de00cf8d235867a00d831e0055b376420789977d276c02e6ff0d1d5b00f5d84d"
+        "bzzr://de00cf8d235867a00d831e0055b376420789977d276c02e6ff0d1d5b00f5d84d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.7+commit.822622cf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.7+commit.822622cf.js"
       ]
     },
     {
@@ -2467,9 +3145,12 @@
       "prerelease": "nightly.2016.12.16",
       "build": "commit.af8bc1c9",
       "longVersion": "0.4.8-nightly.2016.12.16+commit.af8bc1c9",
+      "sha256": "0xbb29565391111fd6d513d0383254bbf9e76cb96242857fd8e41a21719749066d",
       "keccak256": "0x2cbde868d678337df44ac9ca3f3e0bbcc625b5636fbc449c485be6bac1824027",
       "urls": [
-        "bzzr://29af69fee84074a55cf229dfc5969f0c86ae78f4c2a3d0fd3c5ebb82f8aa77fc"
+        "bzzr://29af69fee84074a55cf229dfc5969f0c86ae78f4c2a3d0fd3c5ebb82f8aa77fc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2016.12.16+commit.af8bc1c9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2016.12.16+commit.af8bc1c9.js"
       ]
     },
     {
@@ -2478,9 +3159,12 @@
       "prerelease": "nightly.2017.1.2",
       "build": "commit.75a596ab",
       "longVersion": "0.4.8-nightly.2017.1.2+commit.75a596ab",
+      "sha256": "0x04fc66c2c39ff853b2526cfb83ed2df13ef9f5de1b3cc54fd040358e1841600e",
       "keccak256": "0xd9905b86536de99eb85d75e750f3087b1ab1c5e431caa8539e7956344b538a28",
       "urls": [
-        "bzzr://02a40667b66b38528ea30897637b054b037a3d26ec173ff1c526c05315279a16"
+        "bzzr://02a40667b66b38528ea30897637b054b037a3d26ec173ff1c526c05315279a16",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.2+commit.75a596ab.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.2+commit.75a596ab.js"
       ]
     },
     {
@@ -2489,9 +3173,12 @@
       "prerelease": "nightly.2017.1.3",
       "build": "commit.43a5d11f",
       "longVersion": "0.4.8-nightly.2017.1.3+commit.43a5d11f",
+      "sha256": "0xcbf6ee3823581ac758a63f08f1a3a16c46655669a0c762d7e88e9324762e952f",
       "keccak256": "0x62b3eadee7745d6a744deda7991f4530b095bf7acfdbf0c1fdfda1b29a74cdd3",
       "urls": [
-        "bzzr://efc91e567f86f36d610d5babe0a4a76cf31782dca56b4ec78b837173973c19f5"
+        "bzzr://efc91e567f86f36d610d5babe0a4a76cf31782dca56b4ec78b837173973c19f5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.3+commit.43a5d11f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.3+commit.43a5d11f.js"
       ]
     },
     {
@@ -2500,9 +3187,12 @@
       "prerelease": "nightly.2017.1.5",
       "build": "commit.31e6a5",
       "longVersion": "0.4.8-nightly.2017.1.5+commit.31e6a5",
+      "sha256": "0xad48058e6545936ccba17c454fca326a8ea3525af7bcd98c0476e982ac8c2959",
       "keccak256": "0x81ce6e85324e03362cd89399dec1bd62858d933d62bd9646384e2ba42918ab56",
       "urls": [
-        "bzzr://847dcd34c6c33b60890f427ce7efe34f3b5fdcd4e3c0efdc810ee870e4eb389d"
+        "bzzr://847dcd34c6c33b60890f427ce7efe34f3b5fdcd4e3c0efdc810ee870e4eb389d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.5+commit.31e6a5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.5+commit.31e6a5.js"
       ]
     },
     {
@@ -2511,9 +3201,12 @@
       "prerelease": "nightly.2017.1.6",
       "build": "commit.a4d7a590",
       "longVersion": "0.4.8-nightly.2017.1.6+commit.a4d7a590",
+      "sha256": "0xe3d62ca3e2bea45c3a4683e2dd846a0bcbdbf25d28b9386bf9c255b970fef19f",
       "keccak256": "0x66f15ceb6c4eccf0422b3a6b76bdee1bc499c01df61f2d1938f326d283688a50",
       "urls": [
-        "bzzr://bdf0e335cd28ad0ba20994a8adf9a2d4a1fec02910ab9655d98246ea4fe6c511"
+        "bzzr://bdf0e335cd28ad0ba20994a8adf9a2d4a1fec02910ab9655d98246ea4fe6c511",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.6+commit.a4d7a590.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.6+commit.a4d7a590.js"
       ]
     },
     {
@@ -2522,9 +3215,12 @@
       "prerelease": "nightly.2017.1.9",
       "build": "commit.354a10be",
       "longVersion": "0.4.8-nightly.2017.1.9+commit.354a10be",
+      "sha256": "0x769e1a4c30613350be5a498465a9fc57d5b3c6ebafe814efc84cab2c0cf2691d",
       "keccak256": "0xb719a031166d6ef81caf1c7889959c39f291791bc8a2dca2f903479478c4579b",
       "urls": [
-        "bzzr://45f178ae7aa8ea036a4d5a4fed818add4bb38eca8587aff919ae40139967a6f5"
+        "bzzr://45f178ae7aa8ea036a4d5a4fed818add4bb38eca8587aff919ae40139967a6f5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.9+commit.354a10be.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.9+commit.354a10be.js"
       ]
     },
     {
@@ -2533,9 +3229,12 @@
       "prerelease": "nightly.2017.1.10",
       "build": "commit.26a90af4",
       "longVersion": "0.4.8-nightly.2017.1.10+commit.26a90af4",
+      "sha256": "0x277257e8b37232adc98c3519a048b78a93e2a348804000ad5b1a0d3f5bb10e24",
       "keccak256": "0x4198b085df22d88b2fff91c047cc6a7a7f1e1be9e8888c4a47137eeb3031eeaf",
       "urls": [
-        "bzzr://081ffdd64349f49a044a737dabd3dfbb9147a5afaedbd9cd514049f4eddf4a5f"
+        "bzzr://081ffdd64349f49a044a737dabd3dfbb9147a5afaedbd9cd514049f4eddf4a5f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.10+commit.26a90af4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.10+commit.26a90af4.js"
       ]
     },
     {
@@ -2544,9 +3243,12 @@
       "prerelease": "nightly.2017.1.11",
       "build": "commit.4f5da2ea",
       "longVersion": "0.4.8-nightly.2017.1.11+commit.4f5da2ea",
+      "sha256": "0x380f8d3a8524cb5e345dc38ab8cb5eee0d749f810c234944b1b91c1468d287c0",
       "keccak256": "0x3b0162ed6a0928a883256ef68ab869350840368f77f05737c6a789c73e3b68f7",
       "urls": [
-        "bzzr://9efece3937b3ddfdb28f01b7d446fe715a897d667495ee91e61a9da5abbc3371"
+        "bzzr://9efece3937b3ddfdb28f01b7d446fe715a897d667495ee91e61a9da5abbc3371",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.11+commit.4f5da2ea.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.11+commit.4f5da2ea.js"
       ]
     },
     {
@@ -2555,9 +3257,12 @@
       "prerelease": "nightly.2017.1.12",
       "build": "commit.b983c749",
       "longVersion": "0.4.8-nightly.2017.1.12+commit.b983c749",
+      "sha256": "0xa837095ca346cea821b9b56b9a0418b53de446638d093cb83cce71ef5c336eed",
       "keccak256": "0xa64bf5156c06ba26c0c3cbb3eb6c395b272e77a2f4cf93ad5b603c2476670489",
       "urls": [
-        "bzzr://a464cdb77d23d1d761a00a81f8a48c85424df1e8e349b9c87a0ba08ff8c11ca7"
+        "bzzr://a464cdb77d23d1d761a00a81f8a48c85424df1e8e349b9c87a0ba08ff8c11ca7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.12+commit.b983c749.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.12+commit.b983c749.js"
       ]
     },
     {
@@ -2566,9 +3271,12 @@
       "prerelease": "nightly.2017.1.13",
       "build": "commit.bde0b406",
       "longVersion": "0.4.8-nightly.2017.1.13+commit.bde0b406",
+      "sha256": "0xaf6aa971f754a5af0f5d1bca339cfe52258bf87373b7acaee3e815ddacd93633",
       "keccak256": "0x0cc481e898a63c59114481e1355469a696400c656a7512d9c359e31066da37ba",
       "urls": [
-        "bzzr://4b21f82883390e6e4a0962bc1a1ea017698650155dee557c722a1fb7395064ed"
+        "bzzr://4b21f82883390e6e4a0962bc1a1ea017698650155dee557c722a1fb7395064ed",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8-nightly.2017.1.13+commit.bde0b406.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8-nightly.2017.1.13+commit.bde0b406.js"
       ]
     },
     {
@@ -2576,9 +3284,12 @@
       "version": "0.4.8",
       "build": "commit.60cc1668",
       "longVersion": "0.4.8+commit.60cc1668",
+      "sha256": "0x34f26cddd538c7d66fcc1ddbeb53a432731b06e493a9899b87291a8d111caf83",
       "keccak256": "0x61faf6e732d89464f022a3146a1939f204472c0a243e86b08173e1ec41cb4a7f",
       "urls": [
-        "bzzr://17c083e0ec2a29ec7a5c33cbd40a773dce5448891f2eb22a75898c9da8dd03da"
+        "bzzr://17c083e0ec2a29ec7a5c33cbd40a773dce5448891f2eb22a75898c9da8dd03da",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.8+commit.60cc1668.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.8+commit.60cc1668.js"
       ]
     },
     {
@@ -2587,9 +3298,12 @@
       "prerelease": "nightly.2017.1.13",
       "build": "commit.392ef5f4",
       "longVersion": "0.4.9-nightly.2017.1.13+commit.392ef5f4",
+      "sha256": "0x13cddc83ddc367b0546b7ade72f759ccb9ae6e9ec8cffc73c604f0757c667535",
       "keccak256": "0x52468bb04ac59b76008fc478e7a0140548ae8db4e3202537b9b65bcc851acb14",
       "urls": [
-        "bzzr://03fe83a75078ef227b25868f123c448a9944d7a937836b422717c15c868c052b"
+        "bzzr://03fe83a75078ef227b25868f123c448a9944d7a937836b422717c15c868c052b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.13+commit.392ef5f4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.13+commit.392ef5f4.js"
       ]
     },
     {
@@ -2598,9 +3312,12 @@
       "prerelease": "nightly.2017.1.16",
       "build": "commit.79e5772b",
       "longVersion": "0.4.9-nightly.2017.1.16+commit.79e5772b",
+      "sha256": "0xa881c1aba1880cf37bde4f5267b83af43f6370d575a0883078361d3f8d8b989f",
       "keccak256": "0x44894c0017201f7f98caf4b18282a7b56dc8373ba4ba184c9126ea3aedbddeba",
       "urls": [
-        "bzzr://efa52f61a58b7800d3ae9b765866693a4b1b9a4ed9ac6df786d6b99804a8f27c"
+        "bzzr://efa52f61a58b7800d3ae9b765866693a4b1b9a4ed9ac6df786d6b99804a8f27c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.16+commit.79e5772b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.16+commit.79e5772b.js"
       ]
     },
     {
@@ -2609,9 +3326,12 @@
       "prerelease": "nightly.2017.1.17",
       "build": "commit.6ecb4aa3",
       "longVersion": "0.4.9-nightly.2017.1.17+commit.6ecb4aa3",
+      "sha256": "0x24e7328dd43d5457811f5a9dd965dd102f65065a3833f53327ab44af2c9cd3ae",
       "keccak256": "0x8b836be8975cce726a3c03eb586c3bb30e5e76a81bb95659c595c07a1a5def1c",
       "urls": [
-        "bzzr://342c69978f0946acde07e57be98f0739dcd6847f0a741ff460e948479bacafc5"
+        "bzzr://342c69978f0946acde07e57be98f0739dcd6847f0a741ff460e948479bacafc5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.17+commit.6ecb4aa3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.17+commit.6ecb4aa3.js"
       ]
     },
     {
@@ -2620,9 +3340,12 @@
       "prerelease": "nightly.2017.1.18",
       "build": "commit.5e1908",
       "longVersion": "0.4.9-nightly.2017.1.18+commit.5e1908",
+      "sha256": "0xb785452d98544bdc381f7f6cc161bf81eeda0d580feb563f5dd8093b163da64b",
       "keccak256": "0x3698650dd8a7cfe95f067f5049c888d6cf926562e04afc84aeaa5faba94749a6",
       "urls": [
-        "bzzr://bb95908da92495bef375b30ceb75e5cdf99150af8f7eb32042cecf85127e6d15"
+        "bzzr://bb95908da92495bef375b30ceb75e5cdf99150af8f7eb32042cecf85127e6d15",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.18+commit.5e1908.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.18+commit.5e1908.js"
       ]
     },
     {
@@ -2631,9 +3354,12 @@
       "prerelease": "nightly.2017.1.19",
       "build": "commit.9403dd5",
       "longVersion": "0.4.9-nightly.2017.1.19+commit.9403dd5",
+      "sha256": "0xc16276e518c285260db48d06020ecc2e55ea61010c7de93f9cab156941148efa",
       "keccak256": "0xf97854056bcdf43fbd5a34ff74f0c85390036607a9bd6ac4d5e7a7007a0839fa",
       "urls": [
-        "bzzr://537cbdfd5076fd23966ab1f6eb0eaa9a3d128ea486f0836b8e95e2d88c0c24f7"
+        "bzzr://537cbdfd5076fd23966ab1f6eb0eaa9a3d128ea486f0836b8e95e2d88c0c24f7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.19+commit.9403dd5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.19+commit.9403dd5.js"
       ]
     },
     {
@@ -2642,9 +3368,12 @@
       "prerelease": "nightly.2017.1.20",
       "build": "commit.12b002b3",
       "longVersion": "0.4.9-nightly.2017.1.20+commit.12b002b3",
+      "sha256": "0x3e0972fdc92dd19f482ec831a5d6f969652ff3789f984233d56e525e72d43267",
       "keccak256": "0x83199e85c4703e7e102058682d7f9af6d8312424bd0bc2f46eb7d24a22909816",
       "urls": [
-        "bzzr://ed9eb0cba1f7eaedd48793f53e22291f30d51347c4646764ea03852b7e794427"
+        "bzzr://ed9eb0cba1f7eaedd48793f53e22291f30d51347c4646764ea03852b7e794427",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.20+commit.12b002b3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.20+commit.12b002b3.js"
       ]
     },
     {
@@ -2653,9 +3382,12 @@
       "prerelease": "nightly.2017.1.23",
       "build": "commit.6946902c",
       "longVersion": "0.4.9-nightly.2017.1.23+commit.6946902c",
+      "sha256": "0x5ad4d03c7aa91c12e999acf0c03dcf6b4a70adc6a92deeff3315c73e9bc1ecfc",
       "keccak256": "0x17a810b10a472e673f89a7841756d383e84eaad27ed316ee16ea3c70a28b4b5f",
       "urls": [
-        "bzzr://805930376561ce5bd34e05107acb6f2c4f07afb438582905762d48f77dfdb0bc"
+        "bzzr://805930376561ce5bd34e05107acb6f2c4f07afb438582905762d48f77dfdb0bc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.23+commit.6946902c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.23+commit.6946902c.js"
       ]
     },
     {
@@ -2664,9 +3396,12 @@
       "prerelease": "nightly.2017.1.24",
       "build": "commit.b52a6040",
       "longVersion": "0.4.9-nightly.2017.1.24+commit.b52a6040",
+      "sha256": "0x8d62bb2fb6785d9748e8cd60e0d4a8cd1af99592ce229d9a81d81d99c5341908",
       "keccak256": "0xafd842946dd0b5a0fc61f1681ac00ea946cefc7be242599f0de2c98e0764b3d0",
       "urls": [
-        "bzzr://1a24446260d61ba55b7290f05eeee8d570209c5ae8fc45edeab24d7cb1a621a1"
+        "bzzr://1a24446260d61ba55b7290f05eeee8d570209c5ae8fc45edeab24d7cb1a621a1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.24+commit.b52a6040.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.24+commit.b52a6040.js"
       ]
     },
     {
@@ -2675,9 +3410,12 @@
       "prerelease": "nightly.2017.1.26",
       "build": "commit.2122d2d7",
       "longVersion": "0.4.9-nightly.2017.1.26+commit.2122d2d7",
+      "sha256": "0x2314eab7430cd02346fcc01947eca55c98582fc0098401bee4a1f04ab41c507b",
       "keccak256": "0x0e9060a7909c31629512ef7e70c8cf71371213c47d4615aae4737f92666a63b1",
       "urls": [
-        "bzzr://1644992b48aa15e199a248db342aedece0d05373f549a087849c57c730bf2ec7"
+        "bzzr://1644992b48aa15e199a248db342aedece0d05373f549a087849c57c730bf2ec7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.26+commit.2122d2d7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.26+commit.2122d2d7.js"
       ]
     },
     {
@@ -2686,9 +3424,12 @@
       "prerelease": "nightly.2017.1.27",
       "build": "commit.1774e087",
       "longVersion": "0.4.9-nightly.2017.1.27+commit.1774e087",
+      "sha256": "0xf6393d4597de59e87fcf3776f1eba3520c0afdc22b41f97581ac08cd9e512406",
       "keccak256": "0xb633fa3cad671a7418ee2678edb82bf4740fc0a1d8df4aa48680c4b356a195d4",
       "urls": [
-        "bzzr://d34012b13f76332152c77e30dedfbd8c4be070278f46b0ce2b1efbf5df4a2a59"
+        "bzzr://d34012b13f76332152c77e30dedfbd8c4be070278f46b0ce2b1efbf5df4a2a59",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.27+commit.1774e087.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.27+commit.1774e087.js"
       ]
     },
     {
@@ -2697,9 +3438,12 @@
       "prerelease": "nightly.2017.1.30",
       "build": "commit.edd3696d",
       "longVersion": "0.4.9-nightly.2017.1.30+commit.edd3696d",
+      "sha256": "0x9ff884ebb4ad9af8a58dc7a05d933748fe5599a80cf61fb128d39066a811c171",
       "keccak256": "0x8b649f10fcb5fee1437847d6c9836a11cc0a878786e15a6be5e5e7fe24a58564",
       "urls": [
-        "bzzr://aa46bd87aa0be9b5756353312f8041d4525e70df56b9a57c937537dd2a067e43"
+        "bzzr://aa46bd87aa0be9b5756353312f8041d4525e70df56b9a57c937537dd2a067e43",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.30+commit.edd3696d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.30+commit.edd3696d.js"
       ]
     },
     {
@@ -2708,9 +3452,12 @@
       "prerelease": "nightly.2017.1.31",
       "build": "commit.f9af2de0",
       "longVersion": "0.4.9-nightly.2017.1.31+commit.f9af2de0",
+      "sha256": "0xe8e297e2bc7e5cd6f9437db96483ed27812b79e915a1fe408a9746fa390ad428",
       "keccak256": "0x6367e9e2e577cc3f285bad3dee463b43f4e87b986a6dd25ad4e846e0579e0f38",
       "urls": [
-        "bzzr://953745901e7ed81fbde119ed4d841e1fed88d504bc272ed78cc90a02960b413c"
+        "bzzr://953745901e7ed81fbde119ed4d841e1fed88d504bc272ed78cc90a02960b413c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9-nightly.2017.1.31+commit.f9af2de0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9-nightly.2017.1.31+commit.f9af2de0.js"
       ]
     },
     {
@@ -2718,9 +3465,12 @@
       "version": "0.4.9",
       "build": "commit.364da425",
       "longVersion": "0.4.9+commit.364da425",
+      "sha256": "0x7e93fcc7202d25ef37409541e799c5785efaafc1046cb2b4764e4a706d5dcbd7",
       "keccak256": "0x2b3e45f09075c576d599cadb2e749105b425bb2c8ab30b48170f0e23adcab1aa",
       "urls": [
-        "bzzr://677fdc9a1709aa44b50bcdfc9610f2694ac92e4822e659db458afc1e77eb533e"
+        "bzzr://677fdc9a1709aa44b50bcdfc9610f2694ac92e4822e659db458afc1e77eb533e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.9+commit.364da425.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.9+commit.364da425.js"
       ]
     },
     {
@@ -2729,9 +3479,12 @@
       "prerelease": "nightly.2017.1.31",
       "build": "commit.747db75a",
       "longVersion": "0.4.10-nightly.2017.1.31+commit.747db75a",
+      "sha256": "0x8ed400106456ef02329e59392e7a7044be05bc58928dc8d37f45b381d7e1db75",
       "keccak256": "0x27853c1125649aece6a481276ae68a9dd9f0b58a6362559b29ebab8c9e13a3db",
       "urls": [
-        "bzzr://da68bcc3ea48579543c3cf86d94ef3e6819c710f4fa6b451154fae7cd89c2bd8"
+        "bzzr://da68bcc3ea48579543c3cf86d94ef3e6819c710f4fa6b451154fae7cd89c2bd8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.1.31+commit.747db75a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.1.31+commit.747db75a.js"
       ]
     },
     {
@@ -2740,9 +3493,12 @@
       "prerelease": "nightly.2017.2.1",
       "build": "commit.c1a675da",
       "longVersion": "0.4.10-nightly.2017.2.1+commit.c1a675da",
+      "sha256": "0x24d9e13cd8255d17d31091029ffe06193e3c4d9352f4ff7796ec16e7625f052c",
       "keccak256": "0xadb0ec8752b92aefff5738271e65c8dfa786bab2865cba7b063fffea86a95a38",
       "urls": [
-        "bzzr://562a94f287bd624d034332b5a73e16a60cbf6e1b57a949e98311b912f43f05ef"
+        "bzzr://562a94f287bd624d034332b5a73e16a60cbf6e1b57a949e98311b912f43f05ef",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.1+commit.c1a675da.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.1+commit.c1a675da.js"
       ]
     },
     {
@@ -2751,9 +3507,12 @@
       "prerelease": "nightly.2017.2.2",
       "build": "commit.8f9839c6",
       "longVersion": "0.4.10-nightly.2017.2.2+commit.8f9839c6",
+      "sha256": "0x8908b9191faff7e0ae5960594957d487f3b94de3835541c50cac0a260bf54049",
       "keccak256": "0xf4da1ed28bb20e825c0dec7c218cfd2eff1afda8236b2ce210f7ab2ca0090a7e",
       "urls": [
-        "bzzr://e070ee8cf21e72bf52a319da2301d2283a7b744c620a3bbd42267d317f879794"
+        "bzzr://e070ee8cf21e72bf52a319da2301d2283a7b744c620a3bbd42267d317f879794",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.2+commit.8f9839c6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.2+commit.8f9839c6.js"
       ]
     },
     {
@@ -2762,9 +3521,12 @@
       "prerelease": "nightly.2017.2.3",
       "build": "commit.5ce79609",
       "longVersion": "0.4.10-nightly.2017.2.3+commit.5ce79609",
+      "sha256": "0x2450e0d72f7dff47bfd971d7abc67a6bc744d2a2a7cd7ec6864395c9dc520652",
       "keccak256": "0x57d402a63f93b96e9ad82018f2b738338e6c0214d85d543fa4bc896fc584f614",
       "urls": [
-        "bzzr://da5ad071ac2f605b5d0340f70e741a167416eb47f7aee0cdb56fa8768b5b329f"
+        "bzzr://da5ad071ac2f605b5d0340f70e741a167416eb47f7aee0cdb56fa8768b5b329f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.3+commit.5ce79609.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.3+commit.5ce79609.js"
       ]
     },
     {
@@ -2773,9 +3535,12 @@
       "prerelease": "nightly.2017.2.13",
       "build": "commit.8357bdad",
       "longVersion": "0.4.10-nightly.2017.2.13+commit.8357bdad",
+      "sha256": "0x46aaff2a2a5c801be4215469533b6336f3c37303a30c98e717dddfb0df45fc60",
       "keccak256": "0xc3be8bee3c65b911bb16c7d06770cc0ba01fc282250cedfcb5b1035f09c391bc",
       "urls": [
-        "bzzr://c2fffa2f7719b9fd0b695a38acab9696a9df6d372f16dcda17119e04466786d6"
+        "bzzr://c2fffa2f7719b9fd0b695a38acab9696a9df6d372f16dcda17119e04466786d6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.13+commit.8357bdad.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.13+commit.8357bdad.js"
       ]
     },
     {
@@ -2784,9 +3549,12 @@
       "prerelease": "nightly.2017.2.14",
       "build": "commit.91d5515c",
       "longVersion": "0.4.10-nightly.2017.2.14+commit.91d5515c",
+      "sha256": "0xd6542157ec1212bca3625cf934d7002b307bfc3d590ff5bac08d0a37cef533d1",
       "keccak256": "0x89bbdd5b749926cdffa9d71864ed9a22d0f935ffe6abb74f6fec4aa0bf983537",
       "urls": [
-        "bzzr://2915e09f3d4e50c573b6232f1526748d15e6f09cad02d3547e912554d58d7dda"
+        "bzzr://2915e09f3d4e50c573b6232f1526748d15e6f09cad02d3547e912554d58d7dda",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.14+commit.91d5515c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.14+commit.91d5515c.js"
       ]
     },
     {
@@ -2795,9 +3563,12 @@
       "prerelease": "nightly.2017.2.15",
       "build": "commit.ad751bd3",
       "longVersion": "0.4.10-nightly.2017.2.15+commit.ad751bd3",
+      "sha256": "0x9141904a13991db84359f9fd723e18a6dfc5632a0d255f8599276891e2d87ee6",
       "keccak256": "0xc7978b3242a2b8eec4c6f28538ead7c0cfd23d0c139cd30967972b2bf02f7205",
       "urls": [
-        "bzzr://f8b31a2adfcf5e39f8b54280af4589bae700139e4fc4f6fb73afe19035841b1f"
+        "bzzr://f8b31a2adfcf5e39f8b54280af4589bae700139e4fc4f6fb73afe19035841b1f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.15+commit.ad751bd3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.15+commit.ad751bd3.js"
       ]
     },
     {
@@ -2806,9 +3577,12 @@
       "prerelease": "nightly.2017.2.16",
       "build": "commit.ad8e534",
       "longVersion": "0.4.10-nightly.2017.2.16+commit.ad8e534",
+      "sha256": "0xf23dc686b354f2c8a787bd7a9685505b34f085a4f16d064340fdc77781ffd5ef",
       "keccak256": "0x0ff6a045ec8e6529f92471086775247c7c84bf910f7b77b7c313a7b5a6e461a1",
       "urls": [
-        "bzzr://c9afd22adfbd6c1e9a78583c823da532e3545a51326a71a4f8b4240d28fe6c85"
+        "bzzr://c9afd22adfbd6c1e9a78583c823da532e3545a51326a71a4f8b4240d28fe6c85",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.16+commit.ad8e534.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.16+commit.ad8e534.js"
       ]
     },
     {
@@ -2817,9 +3591,12 @@
       "prerelease": "nightly.2017.2.17",
       "build": "commit.419ab926",
       "longVersion": "0.4.10-nightly.2017.2.17+commit.419ab926",
+      "sha256": "0x320ddfbeba32e1d5c9f07285643d0e3bb0578b355c8d458f0ed5fa06e64a250b",
       "keccak256": "0xdf270603a00242ad205538924b0964f28cfc62b119103a3eb24638e9574a8258",
       "urls": [
-        "bzzr://462defe8f5eab87d42c318a489f226feeb258092bd0399e4e661103e219969ee"
+        "bzzr://462defe8f5eab87d42c318a489f226feeb258092bd0399e4e661103e219969ee",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.17+commit.419ab926.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.17+commit.419ab926.js"
       ]
     },
     {
@@ -2828,9 +3605,12 @@
       "prerelease": "nightly.2017.2.20",
       "build": "commit.32b7d174",
       "longVersion": "0.4.10-nightly.2017.2.20+commit.32b7d174",
+      "sha256": "0x2ae76c08d5b7b6a8de1020914a780abbc23b7528d335ef03cfe64670de8488db",
       "keccak256": "0xf7b827795fb265b98dd38f7e65438efb37504cc522217ab15debc7a28c5eb635",
       "urls": [
-        "bzzr://174816df4ad3e1a3903372c9a221ad3a0148895820331ecb6793b2bbecc67847"
+        "bzzr://174816df4ad3e1a3903372c9a221ad3a0148895820331ecb6793b2bbecc67847",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.20+commit.32b7d174.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.20+commit.32b7d174.js"
       ]
     },
     {
@@ -2839,9 +3619,12 @@
       "prerelease": "nightly.2017.2.22",
       "build": "commit.b67fee3",
       "longVersion": "0.4.10-nightly.2017.2.22+commit.b67fee3",
+      "sha256": "0xd980a92411bf996eb7c82549f3b27d9608fd851c2d62e243f34822ecd492f368",
       "keccak256": "0xc2f2394583ba68fc2d07c30c174c941633dfc21ff1b452230b7220f0a2090c9b",
       "urls": [
-        "bzzr://a9e93bd228ba609c3ea46ef3110bbf433113d72ef33087deb754838fe36f436a"
+        "bzzr://a9e93bd228ba609c3ea46ef3110bbf433113d72ef33087deb754838fe36f436a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.22+commit.b67fee3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.22+commit.b67fee3.js"
       ]
     },
     {
@@ -2850,9 +3633,12 @@
       "prerelease": "nightly.2017.2.24",
       "build": "commit.6bbba106",
       "longVersion": "0.4.10-nightly.2017.2.24+commit.6bbba106",
+      "sha256": "0x590ac0a91f4b72d7519c29d824c6a9f41a7b8f1c380bc1b9743a915f2accd9b7",
       "keccak256": "0x9b83e905b4e8f95735bf01fbb576e8b76ae7444eea41267dbe199b20a93daf28",
       "urls": [
-        "bzzr://c8f1ff36edd68cb73f3d58194808362b8a49b2db845f961cd76e6e884d0f79e8"
+        "bzzr://c8f1ff36edd68cb73f3d58194808362b8a49b2db845f961cd76e6e884d0f79e8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.2.24+commit.6bbba106.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.2.24+commit.6bbba106.js"
       ]
     },
     {
@@ -2861,9 +3647,12 @@
       "prerelease": "nightly.2017.3.1",
       "build": "commit.6ac2c15c",
       "longVersion": "0.4.10-nightly.2017.3.1+commit.6ac2c15c",
+      "sha256": "0xd53475b9c80f9d1e56c2330f508b377bc36535ea62729c7dbf55511140aef18b",
       "keccak256": "0x7da7be0cf1dd02c98cf439584289908b2f46caa2491f0ba15644873b14bcfd88",
       "urls": [
-        "bzzr://261ee95541fe9d51f4e45856be9808a3dc5695085579aa062b9d478b34256827"
+        "bzzr://261ee95541fe9d51f4e45856be9808a3dc5695085579aa062b9d478b34256827",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.1+commit.6ac2c15c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.1+commit.6ac2c15c.js"
       ]
     },
     {
@@ -2872,9 +3661,12 @@
       "prerelease": "nightly.2017.3.2",
       "build": "commit.5c411b47",
       "longVersion": "0.4.10-nightly.2017.3.2+commit.5c411b47",
+      "sha256": "0xf6b596be83eb2c2a4aa91a7526c61a0f26260331b1d6050841e5393100334a53",
       "keccak256": "0x9282f19bb985c615761706f02a46724515e4794ee24e5e8a7b61603fdd9490f6",
       "urls": [
-        "bzzr://a3e8c74973868470d25419007fffc454a5b7ea43b1e6a83de54540db56a6c695"
+        "bzzr://a3e8c74973868470d25419007fffc454a5b7ea43b1e6a83de54540db56a6c695",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.2+commit.5c411b47.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.2+commit.5c411b47.js"
       ]
     },
     {
@@ -2883,9 +3675,12 @@
       "prerelease": "nightly.2017.3.3",
       "build": "commit.6bfd894f",
       "longVersion": "0.4.10-nightly.2017.3.3+commit.6bfd894f",
+      "sha256": "0x19feced2553f2e5190030d6e93af47c7f5636340a2f688b3d9ef5b6d43c5fa77",
       "keccak256": "0x8ddd0f9a359816695d5450fb71305e8e8d09f2cb467e6ccb7a9363804cac2409",
       "urls": [
-        "bzzr://2bd4cefbdbbd57f9ae25534c657aad9f50fdffc13f2ade77dd37da135e4b8181"
+        "bzzr://2bd4cefbdbbd57f9ae25534c657aad9f50fdffc13f2ade77dd37da135e4b8181",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.3+commit.6bfd894f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.3+commit.6bfd894f.js"
       ]
     },
     {
@@ -2894,9 +3689,12 @@
       "prerelease": "nightly.2017.3.6",
       "build": "commit.2dac39b9",
       "longVersion": "0.4.10-nightly.2017.3.6+commit.2dac39b9",
+      "sha256": "0xe6c9cdb2a8f43bb2ed5eeefa101f661d6a3fc762952889cf095ef4288c0ab6c0",
       "keccak256": "0x053ba18197a15de856cf34002c58571614cc37f66201966c492277b70ffc9de4",
       "urls": [
-        "bzzr://31e9341bf7dcaaade502e746018c575ca68304bf0fd1c0824c79b6a7b8284cd8"
+        "bzzr://31e9341bf7dcaaade502e746018c575ca68304bf0fd1c0824c79b6a7b8284cd8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.6+commit.2dac39b9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.6+commit.2dac39b9.js"
       ]
     },
     {
@@ -2905,9 +3703,12 @@
       "prerelease": "nightly.2017.3.8",
       "build": "commit.a1e350a4",
       "longVersion": "0.4.10-nightly.2017.3.8+commit.a1e350a4",
+      "sha256": "0x77a62d29b4c62ec7b4b0af5b190b31f9637ddddd390893dec6f81596e4f982b2",
       "keccak256": "0xb3f071286c58e6e9ba99bbade626d7fda039ae7e6c0458d776f7f30b8690e2d3",
       "urls": [
-        "bzzr://a83f1eac4e01fa2cbdcaa42337aa2a6d47fb962bcd792ab96796c737835a969c"
+        "bzzr://a83f1eac4e01fa2cbdcaa42337aa2a6d47fb962bcd792ab96796c737835a969c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.8+commit.a1e350a4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.8+commit.a1e350a4.js"
       ]
     },
     {
@@ -2916,9 +3717,12 @@
       "prerelease": "nightly.2017.3.9",
       "build": "commit.b22369d5",
       "longVersion": "0.4.10-nightly.2017.3.9+commit.b22369d5",
+      "sha256": "0x5b2540adbfecd3795d1cf723b7add9930df53da6a6ca029a81e72649d85bc4e7",
       "keccak256": "0x6c668e2bebe80f8825767ac23a4acb9cfaa1b211d5e910e6368807d3f20fcf0d",
       "urls": [
-        "bzzr://a1c17c36828a44036164bfd4922626efe0da64aac8a3f0954fa21d9fa315bc4a"
+        "bzzr://a1c17c36828a44036164bfd4922626efe0da64aac8a3f0954fa21d9fa315bc4a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.9+commit.b22369d5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.9+commit.b22369d5.js"
       ]
     },
     {
@@ -2927,9 +3731,12 @@
       "prerelease": "nightly.2017.3.10",
       "build": "commit.f1dd79c7",
       "longVersion": "0.4.10-nightly.2017.3.10+commit.f1dd79c7",
+      "sha256": "0x5260652e4fad8521fb5e9e6f84262f5882c04b724f52a349ac1165ccc7b58e97",
       "keccak256": "0xd7f7f5fde6ac70f654050c85e4ceb8f20d36224d6c00180c7a1f6ba7387175b4",
       "urls": [
-        "bzzr://3ed5ec31709ab23a4aed5450b1ddfe79edd90ddc0929760d596504c64e23274e"
+        "bzzr://3ed5ec31709ab23a4aed5450b1ddfe79edd90ddc0929760d596504c64e23274e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.10+commit.f1dd79c7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.10+commit.f1dd79c7.js"
       ]
     },
     {
@@ -2938,9 +3745,12 @@
       "prerelease": "nightly.2017.3.13",
       "build": "commit.9aab3b86",
       "longVersion": "0.4.10-nightly.2017.3.13+commit.9aab3b86",
+      "sha256": "0x0c6c542b922139b8b3947268209df507f693d80fa924913e624bee4acebb8c25",
       "keccak256": "0x5b08e32949085a8bd3e84832b688663250f2a66e6c30ee4ebcda4ea63deb7da2",
       "urls": [
-        "bzzr://1bc4dd1d361a7515b3ab254f90a66cadffc94128fe356020c48f5d9426a98dbc"
+        "bzzr://1bc4dd1d361a7515b3ab254f90a66cadffc94128fe356020c48f5d9426a98dbc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.13+commit.9aab3b86.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.13+commit.9aab3b86.js"
       ]
     },
     {
@@ -2949,9 +3759,12 @@
       "prerelease": "nightly.2017.3.14",
       "build": "commit.409eb9e3",
       "longVersion": "0.4.10-nightly.2017.3.14+commit.409eb9e3",
+      "sha256": "0xb1485a430b2a92d8854d63f8111da81c714eaaaafe8d0a144ebe1586cbe28efb",
       "keccak256": "0xc7b2cad2a817b9be0b9f685e82591cf19e3b78dd2300303159d483508213ea3d",
       "urls": [
-        "bzzr://88f30ce7d192694c2bdebe1b71ed4270a430e5a4c12566f9efd5d6f809bac446"
+        "bzzr://88f30ce7d192694c2bdebe1b71ed4270a430e5a4c12566f9efd5d6f809bac446",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.14+commit.409eb9e3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.14+commit.409eb9e3.js"
       ]
     },
     {
@@ -2960,9 +3773,12 @@
       "prerelease": "nightly.2017.3.15",
       "build": "commit.d134fda0",
       "longVersion": "0.4.10-nightly.2017.3.15+commit.d134fda0",
+      "sha256": "0xecb060ce34aa0ca33a126582a495a94532e07507eb0dc98e901aa83eb6483657",
       "keccak256": "0xff3a0ab91dc0bdc13e71f6fd0975c5186404784cd95a0555508c4fd52eb8e8a2",
       "urls": [
-        "bzzr://acc2a46c64b49a9176b620a274244e46d729de172e4c56936c53cd360c15f8eb"
+        "bzzr://acc2a46c64b49a9176b620a274244e46d729de172e4c56936c53cd360c15f8eb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10-nightly.2017.3.15+commit.d134fda0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10-nightly.2017.3.15+commit.d134fda0.js"
       ]
     },
     {
@@ -2970,9 +3786,12 @@
       "version": "0.4.10",
       "build": "commit.f0d539ae",
       "longVersion": "0.4.10+commit.f0d539ae",
+      "sha256": "0xf26d712a3a7d0ecd835eb077e23a3eae8d0b2054272baeb3eaa7feb64c69d1ea",
       "keccak256": "0x090c0843563e30fc7e0d6a66daa6ae0ff84dbd48e79a17d187905f25df73d1e0",
       "urls": [
-        "bzzr://a6bb732071169230d3c5cab20d5381d618bbce35a1a1413dc52940d03e2757bb"
+        "bzzr://a6bb732071169230d3c5cab20d5381d618bbce35a1a1413dc52940d03e2757bb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.10+commit.f0d539ae.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.10+commit.f0d539ae.js"
       ]
     },
     {
@@ -2981,9 +3800,12 @@
       "prerelease": "nightly.2017.3.15",
       "build": "commit.157b86c",
       "longVersion": "0.4.11-nightly.2017.3.15+commit.157b86c",
+      "sha256": "0xc721d7a91aee4b47449c3741a357d7613caf26430e6ee07a78c4cb73303a130d",
       "keccak256": "0x97e203b2921ec806f1b6e45e9418acab6c2276cfcfbb7c432f1e08faceecf3a0",
       "urls": [
-        "bzzr://732a0da24158418efe41b72fe9b08c4184be82cf0505e3069086b4e0f5ccfbe8"
+        "bzzr://732a0da24158418efe41b72fe9b08c4184be82cf0505e3069086b4e0f5ccfbe8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.15+commit.157b86c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.15+commit.157b86c.js"
       ]
     },
     {
@@ -2992,9 +3814,12 @@
       "prerelease": "nightly.2017.3.16",
       "build": "commit.a2eb2c0a",
       "longVersion": "0.4.11-nightly.2017.3.16+commit.a2eb2c0a",
+      "sha256": "0x59d1c64754fbf559937791e51b4e4acbf47ebb44c309e9bfd2984fa10ae4cf5c",
       "keccak256": "0x31413f72548aba3ccf520bf24d019b3257f1af43ee7a317cd75c836ea1fec7a3",
       "urls": [
-        "bzzr://4af15bcdd98ac98d2d1d85796a7c5f5f457decf4d398298f25e91922cc5cc276"
+        "bzzr://4af15bcdd98ac98d2d1d85796a7c5f5f457decf4d398298f25e91922cc5cc276",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.16+commit.a2eb2c0a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.16+commit.a2eb2c0a.js"
       ]
     },
     {
@@ -3003,9 +3828,12 @@
       "prerelease": "nightly.2017.3.17",
       "build": "commit.2f2ad42c",
       "longVersion": "0.4.11-nightly.2017.3.17+commit.2f2ad42c",
+      "sha256": "0x4af59009f77d4b38f842105b70702bbc0b94332a98ecfdd7c9e5ce2a50bf8f8d",
       "keccak256": "0x589d948e7287c43f5f504bf6adf30029927d1e38f78e5ece084a5547014b1f2c",
       "urls": [
-        "bzzr://0616e866fc0b269f1f6d836ed57d02c7a09535775875c4b9aa271b7ad1f39a7d"
+        "bzzr://0616e866fc0b269f1f6d836ed57d02c7a09535775875c4b9aa271b7ad1f39a7d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.17+commit.2f2ad42c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.17+commit.2f2ad42c.js"
       ]
     },
     {
@@ -3014,9 +3842,12 @@
       "prerelease": "nightly.2017.3.20",
       "build": "commit.57bc763e",
       "longVersion": "0.4.11-nightly.2017.3.20+commit.57bc763e",
+      "sha256": "0x031444c193ff5224386058e6376f8abe86199b27ff220a0280a4ff5ed08575a1",
       "keccak256": "0x9bf76dc688d0afcc654a43cf9be5592b5201d1b75607ae5545307bc3daf9ab82",
       "urls": [
-        "bzzr://3fe260cd8628710d0ba2f728ce562d067c5666e4276ea3ffa3f444e0ae8a34fe"
+        "bzzr://3fe260cd8628710d0ba2f728ce562d067c5666e4276ea3ffa3f444e0ae8a34fe",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.20+commit.57bc763e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.20+commit.57bc763e.js"
       ]
     },
     {
@@ -3025,9 +3856,12 @@
       "prerelease": "nightly.2017.3.21",
       "build": "commit.6fb27dee",
       "longVersion": "0.4.11-nightly.2017.3.21+commit.6fb27dee",
+      "sha256": "0x362d1c82ad8768ea52ce522fae187c09a9960d42aa361942e1063507c55b2487",
       "keccak256": "0x5373e8c6494d0929b2727bee98ac11d341d6f621e7dcda078166f029e0d02a88",
       "urls": [
-        "bzzr://cea3a09144b21b080614d6009551e7fe0d4b12b48bf135d1dcae80cc91bb9bbd"
+        "bzzr://cea3a09144b21b080614d6009551e7fe0d4b12b48bf135d1dcae80cc91bb9bbd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.21+commit.6fb27dee.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.21+commit.6fb27dee.js"
       ]
     },
     {
@@ -3036,9 +3870,12 @@
       "prerelease": "nightly.2017.3.22",
       "build": "commit.74d7c513",
       "longVersion": "0.4.11-nightly.2017.3.22+commit.74d7c513",
+      "sha256": "0x4db168426195027d9566a6693cfb16da349ffdd34115feb76c8b691ad2ab46ac",
       "keccak256": "0xa3452348d641f4508e830170158f2687eb7c281c273ae0cb2e6d29884cdc494a",
       "urls": [
-        "bzzr://667a02155217c77483dc73850869686c91f7b46ab88eed20784da2cb76fe595f"
+        "bzzr://667a02155217c77483dc73850869686c91f7b46ab88eed20784da2cb76fe595f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.22+commit.74d7c513.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.22+commit.74d7c513.js"
       ]
     },
     {
@@ -3047,9 +3884,12 @@
       "prerelease": "nightly.2017.3.27",
       "build": "commit.9d769a56",
       "longVersion": "0.4.11-nightly.2017.3.27+commit.9d769a56",
+      "sha256": "0x7756168829f8e3b0df6c417c98680bbec236b76b55eda4bd165a8a95f26e97fd",
       "keccak256": "0x2218e03b6582815c51f04e9279a19098b5770d1550be0825503c9084e9c5114a",
       "urls": [
-        "bzzr://7ec6a447b0e9a20efb4449f4c09ebd14b8f6e4e10618b6e2a7a50fe5354a8a37"
+        "bzzr://7ec6a447b0e9a20efb4449f4c09ebd14b8f6e4e10618b6e2a7a50fe5354a8a37",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.27+commit.9d769a56.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.27+commit.9d769a56.js"
       ]
     },
     {
@@ -3058,9 +3898,12 @@
       "prerelease": "nightly.2017.3.28",
       "build": "commit.215184ef",
       "longVersion": "0.4.11-nightly.2017.3.28+commit.215184ef",
+      "sha256": "0xec0962facf8779be7707fbd489a3bc003152ae556c9d91f07a65bf6b240c3287",
       "keccak256": "0xb9cd7939ed03cd975d6c53b0c5ecf6fd01f9e36bb7d64b653e05b5b97fbeb18d",
       "urls": [
-        "bzzr://e99e3378624fb8660c0034fd2a65ec716c3d556f5d71b545bbcc18234c632c50"
+        "bzzr://e99e3378624fb8660c0034fd2a65ec716c3d556f5d71b545bbcc18234c632c50",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.28+commit.215184ef.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.28+commit.215184ef.js"
       ]
     },
     {
@@ -3069,9 +3912,12 @@
       "prerelease": "nightly.2017.3.29",
       "build": "commit.fefb3fad",
       "longVersion": "0.4.11-nightly.2017.3.29+commit.fefb3fad",
+      "sha256": "0x2be6ca22c688810349f7f0ac5a19b9352af2e1dcd457e5c05606951881a357c8",
       "keccak256": "0xf06c6c2b515721bac8748c599a931cf63ace2379da95867b1b1821dbfc59da5c",
       "urls": [
-        "bzzr://77ce85ca7fc337b44aa348cad6f5b63009389ab39da31290a1b7defd2746f59d"
+        "bzzr://77ce85ca7fc337b44aa348cad6f5b63009389ab39da31290a1b7defd2746f59d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.3.29+commit.fefb3fad.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.3.29+commit.fefb3fad.js"
       ]
     },
     {
@@ -3080,9 +3926,12 @@
       "prerelease": "nightly.2017.4.10",
       "build": "commit.9fe20650",
       "longVersion": "0.4.11-nightly.2017.4.10+commit.9fe20650",
+      "sha256": "0x8d6934bfec7eeff36c21a6431dc13359342e9de7d7b1e0d69a658af9b2ae44f5",
       "keccak256": "0x182feb9cd30710479ea8d33ddbee2fa8f5b87da1fdfeaa0a1749f69a77664ac8",
       "urls": [
-        "bzzr://5863614a5a84607493bbaeaea7b41c5cfcf9c71ac0203e62b889a5119e33aea8"
+        "bzzr://5863614a5a84607493bbaeaea7b41c5cfcf9c71ac0203e62b889a5119e33aea8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.10+commit.9fe20650.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.10+commit.9fe20650.js"
       ]
     },
     {
@@ -3091,9 +3940,12 @@
       "prerelease": "nightly.2017.4.13",
       "build": "commit.138c952a",
       "longVersion": "0.4.11-nightly.2017.4.13+commit.138c952a",
+      "sha256": "0xd840ffd82f2c3ad0b295862b90ffad6776a307baef26075103818c32640da4d5",
       "keccak256": "0xaab8cdbf247750b1a6b8fa0d2500a71c6e71583bd7bf0ab9dcae53669b6b38b1",
       "urls": [
-        "bzzr://cc56edba0efd1b9d9e7b2b498314458e2e6a08fbec47d7b24667a6baeeef7836"
+        "bzzr://cc56edba0efd1b9d9e7b2b498314458e2e6a08fbec47d7b24667a6baeeef7836",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.13+commit.138c952a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.13+commit.138c952a.js"
       ]
     },
     {
@@ -3102,9 +3954,12 @@
       "prerelease": "nightly.2017.4.18",
       "build": "commit.82628a80",
       "longVersion": "0.4.11-nightly.2017.4.18+commit.82628a80",
+      "sha256": "0xe5fad4420534da517358dc4a6e5d6f1d5f11b3cda998031baa81188ffd287a61",
       "keccak256": "0xc75a32762b96b08a6f29f433439646afdb4e7aeb12da71dab8918a64309a6ddb",
       "urls": [
-        "bzzr://30f49ee1beb6e3a95dc82808f1ae4a584c2e86d02b89678be7008caea791dd2c"
+        "bzzr://30f49ee1beb6e3a95dc82808f1ae4a584c2e86d02b89678be7008caea791dd2c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.18+commit.82628a80.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.18+commit.82628a80.js"
       ]
     },
     {
@@ -3113,9 +3968,12 @@
       "prerelease": "nightly.2017.4.20",
       "build": "commit.6468955f",
       "longVersion": "0.4.11-nightly.2017.4.20+commit.6468955f",
+      "sha256": "0x35e619e40ca32856cd8416381d67a6fe73effc2a1a42621ce7b7408d68015691",
       "keccak256": "0xdabc18b755fe8e4ede71dbd9f6c063ab12d5c0fc37946ed5240277f34de54254",
       "urls": [
-        "bzzr://ccfcf3026f1dc1fd70bbac1f270c38c4c68cd11c40e2f496ea759c571b03f070"
+        "bzzr://ccfcf3026f1dc1fd70bbac1f270c38c4c68cd11c40e2f496ea759c571b03f070",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.20+commit.6468955f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.20+commit.6468955f.js"
       ]
     },
     {
@@ -3124,9 +3982,12 @@
       "prerelease": "nightly.2017.4.21",
       "build": "commit.e3eea9fc",
       "longVersion": "0.4.11-nightly.2017.4.21+commit.e3eea9fc",
+      "sha256": "0x042654a2a1abc266916f7cd560bfb8233c6e9f9e81a48f1e2de53b7ed63853d3",
       "keccak256": "0xbe55e1ff8c1cbb2dd4c540a76c3152347e87966de262e3be9a1a976b83388dd5",
       "urls": [
-        "bzzr://123dd95e671be4b84cf0cd6ee6f63db168cdb9e1db51c219e3e377de2869336d"
+        "bzzr://123dd95e671be4b84cf0cd6ee6f63db168cdb9e1db51c219e3e377de2869336d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.21+commit.e3eea9fc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.21+commit.e3eea9fc.js"
       ]
     },
     {
@@ -3135,9 +3996,12 @@
       "prerelease": "nightly.2017.4.22",
       "build": "commit.aa441668",
       "longVersion": "0.4.11-nightly.2017.4.22+commit.aa441668",
+      "sha256": "0x417a9550da3d2d8d3f7341d49dde639cee10764c3fad83c5ef70d2d8346998eb",
       "keccak256": "0x5d2d921c7a290afc052c381ebadd52bc68b88fed044947761fb14adbad6d9636",
       "urls": [
-        "bzzr://fce189eb1f8132ce47d2d7c5eb3ae9dd361640c23fc8de574d24082ac4868e92"
+        "bzzr://fce189eb1f8132ce47d2d7c5eb3ae9dd361640c23fc8de574d24082ac4868e92",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.22+commit.aa441668.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.22+commit.aa441668.js"
       ]
     },
     {
@@ -3146,9 +4010,12 @@
       "prerelease": "nightly.2017.4.24",
       "build": "commit.a9f42157",
       "longVersion": "0.4.11-nightly.2017.4.24+commit.a9f42157",
+      "sha256": "0x4b582664de4678166fb115358ba09739cc160b7c112b9aad97fa5d2998bcb763",
       "keccak256": "0x9191e86fc4a6b97c1f3ad3817f2dbb7d4dd16ab0158cf9754f8855bfd6a46daf",
       "urls": [
-        "bzzr://1cccc0a1f58b8bdfb680ceae28cc5d9ddc48affa4b2557d87705be78d568831a"
+        "bzzr://1cccc0a1f58b8bdfb680ceae28cc5d9ddc48affa4b2557d87705be78d568831a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.24+commit.a9f42157.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.24+commit.a9f42157.js"
       ]
     },
     {
@@ -3157,9 +4024,12 @@
       "prerelease": "nightly.2017.4.25",
       "build": "commit.c3b839ca",
       "longVersion": "0.4.11-nightly.2017.4.25+commit.c3b839ca",
+      "sha256": "0x74c2663bc2670384aac0ed5c9281f1aa8bb0bd7e91581d7458ed0a02270316c1",
       "keccak256": "0xa548fb24161930b2fb0fec48268da2de5cf6bc5a4803481b779027cebfad69b0",
       "urls": [
-        "bzzr://d66192a2aca3630b9cd33143276cfb1667c7d11971f3734add4b127035f4c627"
+        "bzzr://d66192a2aca3630b9cd33143276cfb1667c7d11971f3734add4b127035f4c627",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.25+commit.c3b839ca.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.25+commit.c3b839ca.js"
       ]
     },
     {
@@ -3168,9 +4038,12 @@
       "prerelease": "nightly.2017.4.26",
       "build": "commit.3cbdf6d4",
       "longVersion": "0.4.11-nightly.2017.4.26+commit.3cbdf6d4",
+      "sha256": "0x3c0cc24b0cdb6ea513035f95da86a2726480e5ace47cf4ce7648fb68c0b458b3",
       "keccak256": "0x27dd369deea0f9d731f6528dbe6e508ea25c946dbd5dd18747c21000f608785c",
       "urls": [
-        "bzzr://879db3cfa8dcecbb11a33f19a515859e3f375b08ba958ffe86f2af98b20ad577"
+        "bzzr://879db3cfa8dcecbb11a33f19a515859e3f375b08ba958ffe86f2af98b20ad577",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.26+commit.3cbdf6d4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.26+commit.3cbdf6d4.js"
       ]
     },
     {
@@ -3179,9 +4052,12 @@
       "prerelease": "nightly.2017.4.27",
       "build": "commit.abe77f48",
       "longVersion": "0.4.11-nightly.2017.4.27+commit.abe77f48",
+      "sha256": "0xee4c723e01f7989c7d0eaa84c9b4cc16c0afc577d83763340461e2ad0dae80fa",
       "keccak256": "0x7e8cdd383ac1cfcb52a8ed26ca016a728e8d4f7a42945dc15239456fd2d0dbd0",
       "urls": [
-        "bzzr://4d70d00a3fba256b5405005d5c6f65a5cc45f5f5c314e78fbaa8f581eb62a893"
+        "bzzr://4d70d00a3fba256b5405005d5c6f65a5cc45f5f5c314e78fbaa8f581eb62a893",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.27+commit.abe77f48.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.27+commit.abe77f48.js"
       ]
     },
     {
@@ -3190,9 +4066,12 @@
       "prerelease": "nightly.2017.4.28",
       "build": "commit.f33614e1",
       "longVersion": "0.4.11-nightly.2017.4.28+commit.f33614e1",
+      "sha256": "0x51376263bfcb6145f6f9df7cc11efbe3359e4950d3599bdd9089102657625cfd",
       "keccak256": "0xf3e30b1ad80634996abac4e8717d468e037598355652111529cac405522aa23b",
       "urls": [
-        "bzzr://a9d7cc97e7cbdd47727b4f6f61517b10a2b0a2f7c76b2aff681187b5db429ea4"
+        "bzzr://a9d7cc97e7cbdd47727b4f6f61517b10a2b0a2f7c76b2aff681187b5db429ea4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.4.28+commit.f33614e1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.4.28+commit.f33614e1.js"
       ]
     },
     {
@@ -3201,9 +4080,12 @@
       "prerelease": "nightly.2017.5.2",
       "build": "commit.5aeb6352",
       "longVersion": "0.4.11-nightly.2017.5.2+commit.5aeb6352",
+      "sha256": "0xc8a412910e01dec19fc4c3af94cd57fe6b42aa2080cff0faacb28478cd4c1479",
       "keccak256": "0xa606a3c180feb1cbad388fed27a5bb216cf7706c5ad394c8b1dbf4cc7c54a9bf",
       "urls": [
-        "bzzr://0defca04937e20c903e225b78f3f506715a3cdd55ebfe89fb8ab1df6685bf1a4"
+        "bzzr://0defca04937e20c903e225b78f3f506715a3cdd55ebfe89fb8ab1df6685bf1a4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.5.2+commit.5aeb6352.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.5.2+commit.5aeb6352.js"
       ]
     },
     {
@@ -3212,9 +4094,12 @@
       "prerelease": "nightly.2017.5.3",
       "build": "commit.1aa0f77a",
       "longVersion": "0.4.11-nightly.2017.5.3+commit.1aa0f77a",
+      "sha256": "0xe6a1548990b8572f74da321844b481a9c5e43637bba2d10a3df6a0de1a887e9a",
       "keccak256": "0x55b44298e53193fd7c145915ce2d7e85a55e5b37de86fcb5f0464209786a408a",
       "urls": [
-        "bzzr://bf64d601e60c8dcbd047939492bf7fe3bdf85131a7c6fbf775a9c77d3d8682fb"
+        "bzzr://bf64d601e60c8dcbd047939492bf7fe3bdf85131a7c6fbf775a9c77d3d8682fb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11-nightly.2017.5.3+commit.1aa0f77a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11-nightly.2017.5.3+commit.1aa0f77a.js"
       ]
     },
     {
@@ -3222,9 +4107,12 @@
       "version": "0.4.11",
       "build": "commit.68ef5810",
       "longVersion": "0.4.11+commit.68ef5810",
+      "sha256": "0x6cc5b7c2c3c640daeadc8a41ab5cacc085b4fef667c2e119767529ff23075111",
       "keccak256": "0xde17e284da94d3d600c1096f05d83af794eef746d2aba2e4e066e3d3efce7abf",
       "urls": [
-        "bzzr://21a06f49cd51d05d4f40a0f2ade84309e5d411ccdcbaf8b93d14163e42716f7f"
+        "bzzr://21a06f49cd51d05d4f40a0f2ade84309e5d411ccdcbaf8b93d14163e42716f7f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.11+commit.68ef5810.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.11+commit.68ef5810.js"
       ]
     },
     {
@@ -3233,9 +4121,12 @@
       "prerelease": "nightly.2017.5.4",
       "build": "commit.25b32d9",
       "longVersion": "0.4.12-nightly.2017.5.4+commit.25b32d9",
+      "sha256": "0xd0d565478bd167cb0ca2388207dd98644dbaad8ffca3936577740b35c4ec9f70",
       "keccak256": "0x396c1b84020fce45d1a35090051f00960c511e15409a63d66496c3fedc5a3054",
       "urls": [
-        "bzzr://e762aa0e54f8769ef0c30d0db7540445404e10bfc07d6a439f0dbd062e97f649"
+        "bzzr://e762aa0e54f8769ef0c30d0db7540445404e10bfc07d6a439f0dbd062e97f649",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.4+commit.25b32d9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.4+commit.25b32d9.js"
       ]
     },
     {
@@ -3244,9 +4135,12 @@
       "prerelease": "nightly.2017.5.5",
       "build": "commit.582fcb9",
       "longVersion": "0.4.12-nightly.2017.5.5+commit.582fcb9",
+      "sha256": "0xee17f64f73952a31913484f1523accb53cdd0a7623a3a9daf6f573b83c382ff8",
       "keccak256": "0xd3d49469c1de628ff984683af3069ea6ef946ea821325d6a9ee57c2dd7963a3c",
       "urls": [
-        "bzzr://225e409241898c6a909d47c737ea6df8ec00e26c39b191b3250c0cb1b86e18aa"
+        "bzzr://225e409241898c6a909d47c737ea6df8ec00e26c39b191b3250c0cb1b86e18aa",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.5+commit.582fcb9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.5+commit.582fcb9.js"
       ]
     },
     {
@@ -3255,9 +4149,12 @@
       "prerelease": "nightly.2017.5.6",
       "build": "commit.822c9057",
       "longVersion": "0.4.12-nightly.2017.5.6+commit.822c9057",
+      "sha256": "0x627b1204e8949871d049b2e8657512ad2905a39863d5de58b9eb51b5acc4b089",
       "keccak256": "0xd9c6fbc9a46fca4faa9fc5dbb824c301cc0502e35a6af755e60f4321a0da6737",
       "urls": [
-        "bzzr://a84aa7495441d1c5c915f4754ab0c60b212f9fef5a99fc471282ed5473baefb8"
+        "bzzr://a84aa7495441d1c5c915f4754ab0c60b212f9fef5a99fc471282ed5473baefb8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.6+commit.822c9057.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.6+commit.822c9057.js"
       ]
     },
     {
@@ -3266,9 +4163,12 @@
       "prerelease": "nightly.2017.5.10",
       "build": "commit.a6586f75",
       "longVersion": "0.4.12-nightly.2017.5.10+commit.a6586f75",
+      "sha256": "0x81ecddc3a48abd8af4566806f0baafc20ad851eaa69033eebd82791740059732",
       "keccak256": "0x76e72a1b1ea30b7978e9257936847254ef6ec4f1c429db1b5bebc0eae5f2d226",
       "urls": [
-        "bzzr://09bdf24fcbb516ea8edce76334ae45b05e809f133702ee46be81be56301d10c9"
+        "bzzr://09bdf24fcbb516ea8edce76334ae45b05e809f133702ee46be81be56301d10c9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.10+commit.a6586f75.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.10+commit.a6586f75.js"
       ]
     },
     {
@@ -3277,9 +4177,12 @@
       "prerelease": "nightly.2017.5.11",
       "build": "commit.242e4318",
       "longVersion": "0.4.12-nightly.2017.5.11+commit.242e4318",
+      "sha256": "0xbac6994887687c17fb4be032db96951e9d737ea01cad22890d6282e07eb50595",
       "keccak256": "0x523aad809a01dd03acef4f99b6517f5eb8af86c39f8a61f6c92f7ebb30f260ea",
       "urls": [
-        "bzzr://d29f5d0f837da18fdb70d45f6985991e06b3402046a74efdb01a688391b15996"
+        "bzzr://d29f5d0f837da18fdb70d45f6985991e06b3402046a74efdb01a688391b15996",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.11+commit.242e4318.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.11+commit.242e4318.js"
       ]
     },
     {
@@ -3288,9 +4191,12 @@
       "prerelease": "nightly.2017.5.16",
       "build": "commit.2ba87fe8",
       "longVersion": "0.4.12-nightly.2017.5.16+commit.2ba87fe8",
+      "sha256": "0x668112947890530c374b967bec9ed89df4d2524d6691f94d270c6638c277cd26",
       "keccak256": "0x27a6f5263607f302a32b5a334498fd2ef44827a521ef93d84ab0f0dde1e9d065",
       "urls": [
-        "bzzr://77c5077147bfafdb124d6056e2f64452b7144bef9f3d14a8dedcfa1201064dd6"
+        "bzzr://77c5077147bfafdb124d6056e2f64452b7144bef9f3d14a8dedcfa1201064dd6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.16+commit.2ba87fe8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.16+commit.2ba87fe8.js"
       ]
     },
     {
@@ -3299,9 +4205,12 @@
       "prerelease": "nightly.2017.5.17",
       "build": "commit.b4c6877a",
       "longVersion": "0.4.12-nightly.2017.5.17+commit.b4c6877a",
+      "sha256": "0x671d766014fedd211007b53ac81bd36865402704b8030afaa1b23b967171acc4",
       "keccak256": "0x7aab62a6e91206df254b6df9e2660f6933e5d4dfcf254f601dc858552c1aa2aa",
       "urls": [
-        "bzzr://e2c63519284680e984471b6d7140cd719f25d64a8486d805007e0f27277a62c2"
+        "bzzr://e2c63519284680e984471b6d7140cd719f25d64a8486d805007e0f27277a62c2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.17+commit.b4c6877a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.17+commit.b4c6877a.js"
       ]
     },
     {
@@ -3310,9 +4219,12 @@
       "prerelease": "nightly.2017.5.18",
       "build": "commit.6f9428e9",
       "longVersion": "0.4.12-nightly.2017.5.18+commit.6f9428e9",
+      "sha256": "0xafeafad1b3a8f6dee89baeff62ace3e8a8f190ff26290a46d6a04869315fb9c4",
       "keccak256": "0xbfe270fe6dd2ac7fb1d7264e7d044e98fe45aa656404d25253f33d27ba514c85",
       "urls": [
-        "bzzr://5d49b77818e83ca3abaa7679524d94237dd50eb0584e250ce0c01566614efb34"
+        "bzzr://5d49b77818e83ca3abaa7679524d94237dd50eb0584e250ce0c01566614efb34",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.18+commit.6f9428e9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.18+commit.6f9428e9.js"
       ]
     },
     {
@@ -3321,9 +4233,12 @@
       "prerelease": "nightly.2017.5.19",
       "build": "commit.982f6613",
       "longVersion": "0.4.12-nightly.2017.5.19+commit.982f6613",
+      "sha256": "0xf3060498be1ac8ef40bc9eb3be4cc68fba7e265c2df465537d8b20f6f59e803f",
       "keccak256": "0x67066565c9caa5c0dc8a0e907664b62c3f4848d3272b64bffbcce3d00f75c134",
       "urls": [
-        "bzzr://6fb9ba92832396fa81f243be506af7628ec0adda6787e6b6e6f6a47efb4f31f8"
+        "bzzr://6fb9ba92832396fa81f243be506af7628ec0adda6787e6b6e6f6a47efb4f31f8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.19+commit.982f6613.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.19+commit.982f6613.js"
       ]
     },
     {
@@ -3332,9 +4247,12 @@
       "prerelease": "nightly.2017.5.22",
       "build": "commit.e3af0640",
       "longVersion": "0.4.12-nightly.2017.5.22+commit.e3af0640",
+      "sha256": "0x5c65c50e7b27354c655c7b17800cc855c73bee7dbd13f0fa057d4bc1772a5798",
       "keccak256": "0xbf38c0c07901a749a013be811aee4d7aaa8bb0a8571da629e267e03b0f8768da",
       "urls": [
-        "bzzr://52fb55569fa5c1657fd225e32193b6038dbb7cfe976db1bc27bf99abf302dad9"
+        "bzzr://52fb55569fa5c1657fd225e32193b6038dbb7cfe976db1bc27bf99abf302dad9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.22+commit.e3af0640.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.22+commit.e3af0640.js"
       ]
     },
     {
@@ -3343,9 +4261,12 @@
       "prerelease": "nightly.2017.5.23",
       "build": "commit.14b22150",
       "longVersion": "0.4.12-nightly.2017.5.23+commit.14b22150",
+      "sha256": "0x71a92bf73522e627fa89aaafcc191b5e60347a8d01c165f2dd7f6582b36d49a0",
       "keccak256": "0xc772028e4617430ad60b04ff190dbfdf1b86efe8f42bb9740af471d2802ba5c6",
       "urls": [
-        "bzzr://49e933d4a6a5f5e30dab4402bd3b0d3aded6f41de0dffb393257d076c6e854f6"
+        "bzzr://49e933d4a6a5f5e30dab4402bd3b0d3aded6f41de0dffb393257d076c6e854f6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.23+commit.14b22150.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.23+commit.14b22150.js"
       ]
     },
     {
@@ -3354,9 +4275,12 @@
       "prerelease": "nightly.2017.5.24",
       "build": "commit.cf639f48",
       "longVersion": "0.4.12-nightly.2017.5.24+commit.cf639f48",
+      "sha256": "0x33a776cf04613f3e00f70c9e0c8ec4d459d75ee876f1f4a8679022860cbc2411",
       "keccak256": "0x65f3e05f09ba0505da1134e1460498a37484df10dfaf2c9b03361643998ad13b",
       "urls": [
-        "bzzr://32bddcec6a9331c1bcb8c2ddc491e4f4bc21689df6838c093d0643b9a91770c9"
+        "bzzr://32bddcec6a9331c1bcb8c2ddc491e4f4bc21689df6838c093d0643b9a91770c9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.24+commit.cf639f48.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.24+commit.cf639f48.js"
       ]
     },
     {
@@ -3365,9 +4289,12 @@
       "prerelease": "nightly.2017.5.26",
       "build": "commit.e43ff797",
       "longVersion": "0.4.12-nightly.2017.5.26+commit.e43ff797",
+      "sha256": "0xa7748bf8ef857ee37c11b30ddd547a6adfd8e044b130b58ce0b9c2235406f3c6",
       "keccak256": "0x7de59a4629a0e7e56c7fc1904a41bd94d7fcdc91480989c77f99a3f1a62fe89d",
       "urls": [
-        "bzzr://78e39a6bbc66938f183dbc7f72aa453ecc0ea750b41676dcb1bd5caaf58d272a"
+        "bzzr://78e39a6bbc66938f183dbc7f72aa453ecc0ea750b41676dcb1bd5caaf58d272a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.26+commit.e43ff797.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.26+commit.e43ff797.js"
       ]
     },
     {
@@ -3376,9 +4303,12 @@
       "prerelease": "nightly.2017.5.29",
       "build": "commit.4a5dc6a4",
       "longVersion": "0.4.12-nightly.2017.5.29+commit.4a5dc6a4",
+      "sha256": "0x9707478354490b825bda486ba1a6512e87ebd65c0ecf23428b18e0398cb0126e",
       "keccak256": "0x0dd40d13f41f8a30f798524333ab9cf6293a1b8828611fac7aff84144740a06e",
       "urls": [
-        "bzzr://a9f97e4c1c0e2355e275b20c83ec6a9af3145aad8d7a8ee56491de60ef4ddbbe"
+        "bzzr://a9f97e4c1c0e2355e275b20c83ec6a9af3145aad8d7a8ee56491de60ef4ddbbe",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.29+commit.4a5dc6a4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.29+commit.4a5dc6a4.js"
       ]
     },
     {
@@ -3387,9 +4317,12 @@
       "prerelease": "nightly.2017.5.30",
       "build": "commit.254b5572",
       "longVersion": "0.4.12-nightly.2017.5.30+commit.254b5572",
+      "sha256": "0xd6e92ce21a8869e077bd2fb5c5c77f25684121716e52348b383543b35d8341d6",
       "keccak256": "0x4dc45b3275ff55c5c73c3e70231c3978ade5f8ceb08a621f09a464a10916e229",
       "urls": [
-        "bzzr://6f170431c21b8a151f26a7756c77111d60bdc49940408a9676f805d78285683f"
+        "bzzr://6f170431c21b8a151f26a7756c77111d60bdc49940408a9676f805d78285683f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.5.30+commit.254b5572.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.5.30+commit.254b5572.js"
       ]
     },
     {
@@ -3398,9 +4331,12 @@
       "prerelease": "nightly.2017.6.1",
       "build": "commit.96de7a83",
       "longVersion": "0.4.12-nightly.2017.6.1+commit.96de7a83",
+      "sha256": "0x6844d35035955cb3e10dd8754d88200b6be7bf4c9dfbeaefb1ad83a39851d1f1",
       "keccak256": "0xb279d6640df060660cf71a3d2d8dcc09bd2d41dba1022a56d475a17d27d92717",
       "urls": [
-        "bzzr://cfacd958ff32a194412ba0899627d121a1c9a5f62ee8cda161a5c2981a9db5a2"
+        "bzzr://cfacd958ff32a194412ba0899627d121a1c9a5f62ee8cda161a5c2981a9db5a2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.1+commit.96de7a83.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.1+commit.96de7a83.js"
       ]
     },
     {
@@ -3409,9 +4345,12 @@
       "prerelease": "nightly.2017.6.6",
       "build": "commit.243e389f",
       "longVersion": "0.4.12-nightly.2017.6.6+commit.243e389f",
+      "sha256": "0x61035713f45874cb2a748ee21c2da681c34d0ad0acce772c9b9b39a85d8089e3",
       "keccak256": "0xbc082d1158366cf40604029b04957aad96a1e857be7a70a2e2116a427848c038",
       "urls": [
-        "bzzr://042bbd304cbc161fbdc0c1ba4a548e66ae79d8624102ddf1fc0c175c8cec1da4"
+        "bzzr://042bbd304cbc161fbdc0c1ba4a548e66ae79d8624102ddf1fc0c175c8cec1da4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.6+commit.243e389f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.6+commit.243e389f.js"
       ]
     },
     {
@@ -3420,9 +4359,12 @@
       "prerelease": "nightly.2017.6.8",
       "build": "commit.51fcfbcf",
       "longVersion": "0.4.12-nightly.2017.6.8+commit.51fcfbcf",
+      "sha256": "0x8c0a3cb79fb36912538f1216a6b33a90df77adcb26c1333c5d93e3173c324fbd",
       "keccak256": "0xb90a616f667c86dfaf01162c35fbff1a7621af405aefc33c916dff110aa708e0",
       "urls": [
-        "bzzr://d230347894a4499245a4386921a58472d5e8ad4499cdc3a8b07d3aa23e913e2f"
+        "bzzr://d230347894a4499245a4386921a58472d5e8ad4499cdc3a8b07d3aa23e913e2f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.8+commit.51fcfbcf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.8+commit.51fcfbcf.js"
       ]
     },
     {
@@ -3431,9 +4373,12 @@
       "prerelease": "nightly.2017.6.9",
       "build": "commit.76667fed",
       "longVersion": "0.4.12-nightly.2017.6.9+commit.76667fed",
+      "sha256": "0xbf7e5eeb3c7590c0b8f97ec82867d144f1cd23493aeba5c69d57b06d8f03b2c2",
       "keccak256": "0xd9053424297047a145869e886bd8e8bef44dc4c5b8cba0b29007f38371b8fe5b",
       "urls": [
-        "bzzr://b59a8ed1fb5ef8e6ea6803b223e38647b11eec971368a1dea03fc46b7ebab712"
+        "bzzr://b59a8ed1fb5ef8e6ea6803b223e38647b11eec971368a1dea03fc46b7ebab712",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.9+commit.76667fed.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.9+commit.76667fed.js"
       ]
     },
     {
@@ -3442,9 +4387,12 @@
       "prerelease": "nightly.2017.6.12",
       "build": "commit.496c2a20",
       "longVersion": "0.4.12-nightly.2017.6.12+commit.496c2a20",
+      "sha256": "0x2c3cc4feed9e71c1cc58d2053f2ccd5f8c43cdc9a574e7c48e1d954f7dcd2039",
       "keccak256": "0x0d86e48a220c36faa8d79bc598b2173cc325768b524d08ed1d58e56c697db05e",
       "urls": [
-        "bzzr://4ae27dcadea053e98ef93d5e759b8cfefb71bc68dc83b45b5939b1989041d307"
+        "bzzr://4ae27dcadea053e98ef93d5e759b8cfefb71bc68dc83b45b5939b1989041d307",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.12+commit.496c2a20.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.12+commit.496c2a20.js"
       ]
     },
     {
@@ -3453,9 +4401,12 @@
       "prerelease": "nightly.2017.6.13",
       "build": "commit.c8c2091",
       "longVersion": "0.4.12-nightly.2017.6.13+commit.c8c2091",
+      "sha256": "0x623f4314c87d9ec8019c445bd78bee2a370845464de7d9642482bb9b732b95a7",
       "keccak256": "0xde8fd86b5b0c7f74ed76c00b9859bfadb0f09da5431081c3d030c6515826e48b",
       "urls": [
-        "bzzr://8ff2348d15d1c73c8e0eaca3d33e5c00a2075d2956617622b916e9ea9483f83b"
+        "bzzr://8ff2348d15d1c73c8e0eaca3d33e5c00a2075d2956617622b916e9ea9483f83b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.13+commit.c8c2091.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.13+commit.c8c2091.js"
       ]
     },
     {
@@ -3464,9 +4415,12 @@
       "prerelease": "nightly.2017.6.14",
       "build": "commit.43cfab70",
       "longVersion": "0.4.12-nightly.2017.6.14+commit.43cfab70",
+      "sha256": "0x9132345ea028a5ffcd315b14321eaf46dc9b7a81d4b3267ed6f58d3498a5a78d",
       "keccak256": "0x9e41ecc4813a5c2ad3a7973ee6c6bd8377505e8c166c15c7cf08eda2f6148a65",
       "urls": [
-        "bzzr://08930a2c0914ff6132b0dc35b8c0526ea09be04483d25c78e528e969e06439f2"
+        "bzzr://08930a2c0914ff6132b0dc35b8c0526ea09be04483d25c78e528e969e06439f2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.14+commit.43cfab70.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.14+commit.43cfab70.js"
       ]
     },
     {
@@ -3475,9 +4429,12 @@
       "prerelease": "nightly.2017.6.15",
       "build": "commit.71fea1e3",
       "longVersion": "0.4.12-nightly.2017.6.15+commit.71fea1e3",
+      "sha256": "0xe8620865b5ea272b9d35aac01b75963a284c3f2500d00744bcfcf1a54d06c7ff",
       "keccak256": "0xaee06f8570c6063ba411bc5e5ab4df5a3ca36b4721288b992ce2d30cecca9dad",
       "urls": [
-        "bzzr://cc67deb8fdb4320a6499b49a0e1c8609920dce1eae73b23359be3dc86cba7a6a"
+        "bzzr://cc67deb8fdb4320a6499b49a0e1c8609920dce1eae73b23359be3dc86cba7a6a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.15+commit.71fea1e3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.15+commit.71fea1e3.js"
       ]
     },
     {
@@ -3486,9 +4443,12 @@
       "prerelease": "nightly.2017.6.16",
       "build": "commit.17de4a07",
       "longVersion": "0.4.12-nightly.2017.6.16+commit.17de4a07",
+      "sha256": "0x72104744c954de2bc5261e7309a8f26fb52d79d4808d9a39788f2899f5633be9",
       "keccak256": "0x5c306a4f51e3cc5ad89db5dced6be516415d4b85809c0e7d3c01ac981754814e",
       "urls": [
-        "bzzr://b142f792e0c40f2a0440c4146467e14fbd778c229ab73ac45faec085131d97af"
+        "bzzr://b142f792e0c40f2a0440c4146467e14fbd778c229ab73ac45faec085131d97af",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.16+commit.17de4a07.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.16+commit.17de4a07.js"
       ]
     },
     {
@@ -3497,9 +4457,12 @@
       "prerelease": "nightly.2017.6.19",
       "build": "commit.c75afb2",
       "longVersion": "0.4.12-nightly.2017.6.19+commit.c75afb2",
+      "sha256": "0x4c4a73b594307892dfcd931a727119268c254e9b9d63d24e03625acebb8284b0",
       "keccak256": "0x22fe806bccb4270e73d97a77f2c18257aebe89b086c35c382ad017fb3810ad11",
       "urls": [
-        "bzzr://58c509807b16931c04fd39008dc6c67debbb328bddd20f5a9729d6fa31bfa600"
+        "bzzr://58c509807b16931c04fd39008dc6c67debbb328bddd20f5a9729d6fa31bfa600",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.19+commit.c75afb2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.19+commit.c75afb2.js"
       ]
     },
     {
@@ -3508,9 +4471,12 @@
       "prerelease": "nightly.2017.6.20",
       "build": "commit.cb5f2f90",
       "longVersion": "0.4.12-nightly.2017.6.20+commit.cb5f2f90",
+      "sha256": "0xe61216c8d8dec9d12efc977cb105df979ab12ecdb601ad0e4237c22b239cf983",
       "keccak256": "0x92f34e20c629168f03922d57e41005a02937b179af9e3764b25891ca27367db4",
       "urls": [
-        "bzzr://b57b2bcbf49a8c49972c4f70d43d037369bb89fa492580df4f4fb253e6690dab"
+        "bzzr://b57b2bcbf49a8c49972c4f70d43d037369bb89fa492580df4f4fb253e6690dab",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.20+commit.cb5f2f90.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.20+commit.cb5f2f90.js"
       ]
     },
     {
@@ -3519,9 +4485,12 @@
       "prerelease": "nightly.2017.6.21",
       "build": "commit.ac977cdf",
       "longVersion": "0.4.12-nightly.2017.6.21+commit.ac977cdf",
+      "sha256": "0x1fd3ade106981a0ff8aa4103e493bbb7bc8bd22f5f8c07597a21d49f5181d18e",
       "keccak256": "0xf4e9ea4b4dcdb4e569a1e8e73f1efb0662da260aa0c1c904c69d9eaa56c38e7f",
       "urls": [
-        "bzzr://20cf2e5d42cd0f76ec87b93587a42b50368da83511a2f5eb8c4a6fd7269a01ed"
+        "bzzr://20cf2e5d42cd0f76ec87b93587a42b50368da83511a2f5eb8c4a6fd7269a01ed",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.21+commit.ac977cdf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.21+commit.ac977cdf.js"
       ]
     },
     {
@@ -3530,9 +4499,12 @@
       "prerelease": "nightly.2017.6.22",
       "build": "commit.1c54ce2a",
       "longVersion": "0.4.12-nightly.2017.6.22+commit.1c54ce2a",
+      "sha256": "0x028135d2ccd890d976800c882e94a4e968038aa75b7bf24dc13544f222205830",
       "keccak256": "0x25223a0f6059ac1fe907127c40b93e0a6bf2b8d78cc58084f4160aff7c2d9f6f",
       "urls": [
-        "bzzr://b579dbcb741862e1ea3606678c6a7d061d95ac739f0f53978d5e64163b148b42"
+        "bzzr://b579dbcb741862e1ea3606678c6a7d061d95ac739f0f53978d5e64163b148b42",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.22+commit.1c54ce2a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.22+commit.1c54ce2a.js"
       ]
     },
     {
@@ -3541,9 +4513,12 @@
       "prerelease": "nightly.2017.6.23",
       "build": "commit.793f05fa",
       "longVersion": "0.4.12-nightly.2017.6.23+commit.793f05fa",
+      "sha256": "0xa0543821cd1335d8594ac9fa6b9601e44685301a489425aef4fab785807b5e10",
       "keccak256": "0x0f6d05b95849cd5cfa6bd2314267b2cf23ccf15a7835deb528f5c6cec982c723",
       "urls": [
-        "bzzr://a0aec1a83fd0ea2247012524762b3b7da63a92027baf28aad586136d53327b4e"
+        "bzzr://a0aec1a83fd0ea2247012524762b3b7da63a92027baf28aad586136d53327b4e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.23+commit.793f05fa.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.23+commit.793f05fa.js"
       ]
     },
     {
@@ -3552,9 +4527,12 @@
       "prerelease": "nightly.2017.6.25",
       "build": "commit.29b8cdb5",
       "longVersion": "0.4.12-nightly.2017.6.25+commit.29b8cdb5",
+      "sha256": "0x7516e0d33a986037a7c4285893616d330870fa0171ec2a4896599d229875d722",
       "keccak256": "0xd0d8e7f5c0a87ec3866167a0178837328ad29201daf67ee8bced03422b661686",
       "urls": [
-        "bzzr://8db895dd0a5ddc31f39b6bdc866e885d708c46d419a503af4b403d00fc11b4ac"
+        "bzzr://8db895dd0a5ddc31f39b6bdc866e885d708c46d419a503af4b403d00fc11b4ac",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.25+commit.29b8cdb5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.25+commit.29b8cdb5.js"
       ]
     },
     {
@@ -3563,9 +4541,12 @@
       "prerelease": "nightly.2017.6.26",
       "build": "commit.f8794892",
       "longVersion": "0.4.12-nightly.2017.6.26+commit.f8794892",
+      "sha256": "0x9474854840ca59b5d4102109a241fdaff36a7dab8d44099d9f9c205372b6f165",
       "keccak256": "0x4539f5b912a98089f29a8a0f11b77bffeec23493ab490303a11d9e32d68ac8e1",
       "urls": [
-        "bzzr://af41edb300606bfd74ee32d358c08094742afa44b703b73f4d33c964f2147c5d"
+        "bzzr://af41edb300606bfd74ee32d358c08094742afa44b703b73f4d33c964f2147c5d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.26+commit.f8794892.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.26+commit.f8794892.js"
       ]
     },
     {
@@ -3574,9 +4555,12 @@
       "prerelease": "nightly.2017.6.27",
       "build": "commit.bc31d496",
       "longVersion": "0.4.12-nightly.2017.6.27+commit.bc31d496",
+      "sha256": "0x05e0f826afeddff488de99c14ed0bba303145b8362d15a9985ac3ce381fff156",
       "keccak256": "0x3d8d35f89b9ba84cc985c25f46aaa6f5f54b64ce6cf55cbf820f0ca546df4903",
       "urls": [
-        "bzzr://cde5467786137658b6647d1cc504371257a0d751e34e7161a130f44d56966108"
+        "bzzr://cde5467786137658b6647d1cc504371257a0d751e34e7161a130f44d56966108",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.27+commit.bc31d496.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.27+commit.bc31d496.js"
       ]
     },
     {
@@ -3585,9 +4569,12 @@
       "prerelease": "nightly.2017.6.28",
       "build": "commit.e19c4125",
       "longVersion": "0.4.12-nightly.2017.6.28+commit.e19c4125",
+      "sha256": "0x2507b0a4d67390c7a3902fa8a7dbaa33d1784350a54c0316b9af9ff72b06fe94",
       "keccak256": "0x26a64e76f12b7c02d302e8706d00dde642fabe4f17bc02771b779499eec6395c",
       "urls": [
-        "bzzr://1da83a4c76fab7e683afe53b7dd9f699fc4fe05df31469267623fd1c6e593599"
+        "bzzr://1da83a4c76fab7e683afe53b7dd9f699fc4fe05df31469267623fd1c6e593599",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.28+commit.e19c4125.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.28+commit.e19c4125.js"
       ]
     },
     {
@@ -3596,9 +4583,12 @@
       "prerelease": "nightly.2017.6.29",
       "build": "commit.f5372cda",
       "longVersion": "0.4.12-nightly.2017.6.29+commit.f5372cda",
+      "sha256": "0x3426c871565d6d8a3503013e5fde7985c533b3af50863442acf7b410e43fe88b",
       "keccak256": "0xd8ffb8cdd675fa0fea4f8350cbfeffc3ca0301f511c3bdc952d06929679af0b1",
       "urls": [
-        "bzzr://d6752cc6e94a9bb8525b61c5b2ed41096c4471015d983a7e9824dd7a7ae3a273"
+        "bzzr://d6752cc6e94a9bb8525b61c5b2ed41096c4471015d983a7e9824dd7a7ae3a273",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.29+commit.f5372cda.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.29+commit.f5372cda.js"
       ]
     },
     {
@@ -3607,9 +4597,12 @@
       "prerelease": "nightly.2017.6.30",
       "build": "commit.568e7520",
       "longVersion": "0.4.12-nightly.2017.6.30+commit.568e7520",
+      "sha256": "0x42162e33c17fde69d1964d2d96d18b0454c99db84469baec1f93e97ad419e504",
       "keccak256": "0xe894e2a9f611995e09a4b03d8e218b88a8f78808e9c39530945776ed5607535a",
       "urls": [
-        "bzzr://11bc1cf271bf18c8e9868891e76f9fa88407f161030fd405892bd3bc3c87761e"
+        "bzzr://11bc1cf271bf18c8e9868891e76f9fa88407f161030fd405892bd3bc3c87761e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.6.30+commit.568e7520.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.6.30+commit.568e7520.js"
       ]
     },
     {
@@ -3618,9 +4611,12 @@
       "prerelease": "nightly.2017.7.1",
       "build": "commit.6f8949f",
       "longVersion": "0.4.12-nightly.2017.7.1+commit.6f8949f",
+      "sha256": "0x108409dbab821a3e3001691571a75634a54567ea71fc29b328766e3541d4d936",
       "keccak256": "0x4b94255e10b4d49873fc3d5827965d616fc9ce6c47dac9d33b76cc8ee09076d5",
       "urls": [
-        "bzzr://4da4c61db1b627348fdeba2c44893a2adfbe23e28fdff5941d60d680f504d550"
+        "bzzr://4da4c61db1b627348fdeba2c44893a2adfbe23e28fdff5941d60d680f504d550",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.7.1+commit.6f8949f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.7.1+commit.6f8949f.js"
       ]
     },
     {
@@ -3629,9 +4625,12 @@
       "prerelease": "nightly.2017.7.3",
       "build": "commit.c7530a8",
       "longVersion": "0.4.12-nightly.2017.7.3+commit.c7530a8",
+      "sha256": "0xa39c5ea6598386313b0bd9249be9944a17f43c83cd84054898ffa6abaa60c450",
       "keccak256": "0x763ae0e1023f204864e03dcecdb8adb4d1d3419e5d2389a02aa227acd802317b",
       "urls": [
-        "bzzr://0daf2e6f16891664ffdf8611018b23d890f6ba1228a3a9949b86603820f806af"
+        "bzzr://0daf2e6f16891664ffdf8611018b23d890f6ba1228a3a9949b86603820f806af",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12-nightly.2017.7.3+commit.c7530a8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12-nightly.2017.7.3+commit.c7530a8.js"
       ]
     },
     {
@@ -3639,9 +4638,12 @@
       "version": "0.4.12",
       "build": "commit.194ff033",
       "longVersion": "0.4.12+commit.194ff033",
+      "sha256": "0x304f7b092e9493525867b49dd8a833bec53ca6ee5ccb408daca7e266e17a6cf7",
       "keccak256": "0x44dc961e7512f70b660555c7d900632c1863c1bf6234b0244a90645bdddaa53d",
       "urls": [
-        "bzzr://021fcea53baf74dc83891d864b6d6a63a0d289dff9cd4542d901b9d62124764d"
+        "bzzr://021fcea53baf74dc83891d864b6d6a63a0d289dff9cd4542d901b9d62124764d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.12+commit.194ff033.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.12+commit.194ff033.js"
       ]
     },
     {
@@ -3650,9 +4652,12 @@
       "prerelease": "nightly.2017.7.3",
       "build": "commit.6e4e627b",
       "longVersion": "0.4.13-nightly.2017.7.3+commit.6e4e627b",
+      "sha256": "0x68d12edcc7022ab71ae3fd82478f0b7577ce027255ac1f7a128afefe1d508b27",
       "keccak256": "0xc9b519e58fc7a7d049d57f896a266caddec19bac75a6502a4bcd048309a40f78",
       "urls": [
-        "bzzr://bf94ddbee14908240a30da8e29749add1ba6d03421ac840ce954d87fed7101cd"
+        "bzzr://bf94ddbee14908240a30da8e29749add1ba6d03421ac840ce954d87fed7101cd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.13-nightly.2017.7.3+commit.6e4e627b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.13-nightly.2017.7.3+commit.6e4e627b.js"
       ]
     },
     {
@@ -3661,9 +4666,12 @@
       "prerelease": "nightly.2017.7.4",
       "build": "commit.331b0b1c",
       "longVersion": "0.4.13-nightly.2017.7.4+commit.331b0b1c",
+      "sha256": "0x79bad2827e422c06debf6f8e8c80f4441249674d4642ce31ba15ddeefe20cf7e",
       "keccak256": "0xaa8785f49532e117551a7caddd501bc0f3936c613cb07e032c8792b9cd8d7a80",
       "urls": [
-        "bzzr://6575be13d595c17665d591e38a6f84dc3b19478d02a8201db6e607c5f621290c"
+        "bzzr://6575be13d595c17665d591e38a6f84dc3b19478d02a8201db6e607c5f621290c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.13-nightly.2017.7.4+commit.331b0b1c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.13-nightly.2017.7.4+commit.331b0b1c.js"
       ]
     },
     {
@@ -3672,9 +4680,12 @@
       "prerelease": "nightly.2017.7.5",
       "build": "commit.2b505e7a",
       "longVersion": "0.4.13-nightly.2017.7.5+commit.2b505e7a",
+      "sha256": "0xc2470e880c1282b079510282a510523279771a467da812b8fdb758e8aca2c0ab",
       "keccak256": "0xe79c1d39a38663a9937a3cc0572953ed4ebe00e4b8833012b7b243842ff817f1",
       "urls": [
-        "bzzr://d14baa1f28a1c06b6f4042abb5adcfa05c66aaaaed3492d0b5f6361a104f7b7b"
+        "bzzr://d14baa1f28a1c06b6f4042abb5adcfa05c66aaaaed3492d0b5f6361a104f7b7b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.13-nightly.2017.7.5+commit.2b505e7a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.13-nightly.2017.7.5+commit.2b505e7a.js"
       ]
     },
     {
@@ -3683,9 +4694,12 @@
       "prerelease": "nightly.2017.7.6",
       "build": "commit.40d4ee49",
       "longVersion": "0.4.13-nightly.2017.7.6+commit.40d4ee49",
+      "sha256": "0x611924301e223543719953f77c5ffb86c5cb41bc481bdfdffe35e087812791b6",
       "keccak256": "0x5c280582a7e7c443948b49fc8772861308eca13c2aa4a4ad9511af83b7556de0",
       "urls": [
-        "bzzr://43ff7b42df2ea5ec21b51da9e2fdfc146938b886069c562ebcd71cf3be8df849"
+        "bzzr://43ff7b42df2ea5ec21b51da9e2fdfc146938b886069c562ebcd71cf3be8df849",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.13-nightly.2017.7.6+commit.40d4ee49.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.13-nightly.2017.7.6+commit.40d4ee49.js"
       ]
     },
     {
@@ -3693,9 +4707,12 @@
       "version": "0.4.13",
       "build": "commit.fb4cb1a",
       "longVersion": "0.4.13+commit.fb4cb1a",
+      "sha256": "0xf359e1a7d60cd6259caa91a641e29d99faf97a47d7e75318516196248fdbf862",
       "keccak256": "0xbeaf9919ff94d1e339187d97290ed45bf4d6b87a8efc6e9435317f3be35b76de",
       "urls": [
-        "bzzr://c8bd3b51963b90d0c76daa19ef2f966a28b5bf3849cf26c4c3b2f5c48e9c5b52"
+        "bzzr://c8bd3b51963b90d0c76daa19ef2f966a28b5bf3849cf26c4c3b2f5c48e9c5b52",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.13+commit.fb4cb1a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.13+commit.fb4cb1a.js"
       ]
     },
     {
@@ -3704,9 +4721,12 @@
       "prerelease": "nightly.2017.7.6",
       "build": "commit.8dade9f",
       "longVersion": "0.4.14-nightly.2017.7.6+commit.8dade9f",
+      "sha256": "0xfc780ba581708b82a99d04bec17451c1bc884fcfd86d9df6900ba4c8f47d2348",
       "keccak256": "0x63b6d23a97022b6246a756fd3d261ebf81b3c3949268c58c9774422ef0c4fb20",
       "urls": [
-        "bzzr://956d6a4cc848ef5c380217415f11a9aa4ef1da292f577c166d9ac1664281afb2"
+        "bzzr://956d6a4cc848ef5c380217415f11a9aa4ef1da292f577c166d9ac1664281afb2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.6+commit.8dade9f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.6+commit.8dade9f.js"
       ]
     },
     {
@@ -3715,9 +4735,12 @@
       "prerelease": "nightly.2017.7.8",
       "build": "commit.7d1ddfc6",
       "longVersion": "0.4.14-nightly.2017.7.8+commit.7d1ddfc6",
+      "sha256": "0x52573c107dfc51a2ff3cc6b74fbe9adac95959aef0593d1a2536f923a24e3bf6",
       "keccak256": "0x1c92f5eee1796f36ba400ca02c5a9777a76330b7b10eae2d732aa97590842f4e",
       "urls": [
-        "bzzr://d4b962455e1249c270148dd565dbba79413c345fbcadb9f52f76bb7531789186"
+        "bzzr://d4b962455e1249c270148dd565dbba79413c345fbcadb9f52f76bb7531789186",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.8+commit.7d1ddfc6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.8+commit.7d1ddfc6.js"
       ]
     },
     {
@@ -3726,9 +4749,12 @@
       "prerelease": "nightly.2017.7.9",
       "build": "commit.aafcc360",
       "longVersion": "0.4.14-nightly.2017.7.9+commit.aafcc360",
+      "sha256": "0xc0b41b85e8a18f0cc98697c71f7135c824898061346ab68bdfa3262a9b02d2b6",
       "keccak256": "0xbf8b3763e4acf72edc3e194528c9e0072886d77d80dd4705719c8c182a5a83fa",
       "urls": [
-        "bzzr://3a3e0f7c2d6945b6e8105811c5e9b8772b6aaa55d694fb9a1c3f56783f8333e6"
+        "bzzr://3a3e0f7c2d6945b6e8105811c5e9b8772b6aaa55d694fb9a1c3f56783f8333e6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.9+commit.aafcc360.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.9+commit.aafcc360.js"
       ]
     },
     {
@@ -3737,9 +4763,12 @@
       "prerelease": "nightly.2017.7.10",
       "build": "commit.6fa5d47f",
       "longVersion": "0.4.14-nightly.2017.7.10+commit.6fa5d47f",
+      "sha256": "0xf857a9c8f89968df8fba7403ab95dd1bfcecdf205559567da199b19cfa320e3c",
       "keccak256": "0x16ce67785cd4cf90ffd12da8e19afa86f5658a26c9f906e597b9dbc8e63ccb9a",
       "urls": [
-        "bzzr://f3d4f03f1aa222d06bcba0fb7d092374dfec57cb297df4b28b17f886c90eaa40"
+        "bzzr://f3d4f03f1aa222d06bcba0fb7d092374dfec57cb297df4b28b17f886c90eaa40",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.10+commit.6fa5d47f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.10+commit.6fa5d47f.js"
       ]
     },
     {
@@ -3748,9 +4777,12 @@
       "prerelease": "nightly.2017.7.11",
       "build": "commit.b17ff1b",
       "longVersion": "0.4.14-nightly.2017.7.11+commit.b17ff1b",
+      "sha256": "0xce3e78c84dcae0ed917907622a46301308a766d8d0761338fa9be30f6f89191f",
       "keccak256": "0x10c984bf673032e43f4af05000ca3d3937741bcd9525fc2ba092b27e21350347",
       "urls": [
-        "bzzr://d43c996f3b07f06b4416965de973ad085e60ecf12060fd7d3c79ea1ba463a259"
+        "bzzr://d43c996f3b07f06b4416965de973ad085e60ecf12060fd7d3c79ea1ba463a259",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.11+commit.b17ff1b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.11+commit.b17ff1b.js"
       ]
     },
     {
@@ -3759,9 +4791,12 @@
       "prerelease": "nightly.2017.7.12",
       "build": "commit.b981ef20",
       "longVersion": "0.4.14-nightly.2017.7.12+commit.b981ef20",
+      "sha256": "0xe75dfe4b07a8a7507a3d49118f51c2c86bf577acb7397e5f2040d0d49108c44c",
       "keccak256": "0xced2bc71cb62a2a1d67184a3fc7218140dbaf292aa3d3e25c5af2759eda986bb",
       "urls": [
-        "bzzr://6f00fbb534ad352e5e39cd0e5e81adbb1d25307de00a103b36fc18e9599c6b5a"
+        "bzzr://6f00fbb534ad352e5e39cd0e5e81adbb1d25307de00a103b36fc18e9599c6b5a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.12+commit.b981ef20.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.12+commit.b981ef20.js"
       ]
     },
     {
@@ -3770,9 +4805,12 @@
       "prerelease": "nightly.2017.7.13",
       "build": "commit.2b33e0bc",
       "longVersion": "0.4.14-nightly.2017.7.13+commit.2b33e0bc",
+      "sha256": "0xcf5943efab73dfda55641c743514440b6245883a79b9e9ad0301f239b1592b9c",
       "keccak256": "0xa35a06bd5e726cb781f95908799019ed911e1fe7ad4a8bc32bcea81f998a4bd8",
       "urls": [
-        "bzzr://ca27a1103305a2ce56b0d44b9fab57dbfdb2c1a863aba3caa1c1422f081201a8"
+        "bzzr://ca27a1103305a2ce56b0d44b9fab57dbfdb2c1a863aba3caa1c1422f081201a8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.13+commit.2b33e0bc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.13+commit.2b33e0bc.js"
       ]
     },
     {
@@ -3781,9 +4819,12 @@
       "prerelease": "nightly.2017.7.14",
       "build": "commit.7c97546f",
       "longVersion": "0.4.14-nightly.2017.7.14+commit.7c97546f",
+      "sha256": "0x21fdf2893d7b5a69a126a8016633af80e12af503a8199350ea81d20f0b2ec4a3",
       "keccak256": "0xb8d9b384acce988ab469f21b86635bfcf863464861248fbe7fb606e1f99b6b46",
       "urls": [
-        "bzzr://b307bea18c41236a6e5e7165a7cba2a471d3e45e2c2e6bc3ce32547ebe094756"
+        "bzzr://b307bea18c41236a6e5e7165a7cba2a471d3e45e2c2e6bc3ce32547ebe094756",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.14+commit.7c97546f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.14+commit.7c97546f.js"
       ]
     },
     {
@@ -3792,9 +4833,12 @@
       "prerelease": "nightly.2017.7.18",
       "build": "commit.c167a31b",
       "longVersion": "0.4.14-nightly.2017.7.18+commit.c167a31b",
+      "sha256": "0x9b17778a7d64d731cacfba11551946ce23353acc0e07ea9b762dedfe17b1c423",
       "keccak256": "0xe5cd15e4d87a00e6ee7c316a71ea15d98a78434e65eca41f8132ccf058ee08a3",
       "urls": [
-        "bzzr://300e5d57343cee348aa09401a4b80921e7a4a5d7710641062704792fd72eaf68"
+        "bzzr://300e5d57343cee348aa09401a4b80921e7a4a5d7710641062704792fd72eaf68",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.18+commit.c167a31b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.18+commit.c167a31b.js"
       ]
     },
     {
@@ -3803,9 +4847,12 @@
       "prerelease": "nightly.2017.7.19",
       "build": "commit.3ad326be",
       "longVersion": "0.4.14-nightly.2017.7.19+commit.3ad326be",
+      "sha256": "0x5aeab72c94108527f05aa19fb1386cd4dc4cfbbff8eec66493b63d0f685233c7",
       "keccak256": "0x40b2a4be6694b9db98542e4a2c4c2672a03c8199fb576e755e2e5e6ac233358a",
       "urls": [
-        "bzzr://9bfd5c909d53a66c73ae9333fa9aa2bf2da47a2459388f96c592c15503c46d46"
+        "bzzr://9bfd5c909d53a66c73ae9333fa9aa2bf2da47a2459388f96c592c15503c46d46",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.19+commit.3ad326be.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.19+commit.3ad326be.js"
       ]
     },
     {
@@ -3814,9 +4861,12 @@
       "prerelease": "nightly.2017.7.20",
       "build": "commit.d70974ea",
       "longVersion": "0.4.14-nightly.2017.7.20+commit.d70974ea",
+      "sha256": "0x7dffc4b8038902ca8a5fbef0ed18ed689d570d269bc1796a7ebf17824fbd48fb",
       "keccak256": "0xd6f2f5565e897bff40aab1aabe26627c223ebaa2fc3208aace7ed99cc76c5b48",
       "urls": [
-        "bzzr://903e0aab35348928b4694a294c8c61aad558fcbc6d086a680b1e3ead9ae53bc6"
+        "bzzr://903e0aab35348928b4694a294c8c61aad558fcbc6d086a680b1e3ead9ae53bc6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.20+commit.d70974ea.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.20+commit.d70974ea.js"
       ]
     },
     {
@@ -3825,9 +4875,12 @@
       "prerelease": "nightly.2017.7.21",
       "build": "commit.75b48616",
       "longVersion": "0.4.14-nightly.2017.7.21+commit.75b48616",
+      "sha256": "0xfb1d836a944b5c1a1936119215c13140c1c9c4bbffba29c013d5151a9706ca84",
       "keccak256": "0xc7050009ead8d5e342c0abd753be3d94c275363c132ba9591284425672d1c60b",
       "urls": [
-        "bzzr://90dc3bf643d95d7e99a1c748a5d71b2f814fa7d5c40caf49f4362d8ecf64d860"
+        "bzzr://90dc3bf643d95d7e99a1c748a5d71b2f814fa7d5c40caf49f4362d8ecf64d860",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.21+commit.75b48616.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.21+commit.75b48616.js"
       ]
     },
     {
@@ -3836,9 +4889,12 @@
       "prerelease": "nightly.2017.7.24",
       "build": "commit.cfb11ff7",
       "longVersion": "0.4.14-nightly.2017.7.24+commit.cfb11ff7",
+      "sha256": "0x4d6955e1eed7deb07001eeeffe7121cd456e3c392f64e865f2393cb146646b43",
       "keccak256": "0xe8651f23478fa1c8d2d67655fe0da4dd99606caed9284c4ccc432ebbf7b183fd",
       "urls": [
-        "bzzr://f4c32fc63b1e3401b56cdbf77757bb8baccde042f49f5c461012c5ef20d3212c"
+        "bzzr://f4c32fc63b1e3401b56cdbf77757bb8baccde042f49f5c461012c5ef20d3212c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.24+commit.cfb11ff7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.24+commit.cfb11ff7.js"
       ]
     },
     {
@@ -3847,9 +4903,12 @@
       "prerelease": "nightly.2017.7.25",
       "build": "commit.3c2b710b",
       "longVersion": "0.4.14-nightly.2017.7.25+commit.3c2b710b",
+      "sha256": "0xab6014ad53913b50d752d424d4e97422aa80b861a7dd0ab3528a08ec45093b17",
       "keccak256": "0xa334b5e85e431f21c4a8076d2e3070e1a27501b12b523743c62a9030b9b21009",
       "urls": [
-        "bzzr://4449c6e01fcd93df2ec26de67d18148a7f3b817222409790e3183e440511bec0"
+        "bzzr://4449c6e01fcd93df2ec26de67d18148a7f3b817222409790e3183e440511bec0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.25+commit.3c2b710b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.25+commit.3c2b710b.js"
       ]
     },
     {
@@ -3858,9 +4917,12 @@
       "prerelease": "nightly.2017.7.26",
       "build": "commit.d701c94",
       "longVersion": "0.4.14-nightly.2017.7.26+commit.d701c94",
+      "sha256": "0xe1d4ac60aa19077da2646a91338333fa4674627e19eb52d4e194ec9ac67dfc3b",
       "keccak256": "0xa3d8441e1bf173f258489b346a23b2a2537c6b6f48d98cb5fd452a9469a2e096",
       "urls": [
-        "bzzr://1d7bf68f6c7dd3732893019b362e39bd6a2c449939a26899b2a571122519b9fe"
+        "bzzr://1d7bf68f6c7dd3732893019b362e39bd6a2c449939a26899b2a571122519b9fe",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.26+commit.d701c94.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.26+commit.d701c94.js"
       ]
     },
     {
@@ -3869,9 +4931,12 @@
       "prerelease": "nightly.2017.7.27",
       "build": "commit.1298a8df",
       "longVersion": "0.4.14-nightly.2017.7.27+commit.1298a8df",
+      "sha256": "0xa633dd2d04697764baa0273318f30a74cf930371333995d6b15cd18746564c4e",
       "keccak256": "0x676d328a9388f2efb95649fe9dcfa612528c4b66c06ecae184beb72938f9612a",
       "urls": [
-        "bzzr://17589f5a1b619e9652ee9997b3570bcae4b9690a4ac39aa81c31b9f474119f6b"
+        "bzzr://17589f5a1b619e9652ee9997b3570bcae4b9690a4ac39aa81c31b9f474119f6b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.27+commit.1298a8df.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.27+commit.1298a8df.js"
       ]
     },
     {
@@ -3880,9 +4945,12 @@
       "prerelease": "nightly.2017.7.28",
       "build": "commit.7e40def6",
       "longVersion": "0.4.14-nightly.2017.7.28+commit.7e40def6",
+      "sha256": "0x6c99cd6d642a1eaa6201e40ea9df9e30a7bdf7ed40e4d75b3dbcc4fff67a5a74",
       "keccak256": "0x78248f50bcf191822a49dcc52d4ae67f90ece38ecb78e7791f6ae946f0e493d5",
       "urls": [
-        "bzzr://08080076abc848d6cf0cbe6f9f3381c6af86fe2fba9c3ab12aa806ddb025d5f7"
+        "bzzr://08080076abc848d6cf0cbe6f9f3381c6af86fe2fba9c3ab12aa806ddb025d5f7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.28+commit.7e40def6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.28+commit.7e40def6.js"
       ]
     },
     {
@@ -3891,9 +4959,12 @@
       "prerelease": "nightly.2017.7.31",
       "build": "commit.22326189",
       "longVersion": "0.4.14-nightly.2017.7.31+commit.22326189",
+      "sha256": "0x868bb52b5932b6e47fc1e08f5463341f379f91ce12babb8fd011c004febaba24",
       "keccak256": "0xa9ebc613d4a89abe9224d1262d42b11787e8ab8742a8727bbeceaa2d5ce0d133",
       "urls": [
-        "bzzr://79238d491e84955acf997518d2bf60ebf2313ad581bd348e7ddbfbed81ed2c2f"
+        "bzzr://79238d491e84955acf997518d2bf60ebf2313ad581bd348e7ddbfbed81ed2c2f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14-nightly.2017.7.31+commit.22326189.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14-nightly.2017.7.31+commit.22326189.js"
       ]
     },
     {
@@ -3901,9 +4972,12 @@
       "version": "0.4.14",
       "build": "commit.c2215d46",
       "longVersion": "0.4.14+commit.c2215d46",
+      "sha256": "0x83cbe2d5eea94bb7c37ad2f4f9827a67c133852468f8d7c69ea72b9bde0d4b48",
       "keccak256": "0x3dc0900782c03e034959cf33b5c5784265ed6e9daaa101b653f2038c2b12ac4c",
       "urls": [
-        "bzzr://6b69ee5d38284e52a0cc5d8f14c30b4ecc234fba2d77a4124a1f80f3bc5ed8ae"
+        "bzzr://6b69ee5d38284e52a0cc5d8f14c30b4ecc234fba2d77a4124a1f80f3bc5ed8ae",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.14+commit.c2215d46.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.14+commit.c2215d46.js"
       ]
     },
     {
@@ -3912,9 +4986,12 @@
       "prerelease": "nightly.2017.7.31",
       "build": "commit.93f90eb2",
       "longVersion": "0.4.15-nightly.2017.7.31+commit.93f90eb2",
+      "sha256": "0xe8bc1807d075a0058ec5cae275e2586b0332f8008bb8696df326dfe7f000587e",
       "keccak256": "0x66661e0c3954f25a1cbd863d5fe08eb7ae4078a4e3180d1e0fd38f8dedf7af1a",
       "urls": [
-        "bzzr://22269fd15125cbcfd141a811efffeba5afbd7b5b005757d16c6cd22b3b105aad"
+        "bzzr://22269fd15125cbcfd141a811efffeba5afbd7b5b005757d16c6cd22b3b105aad",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15-nightly.2017.7.31+commit.93f90eb2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15-nightly.2017.7.31+commit.93f90eb2.js"
       ]
     },
     {
@@ -3923,9 +5000,12 @@
       "prerelease": "nightly.2017.8.1",
       "build": "commit.7e07eb6e",
       "longVersion": "0.4.15-nightly.2017.8.1+commit.7e07eb6e",
+      "sha256": "0x568969cfc662c57a9122c21115dda54b6f033fab0b1b703f763deb0977a5a791",
       "keccak256": "0xcf2856bd4125ab8991ebc07d88b68b2ce94336ded54d394faa09b2d23253ff3c",
       "urls": [
-        "bzzr://3959762c33eabf268ad9e5a2eb469de360daa3f42f8a8fcd21e1832d5917c33d"
+        "bzzr://3959762c33eabf268ad9e5a2eb469de360daa3f42f8a8fcd21e1832d5917c33d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15-nightly.2017.8.1+commit.7e07eb6e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15-nightly.2017.8.1+commit.7e07eb6e.js"
       ]
     },
     {
@@ -3934,9 +5014,12 @@
       "prerelease": "nightly.2017.8.2",
       "build": "commit.4166ce1",
       "longVersion": "0.4.15-nightly.2017.8.2+commit.4166ce1",
+      "sha256": "0xb47a4376a3fecdeb3c16ac8901e306e24b9db4730d5301a90eafcbc2bad56c12",
       "keccak256": "0xfdf5ad170888daf701b640093c1f29f619af567c1fb8388a2509174004574dbe",
       "urls": [
-        "bzzr://8532bdb22615fd5ce150b7e5273417bf6df37f03a0d4e8feb6c657d5be887f11"
+        "bzzr://8532bdb22615fd5ce150b7e5273417bf6df37f03a0d4e8feb6c657d5be887f11",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15-nightly.2017.8.2+commit.4166ce1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15-nightly.2017.8.2+commit.4166ce1.js"
       ]
     },
     {
@@ -3945,9 +5028,12 @@
       "prerelease": "nightly.2017.8.4",
       "build": "commit.e48730fe",
       "longVersion": "0.4.15-nightly.2017.8.4+commit.e48730fe",
+      "sha256": "0xbe615ba9c55b40f10c61e93313998ada421d20704208d2e69d171e66a7e09998",
       "keccak256": "0xf839140a37e819995430f5accc898c38700a795aff043b761ee75a77be723043",
       "urls": [
-        "bzzr://72439840a33a990b7800da33e74481f0838bb5b32d4cf5e13b8ec69d1d60923b"
+        "bzzr://72439840a33a990b7800da33e74481f0838bb5b32d4cf5e13b8ec69d1d60923b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15-nightly.2017.8.4+commit.e48730fe.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15-nightly.2017.8.4+commit.e48730fe.js"
       ]
     },
     {
@@ -3956,9 +5042,12 @@
       "prerelease": "nightly.2017.8.7",
       "build": "commit.212454a9",
       "longVersion": "0.4.15-nightly.2017.8.7+commit.212454a9",
+      "sha256": "0x21af3c8e6d8e28f44271d360fda055b59925da68176fb0b29d958a4e585b4cc1",
       "keccak256": "0x2285d48c0b390c4a0bebbf389b0b41f849ab85305548f70d2cced4a286f3b88b",
       "urls": [
-        "bzzr://7a042cf77acad01dc5a042f5088fd256f197c5827ea9a7c118bc6ae14e5a5744"
+        "bzzr://7a042cf77acad01dc5a042f5088fd256f197c5827ea9a7c118bc6ae14e5a5744",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15-nightly.2017.8.7+commit.212454a9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15-nightly.2017.8.7+commit.212454a9.js"
       ]
     },
     {
@@ -3967,9 +5056,12 @@
       "prerelease": "nightly.2017.8.8",
       "build": "commit.41e72436",
       "longVersion": "0.4.15-nightly.2017.8.8+commit.41e72436",
+      "sha256": "0x9460991ba898231396237105f795959b80dada5bbf632b95374000abfb86558e",
       "keccak256": "0x0999516efe3123ae5a8b2d1aa57519e6585165e3e6f7fc039d5c23cecd0f93ca",
       "urls": [
-        "bzzr://3a444131bc9e1a0c8d3f590a3d7a4908c86cda220bb61a23a05c5d3894c040dd"
+        "bzzr://3a444131bc9e1a0c8d3f590a3d7a4908c86cda220bb61a23a05c5d3894c040dd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15-nightly.2017.8.8+commit.41e72436.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15-nightly.2017.8.8+commit.41e72436.js"
       ]
     },
     {
@@ -3977,9 +5069,12 @@
       "version": "0.4.15",
       "build": "commit.bbb8e64f",
       "longVersion": "0.4.15+commit.bbb8e64f",
+      "sha256": "0x6e81a09fdf1c630b51a3d7ede35a828f02be2e3ed53d97d361267bc915d774ff",
       "keccak256": "0x4e9f4990d124fa4194a7c06006185d262cd19c47aef9b8a153a688ece674f11b",
       "urls": [
-        "bzzr://fd5e4ed25921655527030d42c49ec1ff5e638ec1d151c81978f9291405920141"
+        "bzzr://fd5e4ed25921655527030d42c49ec1ff5e638ec1d151c81978f9291405920141",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.15+commit.bbb8e64f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.15+commit.bbb8e64f.js"
       ]
     },
     {
@@ -3988,9 +5083,12 @@
       "prerelease": "nightly.2017.8.9",
       "build": "commit.81887bc7",
       "longVersion": "0.4.16-nightly.2017.8.9+commit.81887bc7",
+      "sha256": "0x43836089bafe86343f6b6899eecbf0a46d10bda37916fb88c3714083c037341b",
       "keccak256": "0x6ccab19bfed36cc956fb78c5345bfdfb2f61e68c77c576fd4fd58fd0a51e7fe8",
       "urls": [
-        "bzzr://9a0e07d1117f5ea7f72e5aed8ad64427bc5291c7469af65dac7d4d2075337598"
+        "bzzr://9a0e07d1117f5ea7f72e5aed8ad64427bc5291c7469af65dac7d4d2075337598",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.9+commit.81887bc7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.9+commit.81887bc7.js"
       ]
     },
     {
@@ -3999,9 +5097,12 @@
       "prerelease": "nightly.2017.8.10",
       "build": "commit.41e3cbe0",
       "longVersion": "0.4.16-nightly.2017.8.10+commit.41e3cbe0",
+      "sha256": "0x1840808055f08ada82dd73043c42ee8f6ff267c8c52d1076b4c9a72a38e45924",
       "keccak256": "0xbf78cf8b6f718cc2e1fe0654817b7585b0a549b21ce0029795a4709e2bd3df64",
       "urls": [
-        "bzzr://271b1b93e86155b184e8c934f2b7f061359c9e4890e39f5ede175e67467fbff9"
+        "bzzr://271b1b93e86155b184e8c934f2b7f061359c9e4890e39f5ede175e67467fbff9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.10+commit.41e3cbe0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.10+commit.41e3cbe0.js"
       ]
     },
     {
@@ -4010,9 +5111,12 @@
       "prerelease": "nightly.2017.8.11",
       "build": "commit.c84de7fa",
       "longVersion": "0.4.16-nightly.2017.8.11+commit.c84de7fa",
+      "sha256": "0x308954d8a741266404c85e56f89c153d089969efd38015b5796b5ce345a61bbe",
       "keccak256": "0x13b5c84092e72e58e56f4f279565e109d2102a9186db56e9f2845b983c78f282",
       "urls": [
-        "bzzr://47ca38fe5104f09bb85ab95faaac478f5fb30d69978f1abd9ab94b755dc19baa"
+        "bzzr://47ca38fe5104f09bb85ab95faaac478f5fb30d69978f1abd9ab94b755dc19baa",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.11+commit.c84de7fa.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.11+commit.c84de7fa.js"
       ]
     },
     {
@@ -4021,9 +5125,12 @@
       "prerelease": "nightly.2017.8.14",
       "build": "commit.4d9790b6",
       "longVersion": "0.4.16-nightly.2017.8.14+commit.4d9790b6",
+      "sha256": "0xac2bfb0345c25e2bb36eb68c67c79539e62ccf0ccda0a2e6125df0efad915cf0",
       "keccak256": "0xbf86a60250d6c27e024bda2373134ac972c3d9ac9d9857c6574e32c5febb0bda",
       "urls": [
-        "bzzr://2f45ed7fdb9a2b825be4f6179213515e7979cc617a60f946de780dc1172c6231"
+        "bzzr://2f45ed7fdb9a2b825be4f6179213515e7979cc617a60f946de780dc1172c6231",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.14+commit.4d9790b6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.14+commit.4d9790b6.js"
       ]
     },
     {
@@ -4032,9 +5139,12 @@
       "prerelease": "nightly.2017.8.15",
       "build": "commit.dca1f45c",
       "longVersion": "0.4.16-nightly.2017.8.15+commit.dca1f45c",
+      "sha256": "0xaf49982d37555a08d08472ccf26c3a5fe130a9f2b47bbff0aee4c4e19de0e6c8",
       "keccak256": "0x9193a7fc34b90eee5bcc81e9b3f64b057a9c456d836364d1a462ef9016485cad",
       "urls": [
-        "bzzr://07f07fba8cbc9b89d325e8d508b15c0dfb3d59e20170f6b4fa84e3fa7220e45f"
+        "bzzr://07f07fba8cbc9b89d325e8d508b15c0dfb3d59e20170f6b4fa84e3fa7220e45f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.15+commit.dca1f45c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.15+commit.dca1f45c.js"
       ]
     },
     {
@@ -4043,9 +5153,12 @@
       "prerelease": "nightly.2017.8.16",
       "build": "commit.83561e13",
       "longVersion": "0.4.16-nightly.2017.8.16+commit.83561e13",
+      "sha256": "0x47ae7a46c65ecd1782dfc6b2d22051745e804353d7449554c50240313edafe12",
       "keccak256": "0x4a1fe6c87abbf964e0b864b72b61ed04d8e75c560660034a70f5fee41c9513e6",
       "urls": [
-        "bzzr://2e05375e1414d0a1beba3474b5f884544ab3b2d5af3f7ba929f042159db98b06"
+        "bzzr://2e05375e1414d0a1beba3474b5f884544ab3b2d5af3f7ba929f042159db98b06",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.16+commit.83561e13.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.16+commit.83561e13.js"
       ]
     },
     {
@@ -4054,9 +5167,12 @@
       "prerelease": "nightly.2017.8.21",
       "build": "commit.cf60488",
       "longVersion": "0.4.16-nightly.2017.8.21+commit.cf60488",
+      "sha256": "0x6b156c549032c7f1360cb08b14ce8c1bc0684419a38289929a2187bd09700aa8",
       "keccak256": "0x8928a0df8034c75d1f96005c041755b5f53f01787f16f10031788daed02e8ade",
       "urls": [
-        "bzzr://e1a6df9b8a9c4dc9eff319655e191aeb6759899bc59792f094055691377426b8"
+        "bzzr://e1a6df9b8a9c4dc9eff319655e191aeb6759899bc59792f094055691377426b8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.21+commit.cf60488.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.21+commit.cf60488.js"
       ]
     },
     {
@@ -4065,9 +5181,12 @@
       "prerelease": "nightly.2017.8.22",
       "build": "commit.f874fc28",
       "longVersion": "0.4.16-nightly.2017.8.22+commit.f874fc28",
+      "sha256": "0xce51184a83757993e0d5af77846f7340a29b4548c146490f50aa2c8b814c37ff",
       "keccak256": "0x7c8b229aedf2b6dfc4703b443b8d70303b6d7a8c7aa9e58b1b0935ffe17e79de",
       "urls": [
-        "bzzr://a1f6d53e1f897d084310930520e6d99ceb45e56b453b108b9047c043992315f4"
+        "bzzr://a1f6d53e1f897d084310930520e6d99ceb45e56b453b108b9047c043992315f4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.22+commit.f874fc28.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.22+commit.f874fc28.js"
       ]
     },
     {
@@ -4076,9 +5195,12 @@
       "prerelease": "nightly.2017.8.23",
       "build": "commit.c5f11d93",
       "longVersion": "0.4.16-nightly.2017.8.23+commit.c5f11d93",
+      "sha256": "0x3b4c0b91d992ed11974a9558e2a37663309e09aef3452acf3ffaf4fa29f759ef",
       "keccak256": "0x39ec6359ff78907e1bdadd13988482a9c17a48cd9393c7ba97972b7687e2fb66",
       "urls": [
-        "bzzr://469a82fcb6847d839765be8855ba330df9978ffc7c056e40980d95c2dccc5333"
+        "bzzr://469a82fcb6847d839765be8855ba330df9978ffc7c056e40980d95c2dccc5333",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.23+commit.c5f11d93.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.23+commit.c5f11d93.js"
       ]
     },
     {
@@ -4087,9 +5209,12 @@
       "prerelease": "nightly.2017.8.24",
       "build": "commit.78c2dcac",
       "longVersion": "0.4.16-nightly.2017.8.24+commit.78c2dcac",
+      "sha256": "0x2184a1a27ec7b2b5b7988159989c0be0145a43c6a9fa3a229f89ee32f3ae2490",
       "keccak256": "0x073603ba717fc6a3b73b9243b663b56b63555a550af582b004f69b097adf359f",
       "urls": [
-        "bzzr://25254e42db18fb06b25ac38e630c4a9b55abe90a04b0bd95e8fb170e9852c5fa"
+        "bzzr://25254e42db18fb06b25ac38e630c4a9b55abe90a04b0bd95e8fb170e9852c5fa",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16-nightly.2017.8.24+commit.78c2dcac.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16-nightly.2017.8.24+commit.78c2dcac.js"
       ]
     },
     {
@@ -4097,9 +5222,12 @@
       "version": "0.4.16",
       "build": "commit.d7661dd9",
       "longVersion": "0.4.16+commit.d7661dd9",
+      "sha256": "0x6ebd370d42785bf3a3523b798d85b53711a0f7766c82a465420f67bf403bdd38",
       "keccak256": "0xffecfa33abaaa5c998672c7557947149b25b1e6d8c952fdc3f34fb50620ec100",
       "urls": [
-        "bzzr://f42d52773526513cdbae2eab0a8c6ba2f87e3208c4950d7125b39dfbfa12c474"
+        "bzzr://f42d52773526513cdbae2eab0a8c6ba2f87e3208c4950d7125b39dfbfa12c474",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.16+commit.d7661dd9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.16+commit.d7661dd9.js"
       ]
     },
     {
@@ -4108,9 +5236,12 @@
       "prerelease": "nightly.2017.8.24",
       "build": "commit.12d9f79",
       "longVersion": "0.4.17-nightly.2017.8.24+commit.12d9f79",
+      "sha256": "0x5d0dd0e79263e2e9746c8360fb0916cfa94b9b4f4aba1f8b93a26ae5896c777e",
       "keccak256": "0x32646b9823beb407b835a4a5c86736fdbd1da5cf46e4fae3657dd5686e7202d2",
       "urls": [
-        "bzzr://d6a08efd666e53763baef4aa83ba8f33fcf065f4735cd2b8de04b8463e4aa494"
+        "bzzr://d6a08efd666e53763baef4aa83ba8f33fcf065f4735cd2b8de04b8463e4aa494",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.8.24+commit.12d9f79.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.8.24+commit.12d9f79.js"
       ]
     },
     {
@@ -4119,9 +5250,12 @@
       "prerelease": "nightly.2017.8.25",
       "build": "commit.e945f458",
       "longVersion": "0.4.17-nightly.2017.8.25+commit.e945f458",
+      "sha256": "0x3df48f3e0079e5f293805a1b79f7f29dde2dd4daea74735779a7de55c0b4f25a",
       "keccak256": "0xda4cf2ddd866b86a25588304f77d4781b28f32107f81c03e873a2770fb938e37",
       "urls": [
-        "bzzr://0ebc98817b217b4a61584eb536ee8c640aa2ddfe6843883c35adfc18c38608ca"
+        "bzzr://0ebc98817b217b4a61584eb536ee8c640aa2ddfe6843883c35adfc18c38608ca",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.8.25+commit.e945f458.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.8.25+commit.e945f458.js"
       ]
     },
     {
@@ -4130,9 +5264,12 @@
       "prerelease": "nightly.2017.8.28",
       "build": "commit.d15cde2a",
       "longVersion": "0.4.17-nightly.2017.8.28+commit.d15cde2a",
+      "sha256": "0xe90d0509f6fb3188c64bf001549b356a095e563011fe49df2589577274b51b5d",
       "keccak256": "0x1d2a10d66c848c2c88df2c398bf92a94d104e069242e3201d3c86249628f845f",
       "urls": [
-        "bzzr://089ad4dc3fb0047644956ce60519de1a5eccffb554b73545b56f0940d7aa0721"
+        "bzzr://089ad4dc3fb0047644956ce60519de1a5eccffb554b73545b56f0940d7aa0721",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.8.28+commit.d15cde2a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.8.28+commit.d15cde2a.js"
       ]
     },
     {
@@ -4141,9 +5278,12 @@
       "prerelease": "nightly.2017.8.29",
       "build": "commit.2d39a42d",
       "longVersion": "0.4.17-nightly.2017.8.29+commit.2d39a42d",
+      "sha256": "0xf6544af791e7747e89698967791a0fbd7dee52107298503f92c8db960d291ad5",
       "keccak256": "0x087bee61ca2e779c815c5efc22d57f03e3773cd404c9f1f894726602dbefb8ed",
       "urls": [
-        "bzzr://8d328ebf8d486ceb9838bc3ee9510263595b4f63580d844db29c4d11eaed808d"
+        "bzzr://8d328ebf8d486ceb9838bc3ee9510263595b4f63580d844db29c4d11eaed808d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.8.29+commit.2d39a42d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.8.29+commit.2d39a42d.js"
       ]
     },
     {
@@ -4152,9 +5292,12 @@
       "prerelease": "nightly.2017.8.31",
       "build": "commit.402d6e71",
       "longVersion": "0.4.17-nightly.2017.8.31+commit.402d6e71",
+      "sha256": "0xca79be6bf3b1df06fbd0b02dba5f06a752034c2c1be374917e9768aa4622dc82",
       "keccak256": "0x32771950d3a03ef94153af28f4906291623625a91b0ccf841ee9aa31c80cf2fb",
       "urls": [
-        "bzzr://a6610c4c4826fb592f6d577c0946a0dc19cc873cff451d1226a435eeea64c6de"
+        "bzzr://a6610c4c4826fb592f6d577c0946a0dc19cc873cff451d1226a435eeea64c6de",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.8.31+commit.402d6e71.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.8.31+commit.402d6e71.js"
       ]
     },
     {
@@ -4163,9 +5306,12 @@
       "prerelease": "nightly.2017.9.4",
       "build": "commit.8283f836",
       "longVersion": "0.4.17-nightly.2017.9.4+commit.8283f836",
+      "sha256": "0x4e21f8e7201b3526c4d6de1105a414ce348aa5a294527ecc4383b8f9ee353e5f",
       "keccak256": "0xb2678ba42a82bfb7754372900b04c672418806c53993d5065367db26fbab195b",
       "urls": [
-        "bzzr://1439e5e833fbdd6149a460af5d677f5d96d193247ab665573af4e0e2722fafbc"
+        "bzzr://1439e5e833fbdd6149a460af5d677f5d96d193247ab665573af4e0e2722fafbc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.4+commit.8283f836.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.4+commit.8283f836.js"
       ]
     },
     {
@@ -4174,9 +5320,12 @@
       "prerelease": "nightly.2017.9.5",
       "build": "commit.f242331c",
       "longVersion": "0.4.17-nightly.2017.9.5+commit.f242331c",
+      "sha256": "0x89368d4e1e277b58071aac21d192219d66ea74769385d639e14fddc8ba58b09d",
       "keccak256": "0xf2d009e23901ef2fe47fec9c13bf43e8d254ce8137bc962bf1387ea4940650d3",
       "urls": [
-        "bzzr://089af9f9dab8b53199e3b55b58b873e9e0d24a2a86f713191c69368a58b6f0f7"
+        "bzzr://089af9f9dab8b53199e3b55b58b873e9e0d24a2a86f713191c69368a58b6f0f7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.5+commit.f242331c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.5+commit.f242331c.js"
       ]
     },
     {
@@ -4185,9 +5334,12 @@
       "prerelease": "nightly.2017.9.6",
       "build": "commit.59223061",
       "longVersion": "0.4.17-nightly.2017.9.6+commit.59223061",
+      "sha256": "0xefc16621c60594f33b5dbd9d01f2d5c4b70eafab5e634a1e4a9c6d4c3e147fa6",
       "keccak256": "0x966be33fb6140be87347e6e7a58bc57b226e02048849fee4bfe0e4b48089e46a",
       "urls": [
-        "bzzr://41d93f6c3e59b05252dadbd24e82ccf04c16b486b7cb2591b4261cb64ddccf83"
+        "bzzr://41d93f6c3e59b05252dadbd24e82ccf04c16b486b7cb2591b4261cb64ddccf83",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.6+commit.59223061.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.6+commit.59223061.js"
       ]
     },
     {
@@ -4196,9 +5348,12 @@
       "prerelease": "nightly.2017.9.11",
       "build": "commit.fbe24da1",
       "longVersion": "0.4.17-nightly.2017.9.11+commit.fbe24da1",
+      "sha256": "0x48333e6e6addca89a6613c0bd45218f5d7efc89e54c0b951f20cd1df0e72c44a",
       "keccak256": "0xd732466dfd42dc86ca3c03022b039fa4790bf67b6ec6c222c19be9adac0caf0a",
       "urls": [
-        "bzzr://704eb95325ed8ad8ec1e80738554d50bb90cc8bfbfeaf69227af62aef96c5ec1"
+        "bzzr://704eb95325ed8ad8ec1e80738554d50bb90cc8bfbfeaf69227af62aef96c5ec1",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.11+commit.fbe24da1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.11+commit.fbe24da1.js"
       ]
     },
     {
@@ -4207,9 +5362,12 @@
       "prerelease": "nightly.2017.9.12",
       "build": "commit.4770f8f4",
       "longVersion": "0.4.17-nightly.2017.9.12+commit.4770f8f4",
+      "sha256": "0x4a0ea70c12e228954d74f95781bef9e7748738c2b1de98aea4081446a5cb6ecf",
       "keccak256": "0x4f8e3f0e040bf4da8ee6491ed37447cf4737755a508599f8347392a3d6b2ee02",
       "urls": [
-        "bzzr://6f9d35d9d537dd47baacc14e84391e01c64bb4260bbc3e620fddfadb234ea0bc"
+        "bzzr://6f9d35d9d537dd47baacc14e84391e01c64bb4260bbc3e620fddfadb234ea0bc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.12+commit.4770f8f4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.12+commit.4770f8f4.js"
       ]
     },
     {
@@ -4218,9 +5376,12 @@
       "prerelease": "nightly.2017.9.14",
       "build": "commit.7dd372ce",
       "longVersion": "0.4.17-nightly.2017.9.14+commit.7dd372ce",
+      "sha256": "0x10cac42b259578f4945ee1a664cf649e8c31405d5cf2f55cafea931eda3a54dd",
       "keccak256": "0x5ec4cf12fb863997382482cfb546b93dd35d65a7bf2cf559d6956a4150f2f843",
       "urls": [
-        "bzzr://881b9042097ea90799eab7b5540eef4b12ae20929968be443c7ce3d91cfde0b5"
+        "bzzr://881b9042097ea90799eab7b5540eef4b12ae20929968be443c7ce3d91cfde0b5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.14+commit.7dd372ce.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.14+commit.7dd372ce.js"
       ]
     },
     {
@@ -4229,9 +5390,12 @@
       "prerelease": "nightly.2017.9.16",
       "build": "commit.a0d17172",
       "longVersion": "0.4.17-nightly.2017.9.16+commit.a0d17172",
+      "sha256": "0xd4868cbcdf87de523a395127e8c092c6735f1210fb5825e841c7f9b8b85261fd",
       "keccak256": "0x6f3924a1532246595b64df68c1501c4fa00372d17cd56cc7ed2fcc64d32801e8",
       "urls": [
-        "bzzr://2dfa95b68c259328201f89cf6a1dfa04b9302ca39252ff5c56fda932f3272391"
+        "bzzr://2dfa95b68c259328201f89cf6a1dfa04b9302ca39252ff5c56fda932f3272391",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.16+commit.a0d17172.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.16+commit.a0d17172.js"
       ]
     },
     {
@@ -4240,9 +5404,12 @@
       "prerelease": "nightly.2017.9.18",
       "build": "commit.c289fd3d",
       "longVersion": "0.4.17-nightly.2017.9.18+commit.c289fd3d",
+      "sha256": "0xa9f3b3052ecba20f89589bae48a5d8df4d3a82b5b5025f6110e636574d2c5fef",
       "keccak256": "0x0db2092e152864af8a0e34e0be54b263f4688134b5f30447b0c3da0384a7d99a",
       "urls": [
-        "bzzr://ee901e0938fa2c9e4fccfaaaf193b5fff22395b9e1a24044ef3b5b5f2fd7d2c2"
+        "bzzr://ee901e0938fa2c9e4fccfaaaf193b5fff22395b9e1a24044ef3b5b5f2fd7d2c2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.18+commit.c289fd3d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.18+commit.c289fd3d.js"
       ]
     },
     {
@@ -4251,9 +5418,12 @@
       "prerelease": "nightly.2017.9.19",
       "build": "commit.1fc71bd7",
       "longVersion": "0.4.17-nightly.2017.9.19+commit.1fc71bd7",
+      "sha256": "0x5814c115230eca659ae2b5adb803f7a12ec4c628efde902d725c170d0777589a",
       "keccak256": "0xf554bd5deeca50b9c9935fbc5bb3791325b0bfb5cf48eb9c891f68aac654ff27",
       "urls": [
-        "bzzr://e1ee94911a8eed12fa6c2cdb201845218d5ab536d464e05b08dedf651977d504"
+        "bzzr://e1ee94911a8eed12fa6c2cdb201845218d5ab536d464e05b08dedf651977d504",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.19+commit.1fc71bd7.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.19+commit.1fc71bd7.js"
       ]
     },
     {
@@ -4262,9 +5432,12 @@
       "prerelease": "nightly.2017.9.20",
       "build": "commit.c0b3e5b0",
       "longVersion": "0.4.17-nightly.2017.9.20+commit.c0b3e5b0",
+      "sha256": "0x43c94542d48b8755c1c3120502f8ff0b5c5061ffed4875a9656a5ff2412c6415",
       "keccak256": "0xd600038e6fb8483f6079a9b24d474ac22a9532e2b620b3203018f47e409aa591",
       "urls": [
-        "bzzr://1f9b460163beb8d4041b5148a9140ca4a9fb69fc814acb00c4d93960caad60ac"
+        "bzzr://1f9b460163beb8d4041b5148a9140ca4a9fb69fc814acb00c4d93960caad60ac",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.20+commit.c0b3e5b0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.20+commit.c0b3e5b0.js"
       ]
     },
     {
@@ -4273,9 +5446,12 @@
       "prerelease": "nightly.2017.9.21",
       "build": "commit.725b4fc2",
       "longVersion": "0.4.17-nightly.2017.9.21+commit.725b4fc2",
+      "sha256": "0xba0606bd758ba58099a4e955e71360dbdf96145cf23ac3f9c11cadc2399949e4",
       "keccak256": "0xe810004111bfab15f7d83cfef00648a35c5b549e57eeadbcfd046dd077d06835",
       "urls": [
-        "bzzr://d58ef91b868db4d8c414a0dc4240b5b7f21778aae7fd1a887a65ad537a01e717"
+        "bzzr://d58ef91b868db4d8c414a0dc4240b5b7f21778aae7fd1a887a65ad537a01e717",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17-nightly.2017.9.21+commit.725b4fc2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17-nightly.2017.9.21+commit.725b4fc2.js"
       ]
     },
     {
@@ -4283,9 +5459,12 @@
       "version": "0.4.17",
       "build": "commit.bdeb9e52",
       "longVersion": "0.4.17+commit.bdeb9e52",
+      "sha256": "0xa52d6dddca6c3df5a6364cc11f93a6dd1c58e38e8c740f27e39f98e43cdaafce",
       "keccak256": "0x53d76fdde235668fe06b519bc6378aa6c8eea249fefb9bf84232801bb8c5dcdc",
       "urls": [
-        "bzzr://8f0a94235a4a86bdf162270a3165570cba46e7d6646b84f6ed6bf857f9d1883c"
+        "bzzr://8f0a94235a4a86bdf162270a3165570cba46e7d6646b84f6ed6bf857f9d1883c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.17+commit.bdeb9e52.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.17+commit.bdeb9e52.js"
       ]
     },
     {
@@ -4294,9 +5473,12 @@
       "prerelease": "nightly.2017.9.22",
       "build": "commit.a2a58789",
       "longVersion": "0.4.18-nightly.2017.9.22+commit.a2a58789",
+      "sha256": "0x72f4464a3c2df6a8fcc8d7e4bab44b39ff87d9161d5f4e812e64c099cb5fff81",
       "keccak256": "0x22695892d6698150c63ade14cd66d2f13aa02c75aef29424b693fb8d95100880",
       "urls": [
-        "bzzr://157eb9b64dc3d2a7d9b3cbc8a823e6b7080ce77dec2e22a1059295eb36be2e61"
+        "bzzr://157eb9b64dc3d2a7d9b3cbc8a823e6b7080ce77dec2e22a1059295eb36be2e61",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.9.22+commit.a2a58789.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.9.22+commit.a2a58789.js"
       ]
     },
     {
@@ -4305,9 +5487,12 @@
       "prerelease": "nightly.2017.9.25",
       "build": "commit.a72237f2",
       "longVersion": "0.4.18-nightly.2017.9.25+commit.a72237f2",
+      "sha256": "0xaa47e2afc839a5d29ba75d7b3dc49788f6d131d58097dae487a37718a2a43ee3",
       "keccak256": "0xb25c92c73236a1436ba7257ff011bf3ee9940eeda37061925344a51cbd2a8dca",
       "urls": [
-        "bzzr://d1dd18a662b2ec8f9537df3c0d826ff7c0d8a5fd9ba1dbb748c03f697e1e4d35"
+        "bzzr://d1dd18a662b2ec8f9537df3c0d826ff7c0d8a5fd9ba1dbb748c03f697e1e4d35",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.9.25+commit.a72237f2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.9.25+commit.a72237f2.js"
       ]
     },
     {
@@ -4316,9 +5501,12 @@
       "prerelease": "nightly.2017.9.26",
       "build": "commit.eb5a6aac",
       "longVersion": "0.4.18-nightly.2017.9.26+commit.eb5a6aac",
+      "sha256": "0x791b2310629203c721b92fa70b8673f379b1ab610e0d618f9bf4c1c7516daed9",
       "keccak256": "0x791cb3900d34cf0feb1e61fb090a514b27d1524ba7f3f4ee96782c401faafcda",
       "urls": [
-        "bzzr://d349309f3ee5c6bd648ec054b581749a0bafd92d9b574f2bbd5125ce653cadd2"
+        "bzzr://d349309f3ee5c6bd648ec054b581749a0bafd92d9b574f2bbd5125ce653cadd2",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.9.26+commit.eb5a6aac.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.9.26+commit.eb5a6aac.js"
       ]
     },
     {
@@ -4327,9 +5515,12 @@
       "prerelease": "nightly.2017.9.27",
       "build": "commit.809d5ce1",
       "longVersion": "0.4.18-nightly.2017.9.27+commit.809d5ce1",
+      "sha256": "0x92c783f82e295082998f4418fa76fdd8233c7f052ff08e911a62fc0076651d1a",
       "keccak256": "0x3b99ad3c47b242b26f78b149ec2a39a81c846a41af00710267db9bb008ab697d",
       "urls": [
-        "bzzr://acc059a1d6c1c298d229a478996af2bf8383c3e0826569f5c22b41dee06b58fe"
+        "bzzr://acc059a1d6c1c298d229a478996af2bf8383c3e0826569f5c22b41dee06b58fe",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.9.27+commit.809d5ce1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.9.27+commit.809d5ce1.js"
       ]
     },
     {
@@ -4338,9 +5529,12 @@
       "prerelease": "nightly.2017.9.28",
       "build": "commit.4d01d086",
       "longVersion": "0.4.18-nightly.2017.9.28+commit.4d01d086",
+      "sha256": "0xa1aab0b30879a9d743155b7d4be82a1db06482b8115001a55bd0ab9ae89e56fe",
       "keccak256": "0xd22c748020ecbe982f43ace2da6c40bd117fead7fc45f1785a9c67980709ec69",
       "urls": [
-        "bzzr://87e6312d421d45b4fb408bd349d43d955fc57b6beda8de1bb12cc3e65bc1acec"
+        "bzzr://87e6312d421d45b4fb408bd349d43d955fc57b6beda8de1bb12cc3e65bc1acec",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.9.28+commit.4d01d086.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.9.28+commit.4d01d086.js"
       ]
     },
     {
@@ -4349,9 +5543,12 @@
       "prerelease": "nightly.2017.9.29",
       "build": "commit.b9218468",
       "longVersion": "0.4.18-nightly.2017.9.29+commit.b9218468",
+      "sha256": "0xe329ac76fc7710fc969a74c55159c40f41ebfb5351e1e373308b4bf073318b35",
       "keccak256": "0xbb465c729f6b28f661333aaf69ff2b090eb6d1cb4340babeb8f7fae616e55c33",
       "urls": [
-        "bzzr://676459d6d4abec5ad993ff1c762c8ed627c2326c3c9ef8d8c9140fcbd5e8c964"
+        "bzzr://676459d6d4abec5ad993ff1c762c8ed627c2326c3c9ef8d8c9140fcbd5e8c964",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.9.29+commit.b9218468.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.9.29+commit.b9218468.js"
       ]
     },
     {
@@ -4360,9 +5557,12 @@
       "prerelease": "nightly.2017.10.2",
       "build": "commit.c6161030",
       "longVersion": "0.4.18-nightly.2017.10.2+commit.c6161030",
+      "sha256": "0x5f005afc5bbadfa7b6bdcc85a2fee9f9fb4e6922122f9ceaf8b19a75896a2dbc",
       "keccak256": "0x3af650fc8a6185953f1e309133cc48f2f7001f8adcfc41d8316a5df342d324b7",
       "urls": [
-        "bzzr://2d725abb42a0ff69fc8ca829a079192472e3c9ad7d3225885fc9338fa052219c"
+        "bzzr://2d725abb42a0ff69fc8ca829a079192472e3c9ad7d3225885fc9338fa052219c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.2+commit.c6161030.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.2+commit.c6161030.js"
       ]
     },
     {
@@ -4371,9 +5571,12 @@
       "prerelease": "nightly.2017.10.3",
       "build": "commit.5c284589",
       "longVersion": "0.4.18-nightly.2017.10.3+commit.5c284589",
+      "sha256": "0x12c8a344b99448d455a06e20f76f15e9a7d6aadb0a3b533adf222bbc03452214",
       "keccak256": "0x51ba6c39681cb35d4802a82ec6cb55fe12bbc9df3a4b449008e335fb8cb97bc7",
       "urls": [
-        "bzzr://58d49cbf77635145489a573bf929f343f16ef03c7bcf0bff7517174643625d15"
+        "bzzr://58d49cbf77635145489a573bf929f343f16ef03c7bcf0bff7517174643625d15",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.3+commit.5c284589.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.3+commit.5c284589.js"
       ]
     },
     {
@@ -4382,9 +5585,12 @@
       "prerelease": "nightly.2017.10.4",
       "build": "commit.c3888ab",
       "longVersion": "0.4.18-nightly.2017.10.4+commit.c3888ab",
+      "sha256": "0xb8abd3bcd90989fcf440af5be2c1c4bb19cc6f232e732aa22eb15690da0290c0",
       "keccak256": "0x18cfdde57390bbf06053bcbb5af71f71bc555b2651e7cdeb7c2748afd2fe58a0",
       "urls": [
-        "bzzr://81c090bd4b34720c52379ae5c7c5961da714dc9859183b8059e07d28893282dd"
+        "bzzr://81c090bd4b34720c52379ae5c7c5961da714dc9859183b8059e07d28893282dd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.4+commit.c3888ab.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.4+commit.c3888ab.js"
       ]
     },
     {
@@ -4393,9 +5599,12 @@
       "prerelease": "nightly.2017.10.5",
       "build": "commit.995b5525",
       "longVersion": "0.4.18-nightly.2017.10.5+commit.995b5525",
+      "sha256": "0x25aeeaa8b807bef89f29f0c19f2b424f4606da7103fe4b8319a0e10c1dbf6bc3",
       "keccak256": "0xfc44bbc1e08f4f302a73ee1b7f4f4a9d1d3deb2505a3f79263a09808796aa23a",
       "urls": [
-        "bzzr://293c31d326ee48258d4b80e9514975cc09b0e071d116524658780485ea64dd6f"
+        "bzzr://293c31d326ee48258d4b80e9514975cc09b0e071d116524658780485ea64dd6f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.5+commit.995b5525.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.5+commit.995b5525.js"
       ]
     },
     {
@@ -4404,9 +5613,12 @@
       "prerelease": "nightly.2017.10.6",
       "build": "commit.961f8746",
       "longVersion": "0.4.18-nightly.2017.10.6+commit.961f8746",
+      "sha256": "0xf38c59afe6de7a779b65533c947c1aa28b444ac3642c9d6987dd37a9671489d5",
       "keccak256": "0x67b8ed5d098180f0900d9346c143cba27ca5f5f1a81259640ed47219a60cadd9",
       "urls": [
-        "bzzr://37b1357d0167f0cec09a827d7eb305651dade9bf4ab5a5310d6bc57126a14153"
+        "bzzr://37b1357d0167f0cec09a827d7eb305651dade9bf4ab5a5310d6bc57126a14153",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.6+commit.961f8746.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.6+commit.961f8746.js"
       ]
     },
     {
@@ -4415,9 +5627,12 @@
       "prerelease": "nightly.2017.10.9",
       "build": "commit.6f832cac",
       "longVersion": "0.4.18-nightly.2017.10.9+commit.6f832cac",
+      "sha256": "0x013983d32e9cc9135835e1ea65ca9349ac74a19f8a31f0faf17c8ba508516dde",
       "keccak256": "0x484de3067afecf01739135bf820efdc03e6c56a2dadcf8b5f1ed576b3a6b3384",
       "urls": [
-        "bzzr://9e9556ef31118c4b515b47dd442d64e0160b2115bc731c713b0056af80dde8fc"
+        "bzzr://9e9556ef31118c4b515b47dd442d64e0160b2115bc731c713b0056af80dde8fc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.9+commit.6f832cac.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.9+commit.6f832cac.js"
       ]
     },
     {
@@ -4426,9 +5641,12 @@
       "prerelease": "nightly.2017.10.10",
       "build": "commit.c35496bf",
       "longVersion": "0.4.18-nightly.2017.10.10+commit.c35496bf",
+      "sha256": "0x305ec4db2bf4ece357612b6628f9d972cdc59c9965b51364f91ee47545da5f5e",
       "keccak256": "0x0430395328e4bd3cc5b8f91f5a82f80bbbf340e6101277f071008296ce53a6b8",
       "urls": [
-        "bzzr://8df9ea914024f60f209a7fdd9741652696a35f2c07198c791df8e69f5e5e38ca"
+        "bzzr://8df9ea914024f60f209a7fdd9741652696a35f2c07198c791df8e69f5e5e38ca",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.10+commit.c35496bf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.10+commit.c35496bf.js"
       ]
     },
     {
@@ -4437,9 +5655,12 @@
       "prerelease": "nightly.2017.10.15",
       "build": "commit.a74c9aef",
       "longVersion": "0.4.18-nightly.2017.10.15+commit.a74c9aef",
+      "sha256": "0x2128e70d7ec85c2f99a5b9fd181de3b5800a82febcc61b9595cd94693e5755ad",
       "keccak256": "0x6dab883cb28eb37de2ca334515c79276a1e8ce196240a3dac8995212d9863009",
       "urls": [
-        "bzzr://492e649fead485d214bae5add602ba6811daa3e58e52bba03c7b4bab568be918"
+        "bzzr://492e649fead485d214bae5add602ba6811daa3e58e52bba03c7b4bab568be918",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.15+commit.a74c9aef.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.15+commit.a74c9aef.js"
       ]
     },
     {
@@ -4448,9 +5669,12 @@
       "prerelease": "nightly.2017.10.16",
       "build": "commit.dbc8655b",
       "longVersion": "0.4.18-nightly.2017.10.16+commit.dbc8655b",
+      "sha256": "0x0d3859ad1e083d127c69686d32207a761bdf7354fc456e8e6540a3bc111f438e",
       "keccak256": "0xbc72773e3e7923807144fdb5e2f4f520cd729bccda710424d06b62008e237107",
       "urls": [
-        "bzzr://c5951bc139ec0006596f892d0de95ec7f09e850b66769390056e9bf7a95708a0"
+        "bzzr://c5951bc139ec0006596f892d0de95ec7f09e850b66769390056e9bf7a95708a0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.16+commit.dbc8655b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.16+commit.dbc8655b.js"
       ]
     },
     {
@@ -4459,9 +5683,12 @@
       "prerelease": "nightly.2017.10.17",
       "build": "commit.8fbfd62d",
       "longVersion": "0.4.18-nightly.2017.10.17+commit.8fbfd62d",
+      "sha256": "0xb8ea17dcd9d8c09aa5fcdadd8b2546ee49315a783c5b7b62fcb5b219a2873bf5",
       "keccak256": "0x6d85e74cb2ad3546422c9b6fc1900c794c3180ae2bf42a4c411f2e4e7f88859e",
       "urls": [
-        "bzzr://b32392dad43a479fd4ea15728aa9b27fef0e2aa9c7f20c5ea04e8b030fd9aec9"
+        "bzzr://b32392dad43a479fd4ea15728aa9b27fef0e2aa9c7f20c5ea04e8b030fd9aec9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.17+commit.8fbfd62d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.17+commit.8fbfd62d.js"
       ]
     },
     {
@@ -4470,9 +5697,12 @@
       "prerelease": "nightly.2017.10.18",
       "build": "commit.e854da1a",
       "longVersion": "0.4.18-nightly.2017.10.18+commit.e854da1a",
+      "sha256": "0x329176d6951ee844a989b842496fce06e5d6d1cc8733fd25fef9db02f2600f75",
       "keccak256": "0x96a4aae4a4fe1b0b0b7a0e6f6ec2475945b4964a660e464d10549dcbf8f50f69",
       "urls": [
-        "bzzr://c7bfa001848efe95a733c926b5aa512fb53bfa9c7ae188799a4d12d7eadbe6b5"
+        "bzzr://c7bfa001848efe95a733c926b5aa512fb53bfa9c7ae188799a4d12d7eadbe6b5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18-nightly.2017.10.18+commit.e854da1a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18-nightly.2017.10.18+commit.e854da1a.js"
       ]
     },
     {
@@ -4480,9 +5710,12 @@
       "version": "0.4.18",
       "build": "commit.9cf6e910",
       "longVersion": "0.4.18+commit.9cf6e910",
+      "sha256": "0x905e3d253406973f545666d79cd64c5c85985992f68fa35935f60249e311d74f",
       "keccak256": "0x0478b43de978b1af1d6d6d8c09e84cdb2cc8ed76218d38f17b841b6e539742f0",
       "urls": [
-        "bzzr://bacf94b83b539b0a704236daf9fd9083766905760e39d1372fdefad9a53ea26f"
+        "bzzr://bacf94b83b539b0a704236daf9fd9083766905760e39d1372fdefad9a53ea26f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.18+commit.9cf6e910.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.18+commit.9cf6e910.js"
       ]
     },
     {
@@ -4491,9 +5724,12 @@
       "prerelease": "nightly.2017.10.18",
       "build": "commit.f7ca2421",
       "longVersion": "0.4.19-nightly.2017.10.18+commit.f7ca2421",
+      "sha256": "0xd48a1ba624096f5553448e54cfb19df205bce8484ba132d73b345910f6bb49f8",
       "keccak256": "0x3bec52d85663767e9107ae2bc01f0cdefdacaaf66b13f1fd51b590d8564f2bc5",
       "urls": [
-        "bzzr://55188e5c9c4cca21df17b12a31812c913913f87dcd970e53265a6a589772c9aa"
+        "bzzr://55188e5c9c4cca21df17b12a31812c913913f87dcd970e53265a6a589772c9aa",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.18+commit.f7ca2421.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.18+commit.f7ca2421.js"
       ]
     },
     {
@@ -4502,9 +5738,12 @@
       "prerelease": "nightly.2017.10.19",
       "build": "commit.c58d9d2c",
       "longVersion": "0.4.19-nightly.2017.10.19+commit.c58d9d2c",
+      "sha256": "0x21102667907928da81d246ab661f58e32320b30aa3090366bb09aeaefde3c2df",
       "keccak256": "0x8c102b7102df499c2eceee5b9d6a270f0c2b301cc892443e6fdc930ab941619c",
       "urls": [
-        "bzzr://eb3daec21fd9d4693ceec909f71ee052a950a8b67d91e25ba9adecef48572c75"
+        "bzzr://eb3daec21fd9d4693ceec909f71ee052a950a8b67d91e25ba9adecef48572c75",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.19+commit.c58d9d2c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.19+commit.c58d9d2c.js"
       ]
     },
     {
@@ -4513,9 +5752,12 @@
       "prerelease": "nightly.2017.10.20",
       "build": "commit.bdd2858b",
       "longVersion": "0.4.19-nightly.2017.10.20+commit.bdd2858b",
+      "sha256": "0x1411ccd6fc93fcfda607eb32a52e9099de9cc897e281981ede3f5af8e4f91747",
       "keccak256": "0x336bcf9c87c4c9666dff0a2e51a75ee6446e28223420420a1f567bbe94a8724c",
       "urls": [
-        "bzzr://5b75741798a25bb38e4b27d25a13e7b60c9113aa9c90866730f8900a9df1f3ab"
+        "bzzr://5b75741798a25bb38e4b27d25a13e7b60c9113aa9c90866730f8900a9df1f3ab",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.20+commit.bdd2858b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.20+commit.bdd2858b.js"
       ]
     },
     {
@@ -4524,9 +5766,12 @@
       "prerelease": "nightly.2017.10.23",
       "build": "commit.dc6b1f02",
       "longVersion": "0.4.19-nightly.2017.10.23+commit.dc6b1f02",
+      "sha256": "0xc6405b1c1b3825a7beeb00200a6cdaa3268d776fd497997a88e59156e48d1579",
       "keccak256": "0x8c4e7dc36b495c45e02e6aa42fe1ea63d23dd58135327a01f641d102e65c5729",
       "urls": [
-        "bzzr://6bed1cd7d82973b35fec0ee0c6f98a60cc5b660a9da732cdeb3374e560a49d1e"
+        "bzzr://6bed1cd7d82973b35fec0ee0c6f98a60cc5b660a9da732cdeb3374e560a49d1e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.23+commit.dc6b1f02.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.23+commit.dc6b1f02.js"
       ]
     },
     {
@@ -4535,9 +5780,12 @@
       "prerelease": "nightly.2017.10.24",
       "build": "commit.1313e9d8",
       "longVersion": "0.4.19-nightly.2017.10.24+commit.1313e9d8",
+      "sha256": "0x00fcb6c35bb795672f9783b27b6ad181ad7ac1b30290efb4f9183dd4bf273b5a",
       "keccak256": "0x37f142fb18a99748e3ae5f83fed7b82bb40b245deb2f1a7fc9c4666df005954e",
       "urls": [
-        "bzzr://25bc201ee1ec6fcbdf9dbc66d7b9b41bb7402a72e411acf7cb2d0d2cf9f4852f"
+        "bzzr://25bc201ee1ec6fcbdf9dbc66d7b9b41bb7402a72e411acf7cb2d0d2cf9f4852f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.24+commit.1313e9d8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.24+commit.1313e9d8.js"
       ]
     },
     {
@@ -4546,9 +5794,12 @@
       "prerelease": "nightly.2017.10.26",
       "build": "commit.59d4dfbd",
       "longVersion": "0.4.19-nightly.2017.10.26+commit.59d4dfbd",
+      "sha256": "0x2a9e898ea494ef038276f00e77bc8c527c8af17399d043bfb1d7f8dcc15ca1ac",
       "keccak256": "0xd65d81d8c911febfb1e5ad58e5cc74d972996593e9e4580bf49b14312578310b",
       "urls": [
-        "bzzr://b4f35b32ceb8e4cc6d65a9f078ea91c36021353946c17dcd81396b53e0abe131"
+        "bzzr://b4f35b32ceb8e4cc6d65a9f078ea91c36021353946c17dcd81396b53e0abe131",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.26+commit.59d4dfbd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.26+commit.59d4dfbd.js"
       ]
     },
     {
@@ -4557,9 +5808,12 @@
       "prerelease": "nightly.2017.10.27",
       "build": "commit.1e085f85",
       "longVersion": "0.4.19-nightly.2017.10.27+commit.1e085f85",
+      "sha256": "0xd547991a9165a4cb9a911a5dcec9da98f761253b39e0670a6cb318da3ff9f80f",
       "keccak256": "0x3962de9bb630566af812e389b25190f4b71b23f1e214f144a8d09ce535064371",
       "urls": [
-        "bzzr://10f44d5a3929ce878c5d59e7ee87c5e5e99086858a55443f01c0a5d84fca13bf"
+        "bzzr://10f44d5a3929ce878c5d59e7ee87c5e5e99086858a55443f01c0a5d84fca13bf",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.27+commit.1e085f85.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.27+commit.1e085f85.js"
       ]
     },
     {
@@ -4568,9 +5822,12 @@
       "prerelease": "nightly.2017.10.28",
       "build": "commit.f9b24009",
       "longVersion": "0.4.19-nightly.2017.10.28+commit.f9b24009",
+      "sha256": "0x04181934f4754fb6612568db01dc86976fcaeba0f2fca4d479b3972a7c55ce92",
       "keccak256": "0x75727d3561e9dca2e12a8c7c0f9b3b307544bbb495639afd4a64a36493ffc4ff",
       "urls": [
-        "bzzr://c50e68937d028019915dda43ff80e38c9ca42cd3eca7a43dbbdb5bafdd3f0e9c"
+        "bzzr://c50e68937d028019915dda43ff80e38c9ca42cd3eca7a43dbbdb5bafdd3f0e9c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.28+commit.f9b24009.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.28+commit.f9b24009.js"
       ]
     },
     {
@@ -4579,9 +5836,12 @@
       "prerelease": "nightly.2017.10.29",
       "build": "commit.eb140bc6",
       "longVersion": "0.4.19-nightly.2017.10.29+commit.eb140bc6",
+      "sha256": "0x189ba96df68d6c395b633feefd43a082f0ac86c01e2a4b1916c5a287cd9a8e99",
       "keccak256": "0xf960e5d09cca990d6423cde9f4dcf617e2043d432bdc3fe720704fd09b722404",
       "urls": [
-        "bzzr://6d34609929b1a70be6b1529a38da0e35f106f62fefc8569f04c239aa568a529d"
+        "bzzr://6d34609929b1a70be6b1529a38da0e35f106f62fefc8569f04c239aa568a529d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.10.29+commit.eb140bc6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.10.29+commit.eb140bc6.js"
       ]
     },
     {
@@ -4590,9 +5850,12 @@
       "prerelease": "nightly.2017.11.11",
       "build": "commit.284c3839",
       "longVersion": "0.4.19-nightly.2017.11.11+commit.284c3839",
+      "sha256": "0xb561171563905dbbf892516dfdaea28da6a8db28237fa6935931f67c4c223e4f",
       "keccak256": "0xc08c8407395edd767796ee02c9408782bda1774a7e4e07f05a1a990755e17863",
       "urls": [
-        "bzzr://85337ef8a6cb02d3b3a7499dbd29c4c66ed76fc9e1eca3244ef508f8b57aabbc"
+        "bzzr://85337ef8a6cb02d3b3a7499dbd29c4c66ed76fc9e1eca3244ef508f8b57aabbc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.11+commit.284c3839.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.11+commit.284c3839.js"
       ]
     },
     {
@@ -4601,9 +5864,12 @@
       "prerelease": "nightly.2017.11.13",
       "build": "commit.60b2c2b",
       "longVersion": "0.4.19-nightly.2017.11.13+commit.60b2c2b",
+      "sha256": "0x2688846d14d6b2b3f30b78f0fda18ae8db51e07cd1da11cacd68ced1a047f0ef",
       "keccak256": "0x5702d0cc383e5c121f1deeb141f74508474a5dfbb6dd572bfba9b2d53938774f",
       "urls": [
-        "bzzr://7b48ed7ff3cc24b4fca970d785d88b95a3b8287a14f56cf1b3af925c19bcbc04"
+        "bzzr://7b48ed7ff3cc24b4fca970d785d88b95a3b8287a14f56cf1b3af925c19bcbc04",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.13+commit.60b2c2b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.13+commit.60b2c2b.js"
       ]
     },
     {
@@ -4612,9 +5878,12 @@
       "prerelease": "nightly.2017.11.14",
       "build": "commit.bc39e730",
       "longVersion": "0.4.19-nightly.2017.11.14+commit.bc39e730",
+      "sha256": "0xedeb15d5381a1fa616ad3a44c04ec1b17d570f4a9e889327722b9cc9cf6941de",
       "keccak256": "0x831d55423d63d5fa69916a5eb0a1bf30cf3f4e782f9739d3f29d115b2b5cd58e",
       "urls": [
-        "bzzr://65ff7ec4896383a5d7b18eb94129094e341e188e85bc17f9b5094769a34fdc22"
+        "bzzr://65ff7ec4896383a5d7b18eb94129094e341e188e85bc17f9b5094769a34fdc22",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.14+commit.bc39e730.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.14+commit.bc39e730.js"
       ]
     },
     {
@@ -4623,9 +5892,12 @@
       "prerelease": "nightly.2017.11.15",
       "build": "commit.e3206d8e",
       "longVersion": "0.4.19-nightly.2017.11.15+commit.e3206d8e",
+      "sha256": "0xaa8ebf41bfe73c45f172280c3245914e22200fe27ce04606f33550e049749719",
       "keccak256": "0x06256845062c4f8c47acd0e23437e4a264e9419ae833ee5b0fca622dccbf7535",
       "urls": [
-        "bzzr://4be62feddafe4200e058e9affb3dba7afec864cd8ce8d134fcd7b42abc04effb"
+        "bzzr://4be62feddafe4200e058e9affb3dba7afec864cd8ce8d134fcd7b42abc04effb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.15+commit.e3206d8e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.15+commit.e3206d8e.js"
       ]
     },
     {
@@ -4634,9 +5906,12 @@
       "prerelease": "nightly.2017.11.16",
       "build": "commit.58e452d1",
       "longVersion": "0.4.19-nightly.2017.11.16+commit.58e452d1",
+      "sha256": "0xb8f821ce76a967e7bac9f51e6d28e1f00c1e97f70afc502f64e3327df39bf0ca",
       "keccak256": "0x1707ec11e0d9e9cea65fb4b4995f470ce6929f8c1924ff628a1bea253756ff0c",
       "urls": [
-        "bzzr://91e7ef9afd0df85e3938d5747db58bdab1e82190046ed2f62387f8a9b6dea6b0"
+        "bzzr://91e7ef9afd0df85e3938d5747db58bdab1e82190046ed2f62387f8a9b6dea6b0",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.16+commit.58e452d1.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.16+commit.58e452d1.js"
       ]
     },
     {
@@ -4645,9 +5920,12 @@
       "prerelease": "nightly.2017.11.17",
       "build": "commit.2b5ef806",
       "longVersion": "0.4.19-nightly.2017.11.17+commit.2b5ef806",
+      "sha256": "0x9eb539e5169152ca76b45bddca918ed3644c8f8999589eb26edc9d64837e34dc",
       "keccak256": "0x8aedc2f68b504bf9a15c42fdd20affd26d85cd2891ab3b77698a0bd64af80f77",
       "urls": [
-        "bzzr://df538d814ebd4fee7b17e7911db42212acec4c774528e66a5b158118cd6634d6"
+        "bzzr://df538d814ebd4fee7b17e7911db42212acec4c774528e66a5b158118cd6634d6",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.17+commit.2b5ef806.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.17+commit.2b5ef806.js"
       ]
     },
     {
@@ -4656,9 +5934,12 @@
       "prerelease": "nightly.2017.11.21",
       "build": "commit.5c9e273d",
       "longVersion": "0.4.19-nightly.2017.11.21+commit.5c9e273d",
+      "sha256": "0x92a5ecf12030d77d41c12b7d4a32d84221984da49c1d57f81ad4f7259b7676ab",
       "keccak256": "0xa0a10727124825451e8b5bab35d399f5251188f52dab275898abb6078c18b23e",
       "urls": [
-        "bzzr://965fa1c9a5d8afe6cbaa80c2b5d6e49764944dacd8e214b77819ac26bd1c535a"
+        "bzzr://965fa1c9a5d8afe6cbaa80c2b5d6e49764944dacd8e214b77819ac26bd1c535a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.21+commit.5c9e273d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.21+commit.5c9e273d.js"
       ]
     },
     {
@@ -4667,9 +5948,12 @@
       "prerelease": "nightly.2017.11.22",
       "build": "commit.f22ac8fc",
       "longVersion": "0.4.19-nightly.2017.11.22+commit.f22ac8fc",
+      "sha256": "0x4cee7df8d5e1efbf30f44b489a99a3691ecc21576edc0615146ce6b317fd28f4",
       "keccak256": "0x87503f9997b695249b68c93f5e6898366867892d86724e6471c5a8bb7117c31e",
       "urls": [
-        "bzzr://7d764109331fb91f62177fc530c436dd024a2995f4d19bad2d90dce2e74daa8c"
+        "bzzr://7d764109331fb91f62177fc530c436dd024a2995f4d19bad2d90dce2e74daa8c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.22+commit.f22ac8fc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.22+commit.f22ac8fc.js"
       ]
     },
     {
@@ -4678,9 +5962,12 @@
       "prerelease": "nightly.2017.11.29",
       "build": "commit.7c69d88f",
       "longVersion": "0.4.19-nightly.2017.11.29+commit.7c69d88f",
+      "sha256": "0x25b982acd295acb4d18fe2f5499bd517fc01ff44d24b3a319e7db0398db14606",
       "keccak256": "0x0438e5a8ae5c55888ab8d468caa255d541bae0cc3921853c803b93793cf958dd",
       "urls": [
-        "bzzr://3977fcaf1aaccb60dd45f7c155bb63e8b04ba81dd6c1faae16b3b7deabb8f567"
+        "bzzr://3977fcaf1aaccb60dd45f7c155bb63e8b04ba81dd6c1faae16b3b7deabb8f567",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.29+commit.7c69d88f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.29+commit.7c69d88f.js"
       ]
     },
     {
@@ -4689,9 +5976,12 @@
       "prerelease": "nightly.2017.11.30",
       "build": "commit.f5a2508e",
       "longVersion": "0.4.19-nightly.2017.11.30+commit.f5a2508e",
+      "sha256": "0x83667987815012ed72a4fc9d6f7153e33c777b4899e18e6e8c46385f8b00bd50",
       "keccak256": "0x69b41820450d7b4a9570e3075ed18543b211c6b28e3c2044083f002c4d99ac7b",
       "urls": [
-        "bzzr://ef587b23ccb9405d34320066b2b4f9c0a773ff9756db43838b7317e1b2a2af92"
+        "bzzr://ef587b23ccb9405d34320066b2b4f9c0a773ff9756db43838b7317e1b2a2af92",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19-nightly.2017.11.30+commit.f5a2508e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19-nightly.2017.11.30+commit.f5a2508e.js"
       ]
     },
     {
@@ -4699,9 +5989,12 @@
       "version": "0.4.19",
       "build": "commit.c4cbbb05",
       "longVersion": "0.4.19+commit.c4cbbb05",
+      "sha256": "0x61071ed96228ac7b88ccb9c6eeae9a152daf6c06f19bb15b45b7ed22226a27e8",
       "keccak256": "0x96b6118bea8d3d97739b621e6b0838e3dff6aa407d6a90fa65e06997414f61f0",
       "urls": [
-        "bzzr://5431154a2587e9fcb5922a2490d755e0efa650e9347d084b5107fd5891e2fd57"
+        "bzzr://5431154a2587e9fcb5922a2490d755e0efa650e9347d084b5107fd5891e2fd57",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.19+commit.c4cbbb05.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.19+commit.c4cbbb05.js"
       ]
     },
     {
@@ -4710,9 +6003,12 @@
       "prerelease": "nightly.2017.11.30",
       "build": "commit.cb16a5d3",
       "longVersion": "0.4.20-nightly.2017.11.30+commit.cb16a5d3",
+      "sha256": "0x01af09cd15a62a9bc0ca5c177e5627530fbe98be6214fdad58d77bb42d0bd84c",
       "keccak256": "0x72fa6b890f45efdb5646c23aa8e3570033e0056f2750ddd58d47f597836bf880",
       "urls": [
-        "bzzr://653071a44d598caffe21a6762532f585db5a54bf017b4503a2f18f14caa8a5fc"
+        "bzzr://653071a44d598caffe21a6762532f585db5a54bf017b4503a2f18f14caa8a5fc",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.11.30+commit.cb16a5d3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.11.30+commit.cb16a5d3.js"
       ]
     },
     {
@@ -4721,9 +6017,12 @@
       "prerelease": "nightly.2017.12.1",
       "build": "commit.6d8d0393",
       "longVersion": "0.4.20-nightly.2017.12.1+commit.6d8d0393",
+      "sha256": "0x01b7d366d14cbbc6eb7a73ea6a8d9e38c081e575f3d264ceb060e43ffea25b31",
       "keccak256": "0x564f83c1dce12e68f10f895f579b4670db5424e9c517bf3a8216c58c2e15da53",
       "urls": [
-        "bzzr://cd087575312bf978e3f333e406d8dd83dca12ab3d994d055a2125d13ca25f962"
+        "bzzr://cd087575312bf978e3f333e406d8dd83dca12ab3d994d055a2125d13ca25f962",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.1+commit.6d8d0393.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.1+commit.6d8d0393.js"
       ]
     },
     {
@@ -4732,9 +6031,12 @@
       "prerelease": "nightly.2017.12.4",
       "build": "commit.240c79e6",
       "longVersion": "0.4.20-nightly.2017.12.4+commit.240c79e6",
+      "sha256": "0xfef244a2bc2fadcec90209b070daaa300e335fd3776ccb2c761b87637697b910",
       "keccak256": "0x7d64f3c24546e161f847ba421e82d69885f3c7786fdd1a9bc17214688c10635d",
       "urls": [
-        "bzzr://a86d290c7a4ba07d4c6b5a9fd4a403adb4cecfb364658b9a17f9ac5e4b75b3a5"
+        "bzzr://a86d290c7a4ba07d4c6b5a9fd4a403adb4cecfb364658b9a17f9ac5e4b75b3a5",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.4+commit.240c79e6.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.4+commit.240c79e6.js"
       ]
     },
     {
@@ -4743,9 +6045,12 @@
       "prerelease": "nightly.2017.12.5",
       "build": "commit.b47e023d",
       "longVersion": "0.4.20-nightly.2017.12.5+commit.b47e023d",
+      "sha256": "0x142b0694bb8b7b20242f18bb18c17068dcdad4d45989524f7f68cfbd749e8d2f",
       "keccak256": "0xf33b0646bd6e37278f4913d2ef6a0489d5d8d1232d220c19975235f110993236",
       "urls": [
-        "bzzr://41b05c78df9f5cd7f745f6242aab1ade8b87fb73583468e5cbab07b794caa339"
+        "bzzr://41b05c78df9f5cd7f745f6242aab1ade8b87fb73583468e5cbab07b794caa339",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.5+commit.b47e023d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.5+commit.b47e023d.js"
       ]
     },
     {
@@ -4754,9 +6059,12 @@
       "prerelease": "nightly.2017.12.6",
       "build": "commit.c2109436",
       "longVersion": "0.4.20-nightly.2017.12.6+commit.c2109436",
+      "sha256": "0x6491f056b07fd161c49dc985561eb844f2a3bd86ea6a61f0e6375e1a9f9804d0",
       "keccak256": "0x13ada915c97acf29a43b345f51a3d417c7c825391cc66691458532dd57714c00",
       "urls": [
-        "bzzr://2b1cef842e0038ef47940f3194c88bbb9fdb2e79813dcba2da92d04f785c6894"
+        "bzzr://2b1cef842e0038ef47940f3194c88bbb9fdb2e79813dcba2da92d04f785c6894",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.6+commit.c2109436.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.6+commit.c2109436.js"
       ]
     },
     {
@@ -4765,9 +6073,12 @@
       "prerelease": "nightly.2017.12.8",
       "build": "commit.226bfe5b",
       "longVersion": "0.4.20-nightly.2017.12.8+commit.226bfe5b",
+      "sha256": "0x959e46ae4700cb9e7b58902f70595d3dfcf1fb13f07376f48d9a6c768a7fddba",
       "keccak256": "0x589de5b03df6cb8b68294b8b7aa101a5bd729aa9dae105c87297a0bc14d00587",
       "urls": [
-        "bzzr://0b1f839d7c0ec7c87df61c75a454139847e991136e41b3d09ace1e628f37287d"
+        "bzzr://0b1f839d7c0ec7c87df61c75a454139847e991136e41b3d09ace1e628f37287d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.8+commit.226bfe5b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.8+commit.226bfe5b.js"
       ]
     },
     {
@@ -4776,9 +6087,12 @@
       "prerelease": "nightly.2017.12.11",
       "build": "commit.4a1f18c9",
       "longVersion": "0.4.20-nightly.2017.12.11+commit.4a1f18c9",
+      "sha256": "0xa11b021e2ac8bc02844332133ba3cb66f2db5a54a255599806ac134a8b5f59a0",
       "keccak256": "0xa7c7bebed1a7a4592fd17af555b532f5655c1254ada00b9f48f7b01d0dfe84da",
       "urls": [
-        "bzzr://46aec9ac8a2b881e0c6d4892bee1152b7434ef45423b047f3667decc5995472f"
+        "bzzr://46aec9ac8a2b881e0c6d4892bee1152b7434ef45423b047f3667decc5995472f",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.11+commit.4a1f18c9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.11+commit.4a1f18c9.js"
       ]
     },
     {
@@ -4787,9 +6101,12 @@
       "prerelease": "nightly.2017.12.12",
       "build": "commit.1ddd4e2b",
       "longVersion": "0.4.20-nightly.2017.12.12+commit.1ddd4e2b",
+      "sha256": "0xd5c9d157e90dbfbef190a3ea13036bab777dc922d6070646fba93cfdf79143d9",
       "keccak256": "0xfb0366a873ef20a5b314fb8cc956d6e26ff3940f6ff70ad4dc13356587116008",
       "urls": [
-        "bzzr://af67da6982a7de585bc04854b2853e113a653b1ef8b213d95b9f5db85bc74577"
+        "bzzr://af67da6982a7de585bc04854b2853e113a653b1ef8b213d95b9f5db85bc74577",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.12+commit.1ddd4e2b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.12+commit.1ddd4e2b.js"
       ]
     },
     {
@@ -4798,9 +6115,12 @@
       "prerelease": "nightly.2017.12.13",
       "build": "commit.bfc54463",
       "longVersion": "0.4.20-nightly.2017.12.13+commit.bfc54463",
+      "sha256": "0x226d4bb93dba8714463336c0bfd372cc4eadf694d256215c7edd5a7688d9f24d",
       "keccak256": "0x5101882e0546f1533703ae7df23d6270fa2a62e5ef9e3ac117138a99a8ac930a",
       "urls": [
-        "bzzr://854bfbe94a0b422fe0792c4062452d09f48c4a275d284558063c614c3f058715"
+        "bzzr://854bfbe94a0b422fe0792c4062452d09f48c4a275d284558063c614c3f058715",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.13+commit.bfc54463.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.13+commit.bfc54463.js"
       ]
     },
     {
@@ -4809,9 +6129,12 @@
       "prerelease": "nightly.2017.12.14",
       "build": "commit.3d1830f3",
       "longVersion": "0.4.20-nightly.2017.12.14+commit.3d1830f3",
+      "sha256": "0x47db90330a94bc17b94d5bc3d280e65ed733c95ddc080ddc238570747adb3725",
       "keccak256": "0x236fb765e547f2a91f31393312658d68461b89675b3d5a73db128388420d6076",
       "urls": [
-        "bzzr://cf12d391adaf15ddf1acc91b956b2c09bba0736af6daf62c1f2b74106993de38"
+        "bzzr://cf12d391adaf15ddf1acc91b956b2c09bba0736af6daf62c1f2b74106993de38",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.14+commit.3d1830f3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.14+commit.3d1830f3.js"
       ]
     },
     {
@@ -4820,9 +6143,12 @@
       "prerelease": "nightly.2017.12.18",
       "build": "commit.37b70e8e",
       "longVersion": "0.4.20-nightly.2017.12.18+commit.37b70e8e",
+      "sha256": "0x6d45e3178a08cbca278bbdae282a7387219b4cf2d12da5f9764c1feab2214359",
       "keccak256": "0xa702c4f7a804af805707d4c430b23af1df0bda447c6911ef4985ccac98b98927",
       "urls": [
-        "bzzr://7859b19ac846855e2b7d13198cae4076f429b0cb178226ecedc041a3ef80db3e"
+        "bzzr://7859b19ac846855e2b7d13198cae4076f429b0cb178226ecedc041a3ef80db3e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.18+commit.37b70e8e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.18+commit.37b70e8e.js"
       ]
     },
     {
@@ -4831,9 +6157,12 @@
       "prerelease": "nightly.2017.12.19",
       "build": "commit.2d800e67",
       "longVersion": "0.4.20-nightly.2017.12.19+commit.2d800e67",
+      "sha256": "0x447e5bfb25eefce6af40e94d85f44fa35a59aceeb4249c5052148ee587996ffe",
       "keccak256": "0x512e438bad37751848d4b554f0a50703adb7caaad28e9e00c2686740bf26fde3",
       "urls": [
-        "bzzr://4144ee051b41c09563c20410a9ab9902d1f6ac0135a7adbfc47881c0be8e1242"
+        "bzzr://4144ee051b41c09563c20410a9ab9902d1f6ac0135a7adbfc47881c0be8e1242",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.19+commit.2d800e67.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.19+commit.2d800e67.js"
       ]
     },
     {
@@ -4842,9 +6171,12 @@
       "prerelease": "nightly.2017.12.20",
       "build": "commit.efc198d5",
       "longVersion": "0.4.20-nightly.2017.12.20+commit.efc198d5",
+      "sha256": "0xd3923c14c59c6cdca8cbdc37989e268c964a415c383794ca1399fc779c00d2a9",
       "keccak256": "0xfe4e9faafb7972fc2909a32bbd0ff45b32637faa1a31a7a47197eab1cb592549",
       "urls": [
-        "bzzr://efcf95ca3805faf85bcd6729f41f3ad1a560f843eecd32bc6aeb364a13aef9d3"
+        "bzzr://efcf95ca3805faf85bcd6729f41f3ad1a560f843eecd32bc6aeb364a13aef9d3",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2017.12.20+commit.efc198d5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2017.12.20+commit.efc198d5.js"
       ]
     },
     {
@@ -4853,9 +6185,12 @@
       "prerelease": "nightly.2018.1.4",
       "build": "commit.a0771691",
       "longVersion": "0.4.20-nightly.2018.1.4+commit.a0771691",
+      "sha256": "0x12d331413094130c3d0b01911012b4df0889d34afa9c6dd73d24ec09282c7a1d",
       "keccak256": "0xd14d3d240b75cdd330ee838ffa27c2c68268ee1f355b78783b3f07ee68fad3af",
       "urls": [
-        "bzzr://5b8727a2990706f28b3d4cf157add49320d7164af26974a3c16704a4361d840c"
+        "bzzr://5b8727a2990706f28b3d4cf157add49320d7164af26974a3c16704a4361d840c",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.4+commit.a0771691.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.4+commit.a0771691.js"
       ]
     },
     {
@@ -4864,9 +6199,12 @@
       "prerelease": "nightly.2018.1.5",
       "build": "commit.bca01f8f",
       "longVersion": "0.4.20-nightly.2018.1.5+commit.bca01f8f",
+      "sha256": "0x200b3317f87f6b655edd285907348de7958d112f260792342c5f242ac7ac45b2",
       "keccak256": "0x5226cf597b93edd5a17f48d225e0ef1f6aee60a536f6064351fef61b303fc170",
       "urls": [
-        "bzzr://b35a1295ef8f7ed8cc802bdf4160d903da960153e6531dc84a6903b572d350e7"
+        "bzzr://b35a1295ef8f7ed8cc802bdf4160d903da960153e6531dc84a6903b572d350e7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.5+commit.bca01f8f.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.5+commit.bca01f8f.js"
       ]
     },
     {
@@ -4875,9 +6213,12 @@
       "prerelease": "nightly.2018.1.6",
       "build": "commit.2548228b",
       "longVersion": "0.4.20-nightly.2018.1.6+commit.2548228b",
+      "sha256": "0x6eb8fd5850a8db146462704b52177b7e5abd2b73f69622d572abd7b388334342",
       "keccak256": "0xac4418c0b5799bddfcd78cd355b16e5c5f1f599742cb3fe1e6f32c87fe935cc4",
       "urls": [
-        "bzzr://44a558d10031cd4fc13582b8e10a2cfd4ec653485a8ba94da3f30dea24a07ea7"
+        "bzzr://44a558d10031cd4fc13582b8e10a2cfd4ec653485a8ba94da3f30dea24a07ea7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.6+commit.2548228b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.6+commit.2548228b.js"
       ]
     },
     {
@@ -4886,9 +6227,12 @@
       "prerelease": "nightly.2018.1.10",
       "build": "commit.a75d5333",
       "longVersion": "0.4.20-nightly.2018.1.10+commit.a75d5333",
+      "sha256": "0x58dbe7043eff36fd086098601b96165c9b060a56729724170597ae5bdf3eb0c9",
       "keccak256": "0x458c9136301b4fd6951f1ede9731b6a2f8b8b289179865a231449419b3d3c0ec",
       "urls": [
-        "bzzr://d45d8337ac659d43f409ad21a0da162bc0d1ca3ff771a326934e538350da148b"
+        "bzzr://d45d8337ac659d43f409ad21a0da162bc0d1ca3ff771a326934e538350da148b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.10+commit.a75d5333.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.10+commit.a75d5333.js"
       ]
     },
     {
@@ -4897,9 +6241,12 @@
       "prerelease": "nightly.2018.1.11",
       "build": "commit.c20b6da",
       "longVersion": "0.4.20-nightly.2018.1.11+commit.c20b6da",
+      "sha256": "0xa59dc57c9e6c677dcf41758fc3296cdd490bfda3dd2a59ceba4afcc3a8d64e9b",
       "keccak256": "0x6107351ccc22ca65557dee311527ae0ca66e2f68cacec5924803592792ab5344",
       "urls": [
-        "bzzr://28be1f82df0d1e405bdc1b4a16c99aef785aaf91f0dba24f567e0706230ba200"
+        "bzzr://28be1f82df0d1e405bdc1b4a16c99aef785aaf91f0dba24f567e0706230ba200",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.11+commit.c20b6da.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.11+commit.c20b6da.js"
       ]
     },
     {
@@ -4908,9 +6255,12 @@
       "prerelease": "nightly.2018.1.15",
       "build": "commit.14fcbd65",
       "longVersion": "0.4.20-nightly.2018.1.15+commit.14fcbd65",
+      "sha256": "0xfe756017c3d464b5812e251183f71fbc54826abc7d66beecc0dfafae990492ee",
       "keccak256": "0x400b7161fb03b5158df60813b6d25eb0efc7a05928560352f71d01a204759fea",
       "urls": [
-        "bzzr://48e7eaaed53cbbdf2629ebed16aa4b3994633d2dc3e712fb82e17c8ecffb978a"
+        "bzzr://48e7eaaed53cbbdf2629ebed16aa4b3994633d2dc3e712fb82e17c8ecffb978a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.15+commit.14fcbd65.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.15+commit.14fcbd65.js"
       ]
     },
     {
@@ -4919,9 +6269,12 @@
       "prerelease": "nightly.2018.1.17",
       "build": "commit.4715167e",
       "longVersion": "0.4.20-nightly.2018.1.17+commit.4715167e",
+      "sha256": "0x4da5c414489f4eb8832c8cb3152292b4b7b09836b4d3f80f7e8671a1093b3de8",
       "keccak256": "0x09be7ee37ef342637bb4e9c2cf1e8ccafdde88f7265e52a09bd04632c10627c4",
       "urls": [
-        "bzzr://90d9c722c9bc478d0c3c8a35925d83e7be454ec8b5e6e9e79ec3f334270bacfe"
+        "bzzr://90d9c722c9bc478d0c3c8a35925d83e7be454ec8b5e6e9e79ec3f334270bacfe",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.17+commit.4715167e.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.17+commit.4715167e.js"
       ]
     },
     {
@@ -4930,9 +6283,12 @@
       "prerelease": "nightly.2018.1.18",
       "build": "commit.33723c45",
       "longVersion": "0.4.20-nightly.2018.1.18+commit.33723c45",
+      "sha256": "0x56c937b30233bcb2e5090e4f886b0be17657d0d5db7f7d55843842cf3ef19020",
       "keccak256": "0xe3f86e366fad4d74902654b500dc6df5f3e122ea6ec2b76a85bf4c720f47b1ed",
       "urls": [
-        "bzzr://1b4c7936bc7e4ad9a4b5c93f17de6c03303ef94693eb0766ad6dca05caffcecd"
+        "bzzr://1b4c7936bc7e4ad9a4b5c93f17de6c03303ef94693eb0766ad6dca05caffcecd",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.18+commit.33723c45.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.18+commit.33723c45.js"
       ]
     },
     {
@@ -4941,9 +6297,12 @@
       "prerelease": "nightly.2018.1.19",
       "build": "commit.eba46a65",
       "longVersion": "0.4.20-nightly.2018.1.19+commit.eba46a65",
+      "sha256": "0x386bd4815c753e9258328c2a40c6caa62cc8c84e1a7204098343dfdd4742476e",
       "keccak256": "0x8b4ab1fb31b415585869089f830f61a4982282c731a1873d47a6610126603a62",
       "urls": [
-        "bzzr://50c2e324fd10fbe7a2ffb1dd454148f53a3d15b7b1ae5c8c54c8b3366d0da506"
+        "bzzr://50c2e324fd10fbe7a2ffb1dd454148f53a3d15b7b1ae5c8c54c8b3366d0da506",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.19+commit.eba46a65.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.19+commit.eba46a65.js"
       ]
     },
     {
@@ -4952,9 +6311,12 @@
       "prerelease": "nightly.2018.1.22",
       "build": "commit.e5def2da",
       "longVersion": "0.4.20-nightly.2018.1.22+commit.e5def2da",
+      "sha256": "0x9901cfda8643fbe095e746582b5033e0f6be957ce214ba3424a92799f14fae36",
       "keccak256": "0x1b4a45db77b79052eb4cc04dbe981a60991ab51735c8c1f66fccd7bf8eab3875",
       "urls": [
-        "bzzr://26cd13683cfb44b881d44c96cd2833f6dc678a8d3b48c8a30328c4100fbc37be"
+        "bzzr://26cd13683cfb44b881d44c96cd2833f6dc678a8d3b48c8a30328c4100fbc37be",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.22+commit.e5def2da.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.22+commit.e5def2da.js"
       ]
     },
     {
@@ -4963,9 +6325,12 @@
       "prerelease": "nightly.2018.1.23",
       "build": "commit.31aaf433",
       "longVersion": "0.4.20-nightly.2018.1.23+commit.31aaf433",
+      "sha256": "0x1d0609607d0b6b6c5607d0d71f601100e0b602c368c7f6e0a6e83a42edced231",
       "keccak256": "0x8e2d4bbd6294e6073f938dced44f383372d943ddd847f1635746015ea169b600",
       "urls": [
-        "bzzr://10a2ed5fcede9ddae1c1e3d1b0f322a6b4943c75c9106f16df71d27a50c83b1b"
+        "bzzr://10a2ed5fcede9ddae1c1e3d1b0f322a6b4943c75c9106f16df71d27a50c83b1b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.23+commit.31aaf433.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.23+commit.31aaf433.js"
       ]
     },
     {
@@ -4974,9 +6339,12 @@
       "prerelease": "nightly.2018.1.24",
       "build": "commit.b177352a",
       "longVersion": "0.4.20-nightly.2018.1.24+commit.b177352a",
+      "sha256": "0x79b12c7deb440e0c1fc32bf5f84003140b9eb568bb325d33602a906481a06a14",
       "keccak256": "0x0754a09e115324818bfede345ee6398ce04698b6d1ac8aa3fa97ab8fe2a97d61",
       "urls": [
-        "bzzr://264fc72a259070ba7d18b89731bdfe80001a68aa68f855a0c4de8cc6f7c8959a"
+        "bzzr://264fc72a259070ba7d18b89731bdfe80001a68aa68f855a0c4de8cc6f7c8959a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.24+commit.b177352a.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.24+commit.b177352a.js"
       ]
     },
     {
@@ -4985,9 +6353,12 @@
       "prerelease": "nightly.2018.1.25",
       "build": "commit.e7afde95",
       "longVersion": "0.4.20-nightly.2018.1.25+commit.e7afde95",
+      "sha256": "0xdb910441cc9852400c2f5b07a36f5dc18694fb450c050750fdaa769ce4116697",
       "keccak256": "0x1a9be339d7144634148daa07b2d9fa76965656c77b1e84369f62fee0b6d8e488",
       "urls": [
-        "bzzr://8ae74219f0ff969f09e37c41a62d1de01818ade8c79d2d54a6bff878d17fe39e"
+        "bzzr://8ae74219f0ff969f09e37c41a62d1de01818ade8c79d2d54a6bff878d17fe39e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.25+commit.e7afde95.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.25+commit.e7afde95.js"
       ]
     },
     {
@@ -4996,9 +6367,12 @@
       "prerelease": "nightly.2018.1.26",
       "build": "commit.bbad48bb",
       "longVersion": "0.4.20-nightly.2018.1.26+commit.bbad48bb",
+      "sha256": "0x29507b37c0571be5ddfe65e494e9089d3965c44295761835b81689e38abe26fe",
       "keccak256": "0x505b1fc02f8d242e88fc301469ba9734540e7a12f7bf96d1dbc2e318a9036e2d",
       "urls": [
-        "bzzr://b40f645b3c411dd0b64a57585345045ad9cc2f91a14b4d95ca5ecc835fa7dd7a"
+        "bzzr://b40f645b3c411dd0b64a57585345045ad9cc2f91a14b4d95ca5ecc835fa7dd7a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.26+commit.bbad48bb.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.26+commit.bbad48bb.js"
       ]
     },
     {
@@ -5007,9 +6381,12 @@
       "prerelease": "nightly.2018.1.29",
       "build": "commit.a668b9de",
       "longVersion": "0.4.20-nightly.2018.1.29+commit.a668b9de",
+      "sha256": "0x1223ff8a7a8515ddb84def268146483e9998da3bbef35c7bf3d2bb1d8b5ee136",
       "keccak256": "0x34a439b85ca68891d1d3caa5586764cd1c52204be73a5aae3af73b70cf2f1582",
       "urls": [
-        "bzzr://542f2e9f7e2f174ebab25c75deabe321e46ff03f31315cbb04ef8dbe1545e710"
+        "bzzr://542f2e9f7e2f174ebab25c75deabe321e46ff03f31315cbb04ef8dbe1545e710",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.1.29+commit.a668b9de.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.1.29+commit.a668b9de.js"
       ]
     },
     {
@@ -5018,9 +6395,12 @@
       "prerelease": "nightly.2018.2.12",
       "build": "commit.954903b5",
       "longVersion": "0.4.20-nightly.2018.2.12+commit.954903b5",
+      "sha256": "0xa3efc7db1f01ec591a0abbf598f46c75bc8fee1718d57d4d21a4fe0bbc8f4d7d",
       "keccak256": "0xc7336b7c81862829933d2a84f21793861c5d2ae77702fd2537890a2a62e0daa3",
       "urls": [
-        "bzzr://066ce9dce8c78e2141b32e074c16dc8bc61254f3c6e815e87c2296856a0bf69e"
+        "bzzr://066ce9dce8c78e2141b32e074c16dc8bc61254f3c6e815e87c2296856a0bf69e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.2.12+commit.954903b5.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.2.12+commit.954903b5.js"
       ]
     },
     {
@@ -5029,9 +6409,12 @@
       "prerelease": "nightly.2018.2.13",
       "build": "commit.27ef9794",
       "longVersion": "0.4.20-nightly.2018.2.13+commit.27ef9794",
+      "sha256": "0xc8ae386e328c582c1994e78b125094421a1e5c1e4d3de88da753de4881237d38",
       "keccak256": "0xb6e882e594150b886e120a0a6d3a91444d7dc1fe75bcb397f171914afc7b6607",
       "urls": [
-        "bzzr://6356ee57cd560834a5747981293838c723e30bb0d3fca31f4b87c276915d47b9"
+        "bzzr://6356ee57cd560834a5747981293838c723e30bb0d3fca31f4b87c276915d47b9",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20-nightly.2018.2.13+commit.27ef9794.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20-nightly.2018.2.13+commit.27ef9794.js"
       ]
     },
     {
@@ -5039,9 +6422,12 @@
       "version": "0.4.20",
       "build": "commit.3155dd80",
       "longVersion": "0.4.20+commit.3155dd80",
+      "sha256": "0x2dbd26d82bae11c5469c5a4cc6c04d96e8fa0d6c3e1a98052133840794ed28f6",
       "keccak256": "0xa4d676d718f45f3b81140bd4c3b2e8781b8fdd38203f61a344577ab95bcd89f6",
       "urls": [
-        "bzzr://58b337aa6762473f084d0065040044a29f072e8d6ac47066cdeffc6d04d5473e"
+        "bzzr://58b337aa6762473f084d0065040044a29f072e8d6ac47066cdeffc6d04d5473e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.20+commit.3155dd80.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.20+commit.3155dd80.js"
       ]
     },
     {
@@ -5050,9 +6436,12 @@
       "prerelease": "nightly.2018.2.14",
       "build": "commit.bb3b327c",
       "longVersion": "0.4.21-nightly.2018.2.14+commit.bb3b327c",
+      "sha256": "0x4695e31411926da9baaecc890d5c9aac414bb91f6532eb1bace3aecb48d304d0",
       "keccak256": "0x8115861d77a2452bdd782cae35d1944b7a5e8919e74eb7c1ce7d59b8fb43ddea",
       "urls": [
-        "bzzr://47917aa7d979355c95799cd9368f1bc2810808b7584c3dace95339ab28a957a8"
+        "bzzr://47917aa7d979355c95799cd9368f1bc2810808b7584c3dace95339ab28a957a8",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.14+commit.bb3b327c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.14+commit.bb3b327c.js"
       ]
     },
     {
@@ -5061,9 +6450,12 @@
       "prerelease": "nightly.2018.2.15",
       "build": "commit.f4aa05f3",
       "longVersion": "0.4.21-nightly.2018.2.15+commit.f4aa05f3",
+      "sha256": "0x4831762d8feedd70cf6d74309c775cf1769dec6efb431db6dcbff82d333ab11e",
       "keccak256": "0x12d0d2261be29ce7d8c398b17f9b115ce370f3e1c864913239ee31ce10dfdf97",
       "urls": [
-        "bzzr://9bac688fd880d77d6d9205501b688486a1d33120690a9131aa85244b1bd65cdf"
+        "bzzr://9bac688fd880d77d6d9205501b688486a1d33120690a9131aa85244b1bd65cdf",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.15+commit.f4aa05f3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.15+commit.f4aa05f3.js"
       ]
     },
     {
@@ -5072,9 +6464,12 @@
       "prerelease": "nightly.2018.2.16",
       "build": "commit.3f7e82d0",
       "longVersion": "0.4.21-nightly.2018.2.16+commit.3f7e82d0",
+      "sha256": "0x5212f5a53a3e78eedd680fd9480b2d1a23f6d0ef81932d296535597b511d6617",
       "keccak256": "0x51e400364f99c5645e631e3896ebf4f9dfe953cecd54820034e8a6379045d49f",
       "urls": [
-        "bzzr://790d6efc37cccd042271fec6b3b190fb3233514a4f909b087af5c1f768cb7475"
+        "bzzr://790d6efc37cccd042271fec6b3b190fb3233514a4f909b087af5c1f768cb7475",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.16+commit.3f7e82d0.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.16+commit.3f7e82d0.js"
       ]
     },
     {
@@ -5083,9 +6478,12 @@
       "prerelease": "nightly.2018.2.19",
       "build": "commit.839acafb",
       "longVersion": "0.4.21-nightly.2018.2.19+commit.839acafb",
+      "sha256": "0x01d169302c793339808e06a1b1475c84f5adc22eedde5e28ffc4e1d039aa8abb",
       "keccak256": "0x19a4daeaea6e18ab2302a2c4f29dea87139995370fc7b07b634549794d23f2c5",
       "urls": [
-        "bzzr://cee0acac6345d58ac55e8bb86e8917b28dd3417d9b6cca8494b3337cb2e9f262"
+        "bzzr://cee0acac6345d58ac55e8bb86e8917b28dd3417d9b6cca8494b3337cb2e9f262",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.19+commit.839acafb.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.19+commit.839acafb.js"
       ]
     },
     {
@@ -5094,9 +6492,12 @@
       "prerelease": "nightly.2018.2.20",
       "build": "commit.dcc4083b",
       "longVersion": "0.4.21-nightly.2018.2.20+commit.dcc4083b",
+      "sha256": "0x87920ff2cdadc1e9844066425062c0c17300a5c41115ad68fd2254ca891cb16f",
       "keccak256": "0xd069746e4ee386e75f9710b4ad45394d903b763a3bb78baf0a2b094f299903be",
       "urls": [
-        "bzzr://93fe7bbf49fd1161d1fa340fc2bf74a633c3199b3181fb7e22d2ba7a63c33b5e"
+        "bzzr://93fe7bbf49fd1161d1fa340fc2bf74a633c3199b3181fb7e22d2ba7a63c33b5e",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.20+commit.dcc4083b.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.20+commit.dcc4083b.js"
       ]
     },
     {
@@ -5105,9 +6506,12 @@
       "prerelease": "nightly.2018.2.21",
       "build": "commit.16c7eabc",
       "longVersion": "0.4.21-nightly.2018.2.21+commit.16c7eabc",
+      "sha256": "0x35f206a38f79a939e7db953e0a05b126428bb19e77389d21257651b4ec63f317",
       "keccak256": "0x3b0999c1bfc2c4239107134da7e952e206af34be964419a3ed1a573cb3df4405",
       "urls": [
-        "bzzr://e6733d2d3c5c0f34abc3bd00d37402c0b2078c6ed6b347f7d5b2ac156930dba4"
+        "bzzr://e6733d2d3c5c0f34abc3bd00d37402c0b2078c6ed6b347f7d5b2ac156930dba4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.21+commit.16c7eabc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.21+commit.16c7eabc.js"
       ]
     },
     {
@@ -5116,9 +6520,12 @@
       "prerelease": "nightly.2018.2.22",
       "build": "commit.71a34abd",
       "longVersion": "0.4.21-nightly.2018.2.22+commit.71a34abd",
+      "sha256": "0x06b68017f30744ecd17e2fb427205538847229efa8b27705db4433c308fddbf9",
       "keccak256": "0x570947b969f67d83aee69bb22b89ade6214907b784ab25ed75fc80e6f7dbe6ca",
       "urls": [
-        "bzzr://ebd0c3279e4630f2017632a00bdcd8dd523dedf6a60d6bc5f64aa1d1b9b3da25"
+        "bzzr://ebd0c3279e4630f2017632a00bdcd8dd523dedf6a60d6bc5f64aa1d1b9b3da25",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.22+commit.71a34abd.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.22+commit.71a34abd.js"
       ]
     },
     {
@@ -5127,9 +6534,12 @@
       "prerelease": "nightly.2018.2.23",
       "build": "commit.cae6cc2c",
       "longVersion": "0.4.21-nightly.2018.2.23+commit.cae6cc2c",
+      "sha256": "0x94db4ed24a5ff3120374acda161630187d95d931ae8d98270645cb1b7cfd58a7",
       "keccak256": "0x4d73bf4f2e64ac931321cbb0ab63a262278b7125333ba6c474f9ef92133bebdc",
       "urls": [
-        "bzzr://d1812ea940a0f918b87f5bbef6f2ed54007679fc8cca4203eee143dc20bed76d"
+        "bzzr://d1812ea940a0f918b87f5bbef6f2ed54007679fc8cca4203eee143dc20bed76d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.23+commit.cae6cc2c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.23+commit.cae6cc2c.js"
       ]
     },
     {
@@ -5138,9 +6548,12 @@
       "prerelease": "nightly.2018.2.26",
       "build": "commit.cd2d8936",
       "longVersion": "0.4.21-nightly.2018.2.26+commit.cd2d8936",
+      "sha256": "0xf7a24d0b12f9bd2545f6a8e54ad56ac4f3a2c614da0d40c9eead3f803b061234",
       "keccak256": "0x178002bf29983242916b73eae89c37a00294a1608dafd073a525cf6e94978447",
       "urls": [
-        "bzzr://0ad95eab48fa45ab8f5dae8abdc1168fa6c500af96dd58956ea88a8edb1422ee"
+        "bzzr://0ad95eab48fa45ab8f5dae8abdc1168fa6c500af96dd58956ea88a8edb1422ee",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.26+commit.cd2d8936.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.26+commit.cd2d8936.js"
       ]
     },
     {
@@ -5149,9 +6562,12 @@
       "prerelease": "nightly.2018.2.27",
       "build": "commit.415ac2ae",
       "longVersion": "0.4.21-nightly.2018.2.27+commit.415ac2ae",
+      "sha256": "0x28bd8245d87959cd74d889980055791565ace0fdab2ca1f4627bc42ea90e4c84",
       "keccak256": "0x4bc350add0fdb101a8cee12dadfb2336eea26a4527b43d0ad808bcff940254d8",
       "urls": [
-        "bzzr://ad3d91a6d6458763c9afb6e46f1b7b38c0f26cb930dc52205f6ab12b4062e78d"
+        "bzzr://ad3d91a6d6458763c9afb6e46f1b7b38c0f26cb930dc52205f6ab12b4062e78d",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.27+commit.415ac2ae.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.27+commit.415ac2ae.js"
       ]
     },
     {
@@ -5160,9 +6576,12 @@
       "prerelease": "nightly.2018.2.28",
       "build": "commit.ac5485a2",
       "longVersion": "0.4.21-nightly.2018.2.28+commit.ac5485a2",
+      "sha256": "0xb7abc2b7f62be2f61dfe612708432e7a9fcd5ff55b892bc1d875af4e69e3fde8",
       "keccak256": "0x37b0955799e58b115357630480a67623de7e9745cb06e4ba018b6d98f076d09f",
       "urls": [
-        "bzzr://13c29516ba5e2afd172041e5640292b3a25d35883a11c4e053d195961983e91a"
+        "bzzr://13c29516ba5e2afd172041e5640292b3a25d35883a11c4e053d195961983e91a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.2.28+commit.ac5485a2.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.2.28+commit.ac5485a2.js"
       ]
     },
     {
@@ -5171,9 +6590,12 @@
       "prerelease": "nightly.2018.3.1",
       "build": "commit.cf6720ea",
       "longVersion": "0.4.21-nightly.2018.3.1+commit.cf6720ea",
+      "sha256": "0x8ffe3622660c0bfb1ee6d660e7d119ac702b4cece9107a4265a8c27a8baeb642",
       "keccak256": "0xe023567a19ea835608655477df4f19301fe043991ac8299aa15d2d0065836768",
       "urls": [
-        "bzzr://16715e83cfd91c1b3fd4ca699a55c1d92fa5f9411fb10628a36f6955cbec3e82"
+        "bzzr://16715e83cfd91c1b3fd4ca699a55c1d92fa5f9411fb10628a36f6955cbec3e82",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.3.1+commit.cf6720ea.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.3.1+commit.cf6720ea.js"
       ]
     },
     {
@@ -5182,9 +6604,12 @@
       "prerelease": "nightly.2018.3.5",
       "build": "commit.cd6ffbdf",
       "longVersion": "0.4.21-nightly.2018.3.5+commit.cd6ffbdf",
+      "sha256": "0x52d30d418cfed12af199589c2b6a07f8c2bff030449c490a7018c2a80f7a033a",
       "keccak256": "0x4f8c7ef4f266bc8cbd83d85e9fef8aed32ab643e435a66f72d5b5dec6f725b0e",
       "urls": [
-        "bzzr://2ab18957a5d580396da76f9ed08e0173301a165a9277c4fc2529e1eadbde9446"
+        "bzzr://2ab18957a5d580396da76f9ed08e0173301a165a9277c4fc2529e1eadbde9446",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.3.5+commit.cd6ffbdf.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.3.5+commit.cd6ffbdf.js"
       ]
     },
     {
@@ -5193,9 +6618,12 @@
       "prerelease": "nightly.2018.3.6",
       "build": "commit.a9e02acc",
       "longVersion": "0.4.21-nightly.2018.3.6+commit.a9e02acc",
+      "sha256": "0xc38c09222a31cdc7beaff63b23f537b25309ad923b774eff95273f427e5b9b8e",
       "keccak256": "0x07242c4463dba168ba5c94d5f69a010eef0bbcc7429952603b6304411b5f56e1",
       "urls": [
-        "bzzr://4f91bb5f2b64b348c825897cc5ed1c194d72104cb98ceef46870ff731a19a61a"
+        "bzzr://4f91bb5f2b64b348c825897cc5ed1c194d72104cb98ceef46870ff731a19a61a",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.3.6+commit.a9e02acc.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.3.6+commit.a9e02acc.js"
       ]
     },
     {
@@ -5204,9 +6632,12 @@
       "prerelease": "nightly.2018.3.7",
       "build": "commit.bd7bc7c4",
       "longVersion": "0.4.21-nightly.2018.3.7+commit.bd7bc7c4",
+      "sha256": "0x8a171f6344b698a08dbf065eefc42b487c89c6b1685ccfdec57cbb5838e844cd",
       "keccak256": "0x0b47d5f52269fc0c2c4911fb09f614ab57848cdce255974574659b81d923bfb4",
       "urls": [
-        "bzzr://ff2b007152215bc9f138c792084c4f60933be3f4ed77a3fedab59638dac43ff4"
+        "bzzr://ff2b007152215bc9f138c792084c4f60933be3f4ed77a3fedab59638dac43ff4",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21-nightly.2018.3.7+commit.bd7bc7c4.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21-nightly.2018.3.7+commit.bd7bc7c4.js"
       ]
     },
     {
@@ -5214,9 +6645,12 @@
       "version": "0.4.21",
       "build": "commit.dfe3193c",
       "longVersion": "0.4.21+commit.dfe3193c",
+      "sha256": "0xc58b63408782a254767d1513bd20febfcda3e611a76932279d0ed507900cdc67",
       "keccak256": "0x0d044f67281d5901da07f83548e017f9843870c7a75adc81b8c3b3204a34cd0c",
       "urls": [
-        "bzzr://254e82a618047b9c6796caf7538907eb38dfcb8f1c43b0f6b219b9b4c87c8cec"
+        "bzzr://254e82a618047b9c6796caf7538907eb38dfcb8f1c43b0f6b219b9b4c87c8cec",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.21+commit.dfe3193c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.21+commit.dfe3193c.js"
       ]
     },
     {
@@ -5225,9 +6659,12 @@
       "prerelease": "nightly.2018.3.7",
       "build": "commit.b5e804b8",
       "longVersion": "0.4.22-nightly.2018.3.7+commit.b5e804b8",
+      "sha256": "0x0115bc2f605764d9cf12cc12751bd1bd87eea0c1c22b4825599446e2b2e99ed3",
       "keccak256": "0xbd1f64e62bcb97317d94a4451f468aa6403bb0e02afcc0c1096233588977a219",
       "urls": [
-        "bzzr://23baec38d8a75682f2be7fd5b4b7febc69ba0e686923bd6862fe4e56780e3442"
+        "bzzr://23baec38d8a75682f2be7fd5b4b7febc69ba0e686923bd6862fe4e56780e3442",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.7+commit.b5e804b8.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.7+commit.b5e804b8.js"
       ]
     },
     {
@@ -5236,9 +6673,12 @@
       "prerelease": "nightly.2018.3.8",
       "build": "commit.fbc29f6d",
       "longVersion": "0.4.22-nightly.2018.3.8+commit.fbc29f6d",
+      "sha256": "0x603cd6e462bdc4139f3681f64a5dfb842168209b5b65d06961a9e5faa5bd919a",
       "keccak256": "0xe5ed1c927d67c3b168102d979c62b16faf32cff9886c340ffffe154214eeec05",
       "urls": [
-        "bzzr://b9532c2306066545bfb136a8b18d9062b1b216cc1ad6de38a21913ea06eeae20"
+        "bzzr://b9532c2306066545bfb136a8b18d9062b1b216cc1ad6de38a21913ea06eeae20",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.8+commit.fbc29f6d.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.8+commit.fbc29f6d.js"
       ]
     },
     {
@@ -5247,9 +6687,12 @@
       "prerelease": "nightly.2018.3.12",
       "build": "commit.c6e9dd13",
       "longVersion": "0.4.22-nightly.2018.3.12+commit.c6e9dd13",
+      "sha256": "0xed5166b3d6310e30dd13231d84026b79da250734f73854f3d0055ba3ae526d26",
       "keccak256": "0x56092d977f54bdc788bbf18fc60c45466ec36c95a6e888b15d46a8e58a3a0183",
       "urls": [
-        "bzzr://52f602ba4508758b030e13de8782cd199961f96289c609157cd15dc39d401f08"
+        "bzzr://52f602ba4508758b030e13de8782cd199961f96289c609157cd15dc39d401f08",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.12+commit.c6e9dd13.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.12+commit.c6e9dd13.js"
       ]
     },
     {
@@ -5258,9 +6701,12 @@
       "prerelease": "nightly.2018.3.13",
       "build": "commit.f2614be9",
       "longVersion": "0.4.22-nightly.2018.3.13+commit.f2614be9",
+      "sha256": "0x184debb28d193a59b318b4e526ed81539c41f8db287337bb561e45da53cbb683",
       "keccak256": "0x9fafcef4437ea3837952a86e039ac5ad14499eab956708079a82664d757ac82d",
       "urls": [
-        "bzzr://59138c10076c218493170052aa9209273a77d9023dffac87cf1ea2ed26504ec7"
+        "bzzr://59138c10076c218493170052aa9209273a77d9023dffac87cf1ea2ed26504ec7",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.13+commit.f2614be9.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.13+commit.f2614be9.js"
       ]
     },
     {
@@ -5269,9 +6715,12 @@
       "prerelease": "nightly.2018.3.14",
       "build": "commit.c3f07b52",
       "longVersion": "0.4.22-nightly.2018.3.14+commit.c3f07b52",
+      "sha256": "0xb3d39d859924e3efaaa941cc753820a9a5a394d4f5947e25577395d7b04b4e08",
       "keccak256": "0xe1f87ed62225a48f014fcffce23dcf7579c38ab30b829c7559cc3448b1831609",
       "urls": [
-        "bzzr://1b897f2df9dac09096c83a0e2cbcfd989e0d8afe53713a1f12f84a8fd8bf4486"
+        "bzzr://1b897f2df9dac09096c83a0e2cbcfd989e0d8afe53713a1f12f84a8fd8bf4486",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.14+commit.c3f07b52.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.14+commit.c3f07b52.js"
       ]
     },
     {
@@ -5280,9 +6729,12 @@
       "prerelease": "nightly.2018.3.15",
       "build": "commit.3f1e0d84",
       "longVersion": "0.4.22-nightly.2018.3.15+commit.3f1e0d84",
+      "sha256": "0x1ff485fe74966022dc1cb61bf69e67a209634f22bcdc04921705671fb3da23ac",
       "keccak256": "0x1c1e3e162389885603114ac6e25bff043ae6b5ad62b26d115c69bdd32e418322",
       "urls": [
-        "bzzr://310cb806e5fc4836643f82770a75498ba181ff3412208c4047045ab304f98dbb"
+        "bzzr://310cb806e5fc4836643f82770a75498ba181ff3412208c4047045ab304f98dbb",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.15+commit.3f1e0d84.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.15+commit.3f1e0d84.js"
       ]
     },
     {
@@ -5291,9 +6743,12 @@
       "prerelease": "nightly.2018.3.16",
       "build": "commit.2b2527f3",
       "longVersion": "0.4.22-nightly.2018.3.16+commit.2b2527f3",
+      "sha256": "0x30593c0cef677cb81d4d380bad7c33b7d507584e8d0b941957f886ad66849fd4",
       "keccak256": "0xbfedb3d586cb8f01b600a537a3f8ea01f9decfc16733387240d4650fa9048a9a",
       "urls": [
-        "bzzr://d8944b44db749b5c25d402e6faa941dc564916441f951fe301a9280550f74e59"
+        "bzzr://d8944b44db749b5c25d402e6faa941dc564916441f951fe301a9280550f74e59",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.16+commit.2b2527f3.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.16+commit.2b2527f3.js"
       ]
     },
     {
@@ -5302,9 +6757,12 @@
       "prerelease": "nightly.2018.3.21",
       "build": "commit.8fd53c1c",
       "longVersion": "0.4.22-nightly.2018.3.21+commit.8fd53c1c",
+      "sha256": "0xe5158582eb811b7331dd3121a18f547dcab72e5014738c60ac5a18adc0cdd2f3",
       "keccak256": "0x7d3c11f46be9ac7fcd5e4ee1b9f5e327629c6a148fe9dc6406152e2f7106119b",
       "urls": [
-        "bzzr://4605432cda4936fe5d646a33c7add57f219e57040ccb8be027cfda87afc1117b"
+        "bzzr://4605432cda4936fe5d646a33c7add57f219e57040ccb8be027cfda87afc1117b",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.21+commit.8fd53c1c.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.21+commit.8fd53c1c.js"
       ]
     },
     {
@@ -5313,9 +6771,12 @@
       "prerelease": "nightly.2018.3.27",
       "build": "commit.af262281",
       "longVersion": "0.4.22-nightly.2018.3.27+commit.af262281",
+      "sha256": "0x1c9237b63fc377c5c7c206f915aee5479c65c11d25c98c439341cda9592d48d8",
       "keccak256": "0x61c2e916f021ce53b1c924cf1957780840542d7656354a66d4176504161362cb",
       "urls": [
-        "bzzr://db91d21dd69c41f40d6c1b6b313a3a10c18c2657d624c272f81c2dda1d7337ca"
+        "bzzr://db91d21dd69c41f40d6c1b6b313a3a10c18c2657d624c272f81c2dda1d7337ca",
+        "https://ethereum.github.io/solc-bin/bin/soljson-v0.4.22-nightly.2018.3.27+commit.af262281.js",
+        "http://ethereum.github.io/solc-bin/binsoljson-v0.4.22-nightly.2018.3.27+commit.af262281.js"
       ]
     }
   ],

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "semver": "^5.3.0"
   },
   "devDependencies": {
-    "ethereumjs-util": "^5.0.1",
-    "standard": "^8.4.0",
+    "ethereumjs-util": "^5.1.5",
+    "standard": "^11.0.0",
     "swarmhash": "^0.1.0"
   },
   "scripts": {

--- a/update
+++ b/update
@@ -39,6 +39,7 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
     .map(function (pars) {
       const fileContent = readFile(pars.path)
       pars.longVersion = buildVersion(pars)
+      pars.sha256 = '0x' + ethUtil.sha256(fileContent).toString('hex')
       pars.keccak256 = '0x' + ethUtil.sha3(fileContent).toString('hex')
       pars.urls = [ 'bzzr://' + swarmhash(fileContent).toString('hex') ]
       return pars

--- a/update
+++ b/update
@@ -41,7 +41,11 @@ fs.readdir(path.join(__dirname, '/bin'), function (err, files) {
       pars.longVersion = buildVersion(pars)
       pars.sha256 = '0x' + ethUtil.sha256(fileContent).toString('hex')
       pars.keccak256 = '0x' + ethUtil.sha3(fileContent).toString('hex')
-      pars.urls = [ 'bzzr://' + swarmhash(fileContent).toString('hex') ]
+      pars.urls = [
+        'bzzr://' + swarmhash(fileContent).toString('hex'),
+        'https://ethereum.github.io/solc-bin/bin/' + pars.path,
+        'http://ethereum.github.io/solc-bin/bin' + pars.path
+      ]
       return pars
     })
     .sort(function (a, b) {


### PR DESCRIPTION
After this change it is possible to rely only on `list.json` in a client. The client can look for `http://` or `https://` depending on what they run on.