### PR TITLE
Add missing wasm symlink for release 0.6.11

### DIFF
--- a/wasm/list.js
+++ b/wasm/list.js
@@ -1,5 +1,6 @@
 
 var soljsonSources = [
+  "soljson-v0.6.11+commit.5ef660b1.js",
   "soljson-v0.6.10+commit.00c0fcaf.js",
   "soljson-v0.6.9+commit.3e3065ac.js",
   "soljson-v0.6.8+commit.0bbfe453.js",
@@ -58,6 +59,7 @@ var soljsonSources = [
   "soljson-v0.3.6+commit.3fc68da5.js"
 ];
 var soljsonReleases = {
+  "0.6.11": "soljson-v0.6.11+commit.5ef660b1.js",
   "0.6.10": "soljson-v0.6.10+commit.00c0fcaf.js",
   "0.6.9": "soljson-v0.6.9+commit.3e3065ac.js",
   "0.6.8": "soljson-v0.6.8+commit.0bbfe453.js",

--- a/wasm/list.json
+++ b/wasm/list.json
@@ -559,9 +559,20 @@
       "urls": [
         "bzzr://823b4efe3ca2964d660348214fd1a44579e13e1e8ce69a81f447372a11d60316"
       ]
+    },
+    {
+      "path": "soljson-v0.6.11+commit.5ef660b1.js",
+      "version": "0.6.11",
+      "build": "commit.5ef660b1",
+      "longVersion": "0.6.11+commit.5ef660b1",
+      "keccak256": "0xf0abd02c495a0b4c5c9a7ff20de8b932e11fc3066d0b754422035ecd96fcdbbc",
+      "urls": [
+        "bzzr://9f9244a3605543a67f5ff35f21e3d6d3331a6e1361f09b271c37f396b5b89bd5"
+      ]
     }
   ],
   "releases": {
+    "0.6.11": "soljson-v0.6.11+commit.5ef660b1.js",
     "0.6.10": "soljson-v0.6.10+commit.00c0fcaf.js",
     "0.6.9": "soljson-v0.6.9+commit.3e3065ac.js",
     "0.6.8": "soljson-v0.6.8+commit.0bbfe453.js",
@@ -619,5 +630,5 @@
     "0.4.0": "soljson-v0.4.0+commit.acd334c9.js",
     "0.3.6": "soljson-v0.3.6+commit.3fc68da5.js"
   },
-  "latestRelease": "0.6.10"
+  "latestRelease": "0.6.11"
 }

--- a/wasm/list.txt
+++ b/wasm/list.txt
@@ -1,3 +1,4 @@
+soljson-v0.6.11+commit.5ef660b1.js
 soljson-v0.6.10+commit.00c0fcaf.js
 soljson-v0.6.9+commit.3e3065ac.js
 soljson-v0.6.8+commit.0bbfe453.js

--- a/wasm/soljson-v0.6.11+commit.5ef660b1.js
+++ b/wasm/soljson-v0.6.11+commit.5ef660b1.js
@@ -1,0 +1,1 @@
+../bin/soljson-v0.6.11+commit.5ef660b1.js


### PR DESCRIPTION
Based on #33 (even though it doesn't depend on it) because subsequent PRs depend on both.
Part of https://github.com/ethereum/solidity/issues/9258.

Looks like 3b74dc32d213cead6d1c3fb276c2467e2d67c1fc added 0.6.11 only to `bin/` and not `wasm/`.