### PR TITLE
[s3-mirror] Invalidate cached lists and some symlinks after sync

### DIFF
--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -13,6 +13,7 @@ on:
 env:
   S3_BUCKET: solc-bin
   S3_REGION: eu-central-1
+  CLOUDFRONT_DISTRIBUTION_ID: E1O6GT57WUFUHD
 
 jobs:
   push-to-s3:
@@ -51,4 +52,4 @@ jobs:
 
       - name: Sync the S3 bucket
         run: |
-          ./sync-s3.sh "$S3_BUCKET"
+          ./sync-s3.sh "$S3_BUCKET" "$CLOUDFRONT_DISTRIBUTION_ID"

--- a/sync-s3.sh
+++ b/sync-s3.sh
@@ -44,8 +44,8 @@ done
 echo "===> Removing files that should not be uploaded to S3"
 # NOTE: This ensures that they will be deleted from the bucket if they're already there.
 # If we used `aws s3 sync --delete --exclude` instead, they would not get deleted.
-find -path './.*' -delete
-find -path './_*' -delete
+find . -path './.*' -delete
+find . -path './_*' -delete
 
 echo "===> Adding compatibility symlinks for files containing plus signs in the name"
 # NOTE: This is a quick'n'dirty workaround for Amazon S3 decoding plus sign in paths


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/11572
This is also the second part of the fix for https://github.com/ethereum/devops/issues/789

The first part was to re-enable caching for list files. This should improve transfer speeds because people will be getting them from CloudFront cache rather than from our regional S3 bucket.

The downside is that changes to them might not be visible for up to 24h after we sync. The second part of the fix helps with that - we issue a cache invalidation command immediately after the sync.