### PR TITLE
Remove deprecated set-env from github actions

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -49,12 +49,12 @@ jobs:
           )"
           nightly_version="v${solidity_version}-nightly.${last_commit_date}+commit.${last_commit_hash}"
 
-          echo "::set-env name=SOLIDITY_VERSION::${solidity_version}"
-          echo "::set-env name=NIGHTLY_VERSION::${nightly_version}"
+          echo "SOLIDITY_VERSION=${solidity_version}" >> $GITHUB_ENV
+          echo "NIGHTLY_VERSION=${nightly_version}" >> $GITHUB_ENV
 
           # There's no way to just stop a job without failing and that would spam everyone with
           # spurious e-mail notifications about the failure. Instead we have to make do with `if`s.
-          echo "::set-env name=MATCHING_NIGHTLIES_IN_THE_REPO::${matching_nightlies_in_the_repo}"
+          echo "MATCHING_NIGHTLIES_IN_THE_REPO=${matching_nightlies_in_the_repo}" >> $GITHUB_ENV
 
       - name: Build soljson.js
         if: "!env.MATCHING_NIGHTLIES_IN_THE_REPO"


### PR DESCRIPTION
Fixes warnings that started appearing in the nightly action:
> .github#L1
> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/