### PR TITLE
Add an empty CircleCI config to silence the empty job that fails on every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2.1
+
+jobs:
+  build:
+    docker:
+      - image: alpine
+    steps:
+      - run: echo "This is an empty config just to keep CircleCI quiet."


### PR DESCRIPTION
Maybe we could just disable it in settings but I guess we would have done that long ago if that was that easy.