### PR TITLE
[WIP] Github action for pulling in nightly builds from CircleCI

### DIFF
--- a/.github/workflows/pull-soljson.yml
+++ b/.github/workflows/pull-soljson.yml
@@ -1,0 +1,120 @@
+name: Pull in latest soljson build from CircleCI
+
+on:
+  schedule:
+    # Run once a day, at midnight
+    - cron: '0 0 * * *'
+
+jobs:
+  pull-soljson:
+    runs-on: ubuntu-latest
+
+    env:
+      JOB_NAME: b_ems
+      GIT_NAME: pull-soljson action
+      # TODO: Set a proper e-mail address
+      GIT_EMAIL: solidity@example.com
+      TARGET_BRANCH: master
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Clone the repository without checking out a working copy
+        run: |
+          repository_url="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git clone --no-checkout "$repository_url" "$GITHUB_WORKSPACE" --branch "$TARGET_BRANCH"
+          git config --local user.name "$GIT_NAME"
+          git config --local user.email "$GIT_EMAIL"
+
+      - name: Unstage all files from local index
+        run: |
+          # For some reason git stages all files for deletion when you use --no-checkout
+          git reset HEAD --quiet
+
+      - name: Check out only the files we're going to actually use
+        run: |
+          git checkout -- update package.json
+          git checkout -- bin/list.json
+          git checkout -- bin/list.js
+          git checkout -- bin/list.txt
+          git checkout -- wasm/list.json
+          git checkout -- wasm/list.js
+          git checkout -- wasm/list.txt
+
+          # FIXME: The update script crashes if there isn't at least one release already stored.
+          git checkout -- update bin/soljson-latest.js
+          git checkout -- update wasm/soljson-latest.js
+          git checkout -- update bin/soljson-v0.3.6+commit.3fc68da5.js
+          git checkout -- update wasm/soljson-v0.3.6+commit.3fc68da5.js
+
+      - name: Get job info using CircleCI API
+        run: |
+          job_info_endpoint="https://circleci.com/api/v1.1/project/github/ethereum/solidity?filter=successful&limit=100"
+          job_info=$(
+            curl --silent --show-error "$job_info_endpoint" |
+            jq '[ .[] | select (.workflows.job_name == "'${JOB_NAME}'") ] | sort_by(.build_num) | last'
+          )
+
+          build_num=$(echo "$job_info" | jq ".build_num")
+
+          commit_hash=$(echo "$job_info" | jq --raw-output ".vcs_revision" | head --bytes 8)
+          # FIXME: CircleCI API provides a tag name only if it's directly on the current commit.
+          solidity_version="[version-placeholder]"
+          nightly_version="${solidity_version}+commit.${commit_hash}"
+          version_already_exists="$(test -f "bin/soljson-$nightly_version.js" && echo true || true)"
+
+          echo "::set-env name=NIGHTLY_VERSION::${nightly_version}"
+          echo "::set-env name=VERSION_ALREADY_EXISTS::${version_already_exists}"
+          echo "::set-env name=BUILD_NUM::${build_num}"
+
+      - name: Get artifact URL using CircleCI API
+        if: "!env.VERSION_ALREADY_EXISTS"
+        run: |
+          artifacts_endpoint="https://circleci.com/api/v1.1/project/github/ethereum/solidity/${BUILD_NUM}/artifacts"
+          artifact_url=$(
+            curl --silent --show-error "$artifacts_endpoint" |
+            jq --raw-output '.[].url'
+          )
+
+          echo "::set-env name=ARTIFACT_URL::${artifact_url}"
+
+      - name: Download the binary from CircleCI
+        if: "!env.VERSION_ALREADY_EXISTS"
+        run: |
+          # TMP:
+          #curl --silent --show-error --location --create-dirs --output "$NIGHTLY_PATH" "$ARTIFACT_URL"
+          curl --silent --show-error --location --remote-name "$ARTIFACT_URL"
+          test -f soljson.js
+
+          cp soljson.js "bin/soljson-$NIGHTLY_VERSION.js"
+          mv soljson.js bin/soljson-nightly.js
+
+          # TODO: Add a symlink under wasm/ if it's a tagged commit
+          # [ "$TRAVIS_BRANCH" = release ] && ln -sf ../bin/"$NEWFILE" ./wasm/"$NEWFILE"
+
+      - name: Install dependencies of the update script using npm
+        if: "!env.VERSION_ALREADY_EXISTS"
+        run: |
+          npm install
+
+      - name: Run the script that updates the file lists
+        if: "!env.VERSION_ALREADY_EXISTS"
+        run: |
+          # FIXME: Since we do no check out old binaries, the script will clear the lists.
+          # Modify it to just append the new nightly instead.
+          npm run update
+
+      - name: Commit the nightly binary and updated lists
+        if: "!env.VERSION_ALREADY_EXISTS"
+        run: |
+          # TODO: Commit any wasm and release changes too
+          git add "bin/soljson-$NIGHTLY_VERSION.js"
+          git add bin/soljson-nightly.js
+          git add bin/list.json
+          git add bin/list.js
+          git add bin/list.txt
+          git commit -m "Nightly build ${NIGHTLY_VERSION}"
+
+      - name: Push the commit
+        if: "!env.VERSION_ALREADY_EXISTS"
+        run: |
+          git push origin "$TARGET_BRANCH"


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/9258.

### What works
1. Cloning `solc-bin` repo without checking out all the 10 GB of data. This makes it run in under a minute (compared to ~5 minutes with full checkout).
    - A partial checkout (using `git clone --filter blob:none`) makes it almost instant but then git downloads all the blobs when you commit anyway. Maybe I could get it to stop doing that somehow but 1 minute is already good enough, even for debugging.
    - Theoretically a shallow clone (`git clone --depth 1`) should make it download less data but that doesn't seem to be the case and even makes the whole operation run slower (~30 seconds longer).
2. Getting job information and downloading binaries from CircleCI without any tokens.
3. Running the update script.
4. Committing changes and pushing them back to the repo.

It's already running in my fork of `solc-bin`.

### What's still in progress
- [ ] For now I'm taking binaries from any recent `b_ems` job, even if it's still a PR. I need to switch to getting them only from `develop`.
    - The issue here is that the API endpoint gives me at most 100 recent jobs and jobs from `develop` run only once per day so they can be several pages down the list. I need to start using the `offset` query parameter for pagination and do multiple requests.
- [ ] CircleCI API does not provide information about tags other than those directly on the current commit so I can't use Solidity version in the file name yet.
    - Maybe I can get it using Github API. In the worst case I'll have to clone the Solidity repo just to get the tag.
- [ ] Binaries from tagged commits are not distinguished from ordinary nightlies yet.
- [ ] I'm not adding symlinks to `wasm/` directory yet.
- [ ] The update script needs to be modified to just append the nightly instead of rewriting the whole list.
    - I'm not checking out the old binaries so currently it removes them all from the lists.
- [ ] Add an extra validation that the CircleCI job produced exactly one artifact.
    - Maybe also a check to ensure that the files are not truncated or damaged in some way?
- [ ] Don't try to commit and push if there were no changes.

### Other
- [ ] I need an e-mail address to put in the committer field (currently it's `pull-soljson action <solidity@example.com>`).
- [ ] I have created a `master` branch in the repo and set it as the branch where the action adds new commits. Since there are external tools that rely on binaries hosted on GH pages, I think that it would be best to consider `gh-pages` frozen until we get S3 ready to serve the files instead and to work on `master` in the meantime.