### PR TITLE
Replace linux 0.4.26 build with the binary from 0.4.26 docker image

### DIFF
--- a/linux-amd64/list.json
+++ b/linux-amd64/list.json
@@ -197,11 +197,11 @@
       "version": "0.4.26",
       "build": "commit.4563c3fc",
       "longVersion": "0.4.26+commit.4563c3fc",
-      "keccak256": "0x0d5fcb9bc7534458207abbf64d9f93462bf70f8a7eae6ca259f627e4c1401b2d",
-      "sha256": "0x9f9da5a12fca278d75165f4ca75ee9d290d9f0bd8cabd59f16bf39cf0ac62192",
+      "keccak256": "0x5ee9bf00d10e712f1d43b94df82a17c4a2382a622f41ef67757f83fcbb0a604c",
+      "sha256": "0x5d577b3f7918dd735ab157e2f37a21d06c90469f13868359874f15184f2fa4d0",
       "urls": [
-        "bzzr://3a5c5800c1bc2b60b0c99cd8ed8bb74fdda09348a88d2b7099ba49346b8b0199",
-        "dweb:/ipfs/QmS3va55A2wvVvanqCtFzmhf4ePsuPdt7iFrNLUF6HXE7B"
+        "bzzr://ec7ce34dca7075d994468cfc407b0cddd2fd5d6426d5ba3bc7b9f0471304e11d",
+        "dweb:/ipfs/QmbVDnn2V5uvBZk6vBXSELYvQLZQfegQUNygn3nXMyfrTU"
       ]
     },
     {


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/10840.
~Depends on #76.~
Depends on #91.

I'm not sure if we really want to solve https://github.com/ethereum/solidity/issues/10840 this way but it's certainly one way to do this.
The binary from the [0.4.26 docker image](https://hub.docker.com/layers/ethereum/solc/0.4.26/images/sha256-2e9558c26d9b8659e52fea33a6f744190c5ad9ac8a70e628097ab2fbdc30800e) produces different bytecode on the problematic test case and the asm version looks like the one produced by binaries for other platforms. I used it to replace the one currently in this repo. I'm creating this PR as a draft to see if it passes the comparison on all test cases.

If we want this then we should consider also replacing the binary on the github release page (it's identical to the one in solc-bin).