### PR TITLE
Deterministic sort order for nightlies

### DIFF
--- a/update
+++ b/update
@@ -48,8 +48,14 @@ dirs.forEach(function (dir) {
         return pars
       })
       .sort(function (a, b) {
-        // NOTE: a vs. b (the order is important), because we want oldest first in the list
-        return semver.compare(a.longVersion, b.longVersion)
+        if (a.longVersion === b.longVersion) {
+          return 0
+        }
+
+        // NOTE: a vs. b (the order is important), because we want oldest first on parsedList.
+        // NOTE: If semver considers two versions equal we don't have enough info to say which came earlier
+        // so we don't care about their relative order as long as it's deterministic.
+        return semver.compare(a.longVersion, b.longVersion) || (a.longVersion > b.longVersion ? -1 : 1)
       })
 
     // descending list


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/9258. Related to https://github.com/ethereum/solc-bin/pull/30#issuecomment-655719136.

> [Semantic Versioning 2.0.0 > bullet point 10](https://semver.org/#spec-item-10)
> > Build metadata MUST be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3—-117B344092BD.
>
> So e.g. `0.4.2-nightly.2016.9.17+commit.212e0160` is treated as equal to `v0.4.2-nightly.2016.9.17+commit.a78e7794`. We have to add an extra commit hash comparison if we want the order to be stable.

This PR solves the same problem as #36 but also ensures that it won't happen again. I think we should merge both.