### PR TITLE
Use the right head ref in bytecode PR check

### DIFF
--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -66,7 +66,7 @@ jobs:
           "${base_dir}/solidity/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh" \
             "$PLATFORM" \
             "origin/${{ github.base_ref }}" \
-            "${GITHUB_REF}" \
+            "origin/${GITHUB_HEAD_REF}" \
             "$base_dir/solc-bin" \
             "$base_dir/solidity"
 


### PR DESCRIPTION
Github's docs on [Environment Variables](https://docs.github.com/en/actions/reference/environment-variables) say:

> `GITHUB_REF`
> The branch or tag ref that triggered the workflow. For example, `refs/heads/feature-branch-1`. If neither a branch or tag is available for the event type, the variable will not exist.

Turns out this is not completely true. For example [PR #90 is failing CI checks](https://github.com/ethereum/solc-bin/pull/90/checks?check_run_id=2402697989) because `GITHUB_REF` is `refs/pull/90/merge` which is neither a tag nor a branch:
```
fatal: ambiguous argument 'refs/pull/90/merge': unknown revision or path not in the working tree.
```

This PR replaces it with `GITHUB_HEAD_REF` which is hopefully what we need. This problem went undetected until now because of https://github.com/ethereum/solidity/pull/11189 and because locally I only tested the script with actual branch names.