### PR TITLE
Fix release truncation issue by changing symlinks

### DIFF
--- a/update
+++ b/update
@@ -111,45 +111,37 @@ dirs.forEach(function (dir) {
       console.log('Updated ' + dir + '/list.js')
     })
 
-    // Read latest release file
-    fs.readFile(path.join(__dirname, dir, latestReleaseFile), function (err, data) {
-      if (err) {
-        throw err
-      }
-
-      // Copy to bin/soljson-latest.js
-      fs.writeFile(path.join(__dirname, dir, '/soljson-latest.js'), data, function (err) {
+    if (dir === '/bin') {
+      // Read latest release file
+      fs.readFile(path.join(__dirname, dir, latestReleaseFile), function (err, data) {
         if (err) {
           throw err
         }
-        console.log('Updated ' + dir + '/soljson-latest.js')
-      })
 
-      if (dir === '/bin') {
-        // Copy to soljson.js
-        fs.writeFile(path.join(__dirname, '/soljson.js'), data, function (err) {
+        // Copy to bin/soljson-latest.js
+        fs.writeFile(path.join(__dirname, dir, '/soljson-latest.js'), data, function (err) {
           if (err) {
             throw err
           }
-          console.log('Updated soljson.js')
+          console.log('Updated ' + dir + '/soljson-latest.js')
         })
-      }
-    })
+      })
 
-    // Read latest build file
-    fs.readFile(path.join(__dirname, dir, latestBuildFile), function (err, data) {
-      if (err) {
-        throw err
-      }
-
-      // Copy to bin/soljson-nightly.js
-      fs.writeFile(path.join(__dirname, dir, '/soljson-nightly.js'), data, function (err) {
+      // Read latest build file
+      fs.readFile(path.join(__dirname, dir, latestBuildFile), function (err, data) {
         if (err) {
           throw err
         }
-        console.log('Updated ' + dir + '/soljson-nightly.js')
+
+        // Copy to bin/soljson-nightly.js
+        fs.writeFile(path.join(__dirname, dir, '/soljson-nightly.js'), data, function (err) {
+          if (err) {
+            throw err
+          }
+          console.log('Updated ' + dir + '/soljson-nightly.js')
+        })
       })
-    })
+    }
   })
 })
 

--- a/wasm/soljson-latest.js
+++ b/wasm/soljson-latest.js
@@ -1,1 +1,1 @@
-soljson-v0.6.10+commit.00c0fcaf.js
+../bin/soljson-latest.js

--- a/wasm/soljson-nightly.js
+++ b/wasm/soljson-nightly.js
@@ -1,1 +1,0 @@
-soljson-v0.6.10+commit.00c0fcaf.js


### PR DESCRIPTION
Resolves https://github.com/ethereum/solidity/issues/9261. Part of https://github.com/ethereum/solidity/issues/9258.

It's a PR to `master` but we should backport the fix to `gh-pages` too.

### Cause of the problem
See [diuscussion on Gitter](https://gitter.im/ethereum/solidity-dev?at=5f035269d65a3b0292d1217e)

@cameel
> ```
> ls -la wasm/soljson-*.js
> ```
> ```
> lrwxrwxrwx 1 cameel cameel 34 2020-07-06 17:33 wasm/soljson-latest.js -> soljson-v0.6.10+commit.00c0fcaf.js
> lrwxrwxrwx 1 cameel cameel 34 2020-07-06 17:33 wasm/soljson-nightly.js -> soljson-v0.6.10+commit.00c0fcaf.js
> lrwxrwxrwx 1 cameel cameel 41 2020-06-30 14:44 wasm/soljson-v0.6.10+commit.00c0fcaf.js -> ../bin/soljson-v0.6.10+commit.00c0fcaf.js
> ```
> 
> Looks like [the `solc-bin` commit that added Release 0.6.10](https://github.com/ethereum/solc-bin/commit/50d64646096a3af9c6c18b4ae109c74d3ce8dbd8) replaced `wasm/soljson-latest.js` and `wasm/soljson-nightly.js` with symlinks back to files in `bin/`.
> 
> The `update` script has not been updated to account for that so it still just overwrites them instead of updating the links. They both point at the same file and there are also asynchronous operations trying to read with from the file they're writing to.
> 
> So making things synchronous should fix this. But we should probably make the script take links into account instead.
> 
> Also, not sure if it's deliberate, but `wasm/soljson-nightly.js` points at the release file, not at a nightly build. Technically, it's the latest build available in the `wasm/` directory but I suspect this was not the intention. Should we really have `soljson-nightly.js` in that dir if it nightlies are not linked there?

@ekpyron
> We should (1) remove wasm/soljson-nightly.js, (2) just keep wasm/soljson-latest.js be a symlink to bin/soljson-latest.js that never changes and (3) remove all logic for soljson-nightly and soljson-latest for wasm/ from the update script.