### PR TITLE
Free up disk space in Github Actions

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -20,6 +20,14 @@ jobs:
       nightly-already-exists: ${{ env.NIGHTLY_ALREADY_EXISTS }}
 
     steps:
+      - name: Remove unused software to free up space
+        run: |
+          # These are quick to delete and large enough to make a difference
+          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
+          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
+          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
+          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+
       - uses: actions/checkout@v2
         with:
           repository: 'ethereum/solidity'
@@ -111,6 +119,14 @@ jobs:
 
     if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
+      - name: Remove unused software to free up space
+        run: |
+          # These are quick to delete and large enough to make a difference
+          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
+          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
+          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
+          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.TARGET_BRANCH }}

--- a/.github/workflows/random-macosx-build.yml
+++ b/.github/workflows/random-macosx-build.yml
@@ -358,6 +358,14 @@ jobs:
 
     if: "needs.select-solc-version.outputs.solidity-version"
     steps:
+      - name: Remove unused software to free up space
+        run: |
+          # These are quick to delete and large enough to make a difference
+          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
+          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
+          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
+          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+
       - uses: actions/checkout@v2
         with:
           ref: ${{ env.TARGET_BRANCH }}

--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -20,6 +20,14 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Remove unused software to free up space
+        run: |
+          # These are quick to delete and large enough to make a difference
+          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
+          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
+          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
+          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+
       - name: Wait for other instances of this workflow to finish
         # It's not safe to run two S3 sync operations concurrently with different files
         uses: softprops/turnstyle@v1

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -27,6 +27,16 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
+      - name: Remove unused software to free up space
+        # macOS runners apparently have > 70 GB free so it's only needed on Ubuntu
+        if: "env.PLATFORM != 'macosx-amd64'"
+        run: |
+          # These are quick to delete and large enough to make a difference
+          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
+          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
+          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
+          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+
       - uses: actions/setup-python@v2
         with:
           # Use the latest minor release of Python 3. prepare_report.py requires Python >= 3.7


### PR DESCRIPTION
Currently all of the Github Actions in this repo that check out a working copy run out of disk space and fail.

Apparently the disk in the Github Actions is big enough (~84 GB) but only ~16 GB is free. The rest is taken up by software. Looks like a lot of it can be recovered though. The two biggest space hogs are .NET and Android SDK. They take ~40 GB total. Unfortunately they have lots of files and subdirectories (.NET has 40k subdirs) and removing them all takes over 10 min.

So far I have determined that removing the following subdirectories frees up ~16 GB and takes only 10-15 s:
```bash
rm -rf /usr/share/swift/                        # 1.3 Gb in 80 subdirs
rm -rf /usr/local/lib/android/sdk/build-tools   # 2.1 Gb in 450 subdirs
rm -rf /usr/share/dotnet/shared                 # 5.3 Gb in 350 subdirs
rm -rf /usr/local/lib/android/sdk/ndk           # 7.6 Gb in 1500 subdirs
```
We could cut the time in half by dropping `ndk` but I think that 15 s is quick enough.

This seems to be necessary only on `ubuntu-latest`. On `macosx-10.15` there's a lot of free space already:
```
 Filesystem      Size   Used  Avail Capacity iused      ifree %iused  Mounted on
/dev/disk1s5   380Gi   11Gi   71Gi    13%  488309 3982052091    0%   /
devfs          184Ki  184Ki    0Bi   100%     636          0  100%   /dev
/dev/disk1s1   380Gi  298Gi   71Gi    81% 7827519 3974712881    0%   /System/Volumes/Data
/dev/disk1s4   380Gi  1.0Mi   71Gi     1%       1 3982540399    0%   /private/var/vm
map auto_home    0Bi    0Bi    0Bi   100%       0          0  100%   /System/Volumes/Data/home
```