### PR TITLE
Downgrade node.js in npm&lint PR check to work around sha3 build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,8 @@ version: 2.1
 jobs:
   chk_npm_lint_and_test:
     docker:
-      - image: circleci/node
+      # FIXME: sha3 package fails to build on latest node.js (version 17)
+      - image: circleci/node:16
     resource_class: xlarge
     steps:
       - checkout


### PR DESCRIPTION
The [`chk_npm_lint_and_test`](https://app.circleci.com/pipelines/github/ethereum/solc-bin/872/workflows/457e6725-fdba-4168-83b6-f0751c5df92a/jobs/885) job on CircleCI has been failing for a few days now. There seems to be some problem building the `sha3` module:

```
npm ERR! ../../nan/nan_typedarray_contents.h:34:43: error: ‘class v8::ArrayBuffer’ has no member named ‘GetContents’
npm ERR!    34 |       data   = static_cast<char*>(buffer->GetContents().Data()) + byte_offset;
npm ERR!       | 
```

It does not fail for me locally on node.js 14 or 16 but looks like we're running node.js 17 in CI. Downgrading resolves the problem.