### PR TITLE
Creating wasm/ symlinks in the update script

### DIFF
--- a/update
+++ b/update
@@ -207,7 +207,6 @@ function processDir (dir, listCallback) {
 
 const DIRS = [
   '/bin',
-  '/emscripten-asmjs',
   '/linux-amd64',
   '/macosx-amd64',
   '/windows-amd64'
@@ -227,10 +226,16 @@ DIRS.forEach(function (dir) {
               path.join('/wasm', release.path),
               path.join('..', 'bin', release.path)
             )
+          } else {
+            updateSymlinkSync(
+              path.join('/emscripten-asmjs', 'solc-emscripten-asmjs-v' + release.longVersion + '.js'),
+              path.join('..', 'bin', release.path)
+            )
           }
         }
       })
 
+      processDir('/emscripten-asmjs')
       processDir('/wasm', function (parsedList) {
         // Any new releases added to wasm/ need to be linked in emscripten-wasm32/ first.
         parsedList.forEach(function (release) {

--- a/update
+++ b/update
@@ -207,7 +207,6 @@ function processDir (dir, listCallback) {
 
 const DIRS = [
   '/bin',
-  '/wasm',
   '/emscripten-asmjs',
   '/linux-amd64',
   '/macosx-amd64',
@@ -215,23 +214,36 @@ const DIRS = [
 ]
 
 DIRS.forEach(function (dir) {
-  if (dir !== '/wasm') {
+  if (dir !== '/bin') {
     processDir(dir)
   } else {
     processDir(dir, function (parsedList) {
-      // Any new releases added to wasm/ need to be linked in emscripten-wasm32/ first.
-      // Only then can we start processing emscripten-wasm32/.
-      // We don't need to do this for emscripten-asmjs/ because we don't build asm.js releases any more.
+      // Any new releases added to bin/ need to be linked in other directories before we can start processing them.
       parsedList.forEach(function (release) {
         if (release.prerelease === undefined) {
-          updateSymlinkSync(
-            path.join('/emscripten-wasm32', 'solc-emscripten-wasm32-v' + release.longVersion + '.js'),
-            path.join('..', 'wasm', release.path)
-          )
+          // Starting with 0.6.2 we no longer build asm.js releases and the new builds added to bin/ are all wasm.
+          if (semver.gt(release.version, '0.6.1')) {
+            updateSymlinkSync(
+              path.join('/wasm', release.path),
+              path.join('..', 'bin', release.path)
+            )
+          }
         }
       })
 
-      processDir('/emscripten-wasm32')
+      processDir('/wasm', function (parsedList) {
+        // Any new releases added to wasm/ need to be linked in emscripten-wasm32/ first.
+        parsedList.forEach(function (release) {
+          if (release.prerelease === undefined) {
+            updateSymlinkSync(
+              path.join('/emscripten-wasm32', 'solc-emscripten-wasm32-v' + release.longVersion + '.js'),
+              path.join('..', 'wasm', release.path)
+            )
+          }
+        })
+
+        processDir('/emscripten-wasm32')
+      })
     })
   }
 })


### PR DESCRIPTION
Depends on #48. Part of https://github.com/ethereum/solidity/issues/9258.

It used to be the [responsibility of `publish_binary.sh`](https://github.com/ethereum/solidity/blob/v0.6.12/scripts/travis-emscripten/publish_binary.sh#L90) but this script is not a part of the new, manual process of adding binaries to `solc-bin`. I made `update` do it instead.