### PR TITLE
Async file read to lower memory usage in update script

### DIFF
--- a/bin/list.json
+++ b/bin/list.json
@@ -11066,7 +11066,8 @@
       "longVersion": "0.7.3-nightly.2020.9.30+commit.3af21c92",
       "keccak256": "0x3b72d54b6af0fb49ecaff56e465f0421f2a4c648c58920d8a75bfd7fee748225",
       "urls": [
-        "bzzr://6712bc949619d81962c074c26e3a63ae2864602f03b78c624498c50c67a515e3"
+        "bzzr://6712bc949619d81962c074c26e3a63ae2864602f03b78c624498c50c67a515e3",
+        "dweb:/ipfs/QmXjsuAATrJSNbFwVHsiPTHg3qxrUYJRVaMn1RaMAHfMuE"
       ]
     }
   ],

--- a/update
+++ b/update
@@ -3,6 +3,7 @@
 'use strict'
 
 const fs = require('fs')
+const util = require('util')
 const path = require('path')
 const semver = require('semver')
 const ethUtil = require('ethereumjs-util')
@@ -134,7 +135,8 @@ async function makeEntry (dir, parsedFileName, oldList) {
   }
 
   if (!build.keccak256 || !build.urls || build.urls.length !== 2) {
-    const fileContent = fs.readFileSync(absolutePath)
+    const readFile = util.promisify(fs.readFile)
+    const fileContent = await readFile(absolutePath)
     build.keccak256 = '0x' + ethUtil.keccak(fileContent).toString('hex')
     console.log("Computing hashes of '" + pathRelativeToRoot + "'")
     build.urls = [


### PR DESCRIPTION
Workaround for https://github.com/ethereum/solidity/issues/9956.

This is basically a hack. Or at most a harmless optimization that we should not really rely on.

Currently IPFS hash computation is queued for asynchronous execution only after the whole file has been read into memory and processed using keccak and swarm's hashing function. This results in all the read operations being executed first and hogging a lot of memory that can't be freed until IPFS hashing finishes. Making read asynchronous allows the IPFS hashing to be queued immediately and be interleaved with read operations. This lowers peak memory usage to about 6 GB on my machine. I think this should be enough to at least stop crashing the nightly builds even if it doesn't solve the problem completely.