### PR TITLE
Fix multiline variables no longer working in GitHub actions

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       solidity-version: ${{ env.SOLIDITY_VERSION }}
       nightly-version: ${{ env.NIGHTLY_VERSION }}
-      matching-nightlies-in-the-repo: ${{ env.MATCHING_NIGHTLIES_IN_THE_REPO }}
+      nightly-already-exists: ${{ env.NIGHTLY_ALREADY_EXISTS }}
 
     steps:
       - uses: actions/checkout@v2
@@ -47,6 +47,7 @@ jobs:
             git ls-files "bin/soljson-v${solidity_version}-nightly.${last_commit_date}+commit.*.js";
             git ls-files "bin/soljson-v${solidity_version}-nightly.*+commit.${last_commit_hash}.js"
           )"
+          nightly_already_exists="$(test -n "$matching_nightlies_in_the_repo" && echo true || echo false)"
           nightly_version="v${solidity_version}-nightly.${last_commit_date}+commit.${last_commit_hash}"
 
           echo "SOLIDITY_VERSION=${solidity_version}" >> $GITHUB_ENV
@@ -54,17 +55,17 @@ jobs:
 
           # There's no way to just stop a job without failing and that would spam everyone with
           # spurious e-mail notifications about the failure. Instead we have to make do with `if`s.
-          echo "MATCHING_NIGHTLIES_IN_THE_REPO=${matching_nightlies_in_the_repo}" >> $GITHUB_ENV
+          echo "NIGHTLY_ALREADY_EXISTS=${nightly_already_exists}" >> $GITHUB_ENV
 
       - name: Build soljson.js
-        if: "!env.MATCHING_NIGHTLIES_IN_THE_REPO"
+        if: "env.NIGHTLY_ALREADY_EXISTS == 'false'"
         run: |
           cd solidity/
           # Note that this script will spawn and build inside a docker image (which works just fine in github actions).
           scripts/build_emscripten.sh
 
       - name: Upload soljson.js as an artifact
-        if: "!env.MATCHING_NIGHTLIES_IN_THE_REPO"
+        if: "env.NIGHTLY_ALREADY_EXISTS == 'false'"
         uses: actions/upload-artifact@v2
         with:
           name: soljson.js
@@ -78,7 +79,7 @@ jobs:
     env:
       SOLIDITY_VERSION: ${{ needs.build-emscripten-nightly.outputs.solidity-version }}
 
-    if: "!needs.build-emscripten-nightly.outputs.matching-nightlies-in-the-repo"
+    if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -103,7 +104,7 @@ jobs:
     env:
       NIGHTLY_VERSION: ${{ needs.build-emscripten-nightly.outputs.nightly-version }}
 
-    if: "!needs.build-emscripten-nightly.outputs.matching-nightlies-in-the-repo"
+    if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -34,24 +34,28 @@ jobs:
           cd solc-bin/
           git reset HEAD --quiet
 
-      - name: Check if there's already a nightly with the same date or commit ID
+      - name: Determine Solidity version
         run: |
           cd solidity/
-          solidity_version=$("scripts/get_version.sh")
           last_commit_timestamp=$(git log -1 --date=iso --format=%ad HEAD)
           last_commit_date=$(date --date="$last_commit_timestamp" --utc +%Y.%-m.%-d)
           last_commit_hash=$(git rev-parse --short=8 HEAD)
-
-          cd ../solc-bin/
-          matching_nightlies_in_the_repo="$(
-            git ls-files "bin/soljson-v${solidity_version}-nightly.${last_commit_date}+commit.*.js";
-            git ls-files "bin/soljson-v${solidity_version}-nightly.*+commit.${last_commit_hash}.js"
-          )"
-          nightly_already_exists="$(test -n "$matching_nightlies_in_the_repo" && echo true || echo false)"
+          solidity_version=$("scripts/get_version.sh")
           nightly_version="v${solidity_version}-nightly.${last_commit_date}+commit.${last_commit_hash}"
 
+          echo "LAST_COMMIT_DATE=${last_commit_date}" >> $GITHUB_ENV
+          echo "LAST_COMMIT_HASH=${last_commit_hash}" >> $GITHUB_ENV
           echo "SOLIDITY_VERSION=${solidity_version}" >> $GITHUB_ENV
           echo "NIGHTLY_VERSION=${nightly_version}" >> $GITHUB_ENV
+
+      - name: Check if there's already a nightly with the same date or commit ID
+        run: |
+          cd solc-bin/
+          matching_nightlies_in_the_repo="$(
+            git ls-files "bin/soljson-v${SOLIDITY_VERSION}-nightly.${LAST_COMMIT_DATE}+commit.*.js";
+            git ls-files "bin/soljson-v${SOLIDITY_VERSION}-nightly.*+commit.${LAST_COMMIT_HASH}.js"
+          )"
+          nightly_already_exists="$(test -n "$matching_nightlies_in_the_repo" && echo true || echo false)"
 
           # There's no way to just stop a job without failing and that would spam everyone with
           # spurious e-mail notifications about the failure. Instead we have to make do with `if`s.


### PR DESCRIPTION
Apparently the new syntax (#60) for setting environment variables in github actions does not work when the variable value spans multiple lines. That's the case with `MATCHING_NIGHTLIES_IN_THE_REPO` in the nightly action when a matching binary is found. I replaced it with a "boolean" flag.

The good news is that this broke the nightly action only in cases where the build would have been skipped anyway (i.e. because there were no new commits in `solidity`) so we did not really miss any actual builds.