### PR TITLE
Update dependencies to the latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@ version: 2.1
 jobs:
   chk_npm_lint_and_test:
     docker:
-      - image: circleci/node
+      # FIXME: sha3 package fails to build on latest node.js (version 17)
+      - image: circleci/node:16
     resource_class: xlarge
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "version": "0.0.0",
   "description": "Current and historical (emscripten) binaries for Solidity",
   "dependencies": {
-    "semver": "^5.3.0"
+    "semver": "^7.3.5"
   },
   "devDependencies": {
-    "ethereumjs-util": "^7.0.2",
-    "standard": "^14.3.4",
+    "ethereumjs-util": "^7.1.3",
+    "standard": "^16.0.4",
     "swarmhash": "^0.1.1",
-    "ipfs-unixfs-importer": "^3.0.4",
-    "ipld-in-memory": "^6.0.0",
-    "ipld": "^0.27.1"
+    "ipfs-unixfs-importer": "^9.0.6",
+    "ipld-in-memory": "^8.0.0",
+    "ipld": "^0.30.2"
   },
   "scripts": {
     "lint": "standard update",

--- a/update
+++ b/update
@@ -16,9 +16,14 @@ const swarmhash = require('swarmhash')
 // as well as the 'latest' and 'nightly' symlinks/files.
 
 const ipfsHash = async (content) => {
-  for await (const { cid } of ipfsImporter([{ content }], await inMemory(IPLD), { onlyHash: true })) {
-    return cid.toString()
+  const iterator = ipfsImporter.importer([{ content }], await inMemory(IPLD), { onlyHash: true })
+  const { value, done } = await iterator.next()
+  if (done) {
+    throw new Error('Failed to calculate an IPFS hash.')
   }
+
+  await iterator.return()
+  return value.cid.toString()
 }
 
 function generateLegacyListJS (builds, releases) {
@@ -231,6 +236,7 @@ function processDir (dir, options, listCallback) {
         if (version.prerelease === undefined) {
           return version
         }
+        return undefined
       })
       .map(function (version) {
         return version.version


### PR DESCRIPTION
Depends on #101 (technically it's independent but tests won't pass without it). Draft until that PR is merged.

While trying to solve the problem from #101 I tried updating dependencies. This did not solve it but we should update them anyway.

One of the dependencies ([js-ipld](https://github.com/ipld/js-ipld)) seems to have been deprecated and replaced by [js-multiformats](https://github.com/multiformats/js-multiformats). We should switch eventually but this PR only updates it to the latest version of the original package for now.