### PR TITLE
Convert bin/soljson-latest.js back from symlink to a copy

### DIFF
--- a/update
+++ b/update
@@ -31,6 +31,33 @@ function updateSymlink (linkPathRelativeToRoot, targetRelativeToLink) {
   })
 }
 
+function updateCopy (srcRelativeToRoot, destRelativeToRoot) {
+  fs.readFile(path.join(__dirname, srcRelativeToRoot), function (err, data) {
+    if (err) {
+      throw err
+    }
+
+    const absoluteDest = path.join(__dirname, destRelativeToRoot)
+    fs.stat(absoluteDest, function (err, stats) {
+      if (err && err.code !== 'ENOENT') {
+        throw err
+      }
+
+      // If the target is a symlink, we want to replace it with a copy rather than overwrite the file it links to
+      if (!err && stats.isSymbolicLink()) {
+        fs.unlinkSync(absoluteDest)
+      }
+
+      fs.writeFile(absoluteDest, data, function (err) {
+        if (err) {
+          throw err
+        }
+        console.log('Updated ' + destRelativeToRoot)
+      })
+    })
+  })
+}
+
 function processDir (dir, listCallback) {
   fs.readdir(path.join(__dirname, dir), { withFileTypes: true }, function (err, files) {
     if (err) {

--- a/update
+++ b/update
@@ -9,7 +9,7 @@ const ethUtil = require('ethereumjs-util')
 const swarmhash = require('swarmhash')
 
 // This script updates the index files list.js and list.txt in the directories containing binaries,
-// as well as the 'latest' and 'nightly' symlinks.
+// as well as the 'latest' and 'nightly' symlinks/files.
 
 function updateSymlink (linkPathRelativeToRoot, targetRelativeToLink) {
   const absoluteLinkPath = path.join(__dirname, linkPathRelativeToRoot)
@@ -186,8 +186,12 @@ function processDir (dir, listCallback) {
       console.log('Updated ' + dir + '/list.js')
     })
 
-    // Update 'latest' symlink (except for wasm/ where the link is hard-coded to point at the one in bin/)
-    if (dir !== '/wasm') {
+    // Update 'latest' symlink (except for wasm/ where the link is hard-coded to point at the one in bin/).
+    // bin/ is a special case because we need to keep a copy rather than a symlink. The reason is that
+    // some tools (in particular solc-js) have hard-coded github download URLs to it and can't handle symlinks.
+    if (dir === '/bin') {
+      updateCopy(path.join(dir, latestReleaseFile), path.join(dir, binaryPrefix + '-latest' + binaryExtension))
+    } else if (dir !== '/wasm') {
       updateSymlink(path.join(dir, binaryPrefix + '-latest' + binaryExtension), latestReleaseFile)
     }
 


### PR DESCRIPTION
Turns out that the "Unexpected number" error is still there even after #43. I just got it while running `solc-js` tests locally:
```
# loading remote version - development snapshot
soljson-latest.js:1
soljson-v0.6.11+commit.5ef660b1.js
          ^^

SyntaxError: Unexpected number
    at wrapSafe (internal/modules/cjs/loader.js:1117:16)
    at Module._compile (internal/modules/cjs/loader.js:1165:27)
    at requireFromString (/tmp/tmp.MHw54T6wnQ/solc/node_modules/require-from-string/index.js:28:4)
    at IncomingMessage.<anonymous> (/tmp/tmp.MHw54T6wnQ/solc/wrapper.js:338:35)
    at IncomingMessage.emit (events.js:326:22)
    at endReadableNT (_stream_readable.js:1226:12)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
npm ERR! Test failed.  See above for more details.
```

It's a different (but related) problem. This test uses `solc-js` to download `bin/soljson-latest.js`. It's a symlink now and `soljson-v0.6.11+commit.5ef660b1.js` in the above is actually the file content (rather than a name) which `solc-js` tries to intepret as JavaScript and fails.

In this PR I'm reverting the change that made this file a symlink and changing the `update` script back to handle this. While at it, I added safeguards against overwriting symlink targets to prevent bugs like #32 from popping up again. I'm keeping `bin/soljson-nightly.js` as a symlink since tests don't rely on it and really, `solc-js` will have this problem with any of the symlinks in `bin/` of which there are many - this is just a workaround for them, not a fix.