### PR TITLE
Fix race condition in symlink creation in the update script

### DIFF
--- a/update
+++ b/update
@@ -11,24 +11,27 @@ const swarmhash = require('swarmhash')
 // This script updates the index files list.js and list.txt in the directories containing binaries,
 // as well as the 'latest' and 'nightly' symlinks/files.
 
-function updateSymlink (linkPathRelativeToRoot, targetRelativeToLink) {
+function updateSymlinkSync (linkPathRelativeToRoot, targetRelativeToLink) {
   const absoluteLinkPath = path.join(__dirname, linkPathRelativeToRoot)
+  let linkString
 
-  fs.readlink(absoluteLinkPath, (err, linkString) => {
-    if (err && err.code !== 'ENOENT') {
-      throw err
-    }
+  try {
+    linkString = fs.readlinkSync(absoluteLinkPath)
 
-    if (!err && targetRelativeToLink !== linkString) {
+    if (targetRelativeToLink !== linkString) {
       fs.unlinkSync(absoluteLinkPath)
       console.log('Removed link ' + linkPathRelativeToRoot + ' -> ' + linkString)
     }
-
-    if (err || targetRelativeToLink !== linkString) {
-      fs.symlinkSync(targetRelativeToLink, absoluteLinkPath, 'file')
-      console.log('Created link ' + linkPathRelativeToRoot + ' -> ' + targetRelativeToLink)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
     }
-  })
+  }
+
+  if (targetRelativeToLink !== linkString) {
+    fs.symlinkSync(targetRelativeToLink, absoluteLinkPath, 'file')
+    console.log('Created link ' + linkPathRelativeToRoot + ' -> ' + targetRelativeToLink)
+  }
 }
 
 function updateCopy (srcRelativeToRoot, destRelativeToRoot) {
@@ -192,12 +195,12 @@ function processDir (dir, listCallback) {
     if (dir === '/bin') {
       updateCopy(path.join(dir, latestReleaseFile), path.join(dir, binaryPrefix + '-latest' + binaryExtension))
     } else if (dir !== '/wasm') {
-      updateSymlink(path.join(dir, binaryPrefix + '-latest' + binaryExtension), latestReleaseFile)
+      updateSymlinkSync(path.join(dir, binaryPrefix + '-latest' + binaryExtension), latestReleaseFile)
     }
 
     // Update 'nightly' symlink in bin/ (we don't have nightlies for other platforms)
     if (dir === '/bin') {
-      updateSymlink(path.join(dir, binaryPrefix + '-nightly' + binaryExtension), latestBuildFile)
+      updateSymlinkSync(path.join(dir, binaryPrefix + '-nightly' + binaryExtension), latestBuildFile)
     }
   })
 }
@@ -221,7 +224,7 @@ DIRS.forEach(function (dir) {
       // We don't need to do this for emscripten-asmjs/ because we don't build asm.js releases any more.
       parsedList.forEach(function (release) {
         if (release.prerelease === undefined) {
-          updateSymlink(
+          updateSymlinkSync(
             path.join('/emscripten-wasm32', 'solc-emscripten-wasm32-v' + release.longVersion + '.js'),
             path.join('..', 'wasm', release.path)
           )


### PR DESCRIPTION
Fixes the issue we encountered in https://github.com/ethereum/solc-bin/pull/46#issuecomment-662655276. Part of https://github.com/ethereum/solidity/issues/9258.

The problem is that I made processing of `emscripten-wasm32/` dir wait until `wasm` finishes processing its files but the link creation that happens at that point is still asynchronous.

There are multiple `updateSymlink()` calls in a loop so one solution would be to wait for all of them using `Promise`s. But for simplicity I just made `updateSymlink()` synchronous instead.