### PR TITLE
Github action for emscripten nightly builds

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -1,0 +1,127 @@
+name: Emscripten nightly build + push to solc-bin
+
+on:
+  schedule:
+    # Run once a day, at midnight
+    - cron: '0 0 * * *'
+
+env:
+  TARGET_BRANCH: gh-pages
+  COMMITTER_NAME: emscripten nightly action
+  COMMITTER_EMAIL: builds@ethereum.org
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build-emscripten-nightly:
+    runs-on: ubuntu-latest
+    outputs:
+      solidity-version: ${{ env.SOLIDITY_VERSION }}
+      nightly-version: ${{ env.NIGHTLY_VERSION }}
+      matching-nightlies-in-the-repo: ${{ env.MATCHING_NIGHTLIES_IN_THE_REPO }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'ethereum/solidity'
+          ref: 'develop'
+          path: 'solidity/'
+
+      - name: Clone solc-bin repository without checking out a working copy
+        run: |
+          git clone --no-checkout --branch "$TARGET_BRANCH" "https://github.com/${GITHUB_REPOSITORY}.git" solc-bin/
+
+          # For some reason git stages all files for deletion when you use --no-checkout
+          cd solc-bin/
+          git reset HEAD --quiet
+
+      - name: Check if there's already a nightly with the same date or commit ID
+        run: |
+          cd solidity/
+          solidity_version=$("scripts/get_version.sh")
+          last_commit_timestamp=$(git log -1 --date=iso --format=%ad HEAD)
+          last_commit_date=$(date --date="$last_commit_timestamp" --utc +%Y.%-m.%-d)
+          last_commit_hash=$(git rev-parse --short=8 HEAD)
+
+          cd ../solc-bin/
+          matching_nightlies_in_the_repo="$(
+            git ls-files "bin/soljson-v${solidity_version}-nightly.${last_commit_date}+commit.*.js";
+            git ls-files "bin/soljson-v${solidity_version}-nightly.*+commit.${last_commit_hash}.js"
+          )"
+          nightly_version="v${solidity_version}-nightly.${last_commit_date}+commit.${last_commit_hash}"
+
+          echo "::set-env name=SOLIDITY_VERSION::${solidity_version}"
+          echo "::set-env name=NIGHTLY_VERSION::${nightly_version}"
+
+          # There's no way to just stop a job without failing and that would spam everyone with
+          # spurious e-mail notifications about the failure. Instead we have to make do with `if`s.
+          echo "::set-env name=MATCHING_NIGHTLIES_IN_THE_REPO::${matching_nightlies_in_the_repo}"
+
+      - name: Build soljson.js
+        if: "!env.MATCHING_NIGHTLIES_IN_THE_REPO"
+        run: |
+          cd solidity/
+          # Note that this script will spawn and build inside a docker image (which works just fine in github actions).
+          scripts/build_emscripten.sh
+
+      - name: Upload soljson.js as an artifact
+        if: "!env.MATCHING_NIGHTLIES_IN_THE_REPO"
+        uses: actions/upload-artifact@v2
+        with:
+          name: soljson.js
+          path: solidity/upload/soljson.js
+
+
+  test-emscripten-nightly:
+    runs-on: ubuntu-latest
+    needs: build-emscripten-nightly
+
+    env:
+      SOLIDITY_VERSION: ${{ needs.build-emscripten-nightly.outputs.solidity-version }}
+
+    if: "!needs.build-emscripten-nightly.outputs.matching-nightlies-in-the-repo"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          repository: 'ethereum/solidity'
+
+      - name: Download soljson.js artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: soljson.js
+
+      - name: Run solc-js tests
+        run: |
+          test/externalTests/solc-js/solc-js.sh "${PWD}/soljson.js" "$SOLIDITY_VERSION"
+
+
+  add-nightly-and-push:
+    runs-on: ubuntu-latest
+    needs:
+      - build-emscripten-nightly
+      - test-emscripten-nightly
+
+    env:
+      NIGHTLY_VERSION: ${{ needs.build-emscripten-nightly.outputs.nightly-version }}
+
+    if: "!needs.build-emscripten-nightly.outputs.matching-nightlies-in-the-repo"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          path: 'solc-bin'
+
+      - name: Download soljson.js artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: soljson.js
+
+      - name: Set committer name and e-mail
+        run: |
+          cd solc-bin/
+          git config --local user.name "$COMMITTER_NAME"
+          git config --local user.email "$COMMITTER_EMAIL"
+
+      - name: Run add-nightly-and-push.sh
+        run: |
+          cd solc-bin/
+          ./add-nightly-and-push.sh ../soljson.js "$NIGHTLY_VERSION"

--- a/add-nightly-and-push.sh
+++ b/add-nightly-and-push.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+#------------------------------------------------------------------------------
+# Adds a nightly binary to a local checkout of solc-bin repository, updates
+# file lists, commits and pushes the changes to the remote repository.
+#
+# The script expects to find the working copy in its working directory with
+# the right branch already checked out and all the details necessary to make
+# a commit and push it (committer name, `origin` remote, etc.) configured.
+#
+# The script fails if the specified version is already present in the
+# repository.
+#------------------------------------------------------------------------------
+
+set -e
+
+die() {
+    echo
+    >&2 echo "ERROR: $@" && false
+}
+
+nightly_binary="$1"
+nightly_version="$2"
+(( $# == 2 )) || die "Expected exactly 2 parameters."
+
+if [[ $(git status --porcelain) != "" ]]; then
+    >&2 git status
+    die "Uncommitted and/or untracked files present. This script must be executed in a clean working copy of the repository."
+fi
+
+echo "Adding bin/soljson-${nightly_version}.js"
+[[ ! -e "bin/soljson-${nightly_version}.js" ]] || die "File bin/soljson-${nightly_version}.js already exists."
+cp "$nightly_binary" "bin/soljson-${nightly_version}.js"
+
+# Stage the new nightly before running the list update to be able to detect any unintended changes caused by the script.
+git add --verbose "bin/soljson-$nightly_version.js"
+
+npm config set package-lock false
+npm install
+npm run update
+rm -r node_modules/
+
+git add --verbose bin/soljson-nightly.js
+git add --verbose bin/list.*
+
+git commit --message "Nightly build ${nightly_version}"
+
+if [[ $(git status --porcelain) != "" ]]; then
+    >&2 git status
+    die "Unexpected file modifications found. This should never happen and might be the result of a bug."
+fi
+
+git push origin HEAD


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/9258. Replaces #29.

Another go at the same problem. This time doing a full checkout and building `soljson.js` within the action instead of pulling it from CircleCI. This does make things simpler and pretty much solves all the outstanding problems from the previous PR. I just still need answers for the two questions below.

It's also significantly slower now: ~20 min for the build, ~3.5 min for git checkout, ~8 min for the update script.

I went with @ekpyron's suggestion and split the workflow into two jobs with `soljson.js` being passed between them as an artifact. This way we can still reuse the second part (that updates `solc-bin`) if we ever decide to go back to the solution with pulling from CircleCI.

#### Questions
- [x] ~I need an e-mail address to put in the committer field (currently it's `emscripten nightly action <solidity@example.com>`).~
    - I'll use builds@ethereum.org.
- [x] ~I have created a `master` branch in the repo and set it as the branch where the action adds new commits. Since there are external tools that rely on binaries hosted on GH pages, I think that it would be best to consider `gh-pages` frozen until we get S3 ready to serve the files instead and to work on `master` in the meantime.~
    - After discussing it on Gitter, I'm dropping the `master` branch. We'll keep updating `gh-pages` and just exclude files that go over the GH pages limit using jekyll config.