### PR TITLE
Update node.js dependencies to the latest versions to pull in newer keccak module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "semver": "^5.3.0"
   },
   "devDependencies": {
-    "ethereumjs-util": "^5.0.1",
-    "standard": "^8.4.0",
-    "swarmhash": "^0.1.0"
+    "ethereumjs-util": "^7.0.2",
+    "standard": "^14.3.4",
+    "swarmhash": "^0.1.1"
   },
   "scripts": {
     "lint": "standard update",

--- a/update
+++ b/update
@@ -43,8 +43,8 @@ dirs.forEach(function (dir) {
       .map(function (pars) {
         const fileContent = readFile(pars.path)
         pars.longVersion = buildVersion(pars)
-        pars.keccak256 = '0x' + ethUtil.sha3(fileContent).toString('hex')
-        pars.urls = [ 'bzzr://' + swarmhash(fileContent).toString('hex') ]
+        pars.keccak256 = '0x' + ethUtil.keccak(fileContent).toString('hex')
+        pars.urls = ['bzzr://' + swarmhash(fileContent).toString('hex')]
         return pars
       })
       .sort(function (a, b) {


### PR DESCRIPTION
This resolves the issue with `ethereumjs-util` pulling in an old version of `keccak` version that does not build on node.js >= 12. The problem was not making `npm install fail` because there's a fallback to the pure JS implementation but it ran slower because of that. After the update the script runs in ~5 minutes in a github action, compared to ~8 minutes before.

#### `npm install` output before this PR
```
> keccak@1.4.0 rebuild /home/runner/work/solc-bin/solc-bin/node_modules/keccak
> node-gyp rebuild

make: Entering directory '/home/runner/work/solc-bin/solc-bin/node_modules/keccak/build'
  CXX(target) Release/obj.target/keccak/src/addon.o
../src/addon.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE KeccakWrapper::Initialize(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/addon.cc:37:47: error: no matching function for call to ‘v8::Value::IntegerValue()’
     unsigned int rate = info[0]->IntegerValue();
                                               ^

(...)

make: *** [Release/obj.target/keccak/src/addon.o] Error 1
keccak.target.mk:129: recipe for target 'Release/obj.target/keccak/src/addon.o' failed
make: Leaving directory '/home/runner/work/solc-bin/solc-bin/node_modules/keccak/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:315:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
gyp ERR! System Linux 5.3.0-1031-azure
gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/runner/work/solc-bin/solc-bin/node_modules/keccak
gyp ERR! node -v v12.18.1
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok 
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! keccak@1.4.0 rebuild: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the keccak@1.4.0 rebuild script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-07-03T22_17_39_459Z-debug.log
Keccak bindings compilation fail. Pure JS implementation will be used.
```

#### `npm install` output after this PR
```
> keccak@3.0.0 install /home/runner/work/solc-bin/solc-bin/node_modules/keccak
> node-gyp-build || exit 0
```