### PR TITLE
Reduce concurrency in the `update` script to lower memory usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       # FIXME: sha3 package fails to build on latest node.js (version 17)
       - image: circleci/node:16
-    resource_class: xlarge
+    resource_class: small
     steps:
       - checkout
       - run: npm install

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "lint": "standard update",
-    "update": "./update",
+    "update": "./update --max-files-per-batch 1",
     "test": "git checkout -f && npm run update && git diff --exit-code"
   },
   "repository": {

--- a/update
+++ b/update
@@ -155,6 +155,18 @@ async function makeEntry (dir, parsedFileName, oldList) {
   return build
 }
 
+async function batchedAsyncMap (values, batchSize, asyncMapFunction) {
+  if (batchSize === null) {
+    batchSize = values.length
+  }
+
+  let results = []
+  for (let i = 0; i < values.length; i += batchSize) {
+    results = results.concat(await Promise.all(values.slice(i, i + batchSize).map(asyncMapFunction)))
+  }
+  return results
+}
+
 function processDir (dir, options, listCallback) {
   fs.readdir(path.join(__dirname, dir), { withFileTypes: true }, async function (err, files) {
     if (err) {
@@ -183,25 +195,26 @@ function processDir (dir, options, listCallback) {
     }[dir] || ''
 
     // ascending list (oldest version first)
-    const parsedList = (await Promise.all(
-      files
-        .filter(function (file) {
-          // Skip symbolic links with less then 8 characters in the commit hash.
-          // They exist only for backwards-compatibilty and should not be on the list.
-          return dir !== '/bin' ||
-            !file.isSymbolicLink() ||
-            file.name.match(/^.+\+commit\.[0-9a-f]{8,}\.js$/)
+    const parsedFileNames = files
+      .filter(function (file) {
+        // Skip symbolic links with less then 8 characters in the commit hash.
+        // They exist only for backwards-compatibilty and should not be on the list.
+        return dir !== '/bin' ||
+          !file.isSymbolicLink() ||
+          file.name.match(/^.+\+commit\.[0-9a-f]{8,}\.js$/)
+      })
+      .map(function (file) { return file.name })
+      .map(function (binaryName) {
+        const escapedExtensions = binaryExtensions.map(function (binaryExtension) {
+          return binaryExtension.replace('.', '\\.')
         })
-        .map(function (file) { return file.name })
-        .map(function (binaryName) {
-          const escapedExtensions = binaryExtensions.map(function (binaryExtension) {
-            return binaryExtension.replace('.', '\\.')
-          })
-          return binaryName.match(new RegExp('^' + binaryPrefix + '-v([0-9.]*)(-([^+]*))?(\\+(.*))?(' + escapedExtensions.join('|') + ')$'))
-        })
-        .filter(function (matchResult) { return matchResult !== null })
-        .map(async function (matchResult) { return await makeEntry(dir, matchResult, oldList) })
-    ))
+        return binaryName.match(new RegExp('^' + binaryPrefix + '-v([0-9.]*)(-([^+]*))?(\\+(.*))?(' + escapedExtensions.join('|') + ')$'))
+      })
+      .filter(function (matchResult) { return matchResult !== null })
+
+    const parsedList = (await batchedAsyncMap(parsedFileNames, options.maxFilesPerBatch, async function (matchResult) {
+      return await makeEntry(dir, matchResult, oldList)
+    }))
       .sort(function (a, b) {
         if (a.longVersion === b.longVersion) {
           return 0
@@ -317,10 +330,23 @@ function processDir (dir, options, listCallback) {
 
 function parseCommandLine () {
   let reuseHashes
+  let maxFilesPerBatch
 
   for (let i = 2; i < process.argv.length; ++i) {
     if (process.argv[i] === '--reuse-hashes') {
       reuseHashes = true
+    } else if (process.argv[i] === '--max-files-per-batch') {
+      if (i + 1 >= process.argv.length) {
+        console.error('Expected an integer argument after --max-files-per-batch.')
+        process.exit(1)
+      }
+
+      maxFilesPerBatch = parseInt(process.argv[i + 1], 10)
+      if (isNaN(maxFilesPerBatch) || maxFilesPerBatch <= 0) {
+        console.error("Expected the argument of --max-files-per-batch to be a positive integer, got '" + process.argv[i + 1] + "'.")
+        process.exit(1)
+      }
+      ++i
     } else {
       console.error("Invalid option: '" + process.argv[i] + "'.")
       process.exit(1)
@@ -331,9 +357,13 @@ function parseCommandLine () {
   if (reuseHashes === undefined) {
     reuseHashes = false
   }
+  if (maxFilesPerBatch === undefined) {
+    maxFilesPerBatch = null // no limit
+  }
 
   return {
     reuseHashes: reuseHashes,
+    maxFilesPerBatch: maxFilesPerBatch
   }
 }
 

--- a/update
+++ b/update
@@ -316,18 +316,24 @@ function processDir (dir, options, listCallback) {
 }
 
 function parseCommandLine () {
-  if (process.argv.length > 3) {
-    console.error('Expected at most one argument, got ' + (process.argv.length - 2))
-    process.exit(1)
+  let reuseHashes
+
+  for (let i = 2; i < process.argv.length; ++i) {
+    if (process.argv[i] === '--reuse-hashes') {
+      reuseHashes = true
+    } else {
+      console.error("Invalid option: '" + process.argv[i] + "'.")
+      process.exit(1)
+    }
   }
 
-  if (process.argv.length === 3 && process.argv[2] !== '--reuse-hashes') {
-    console.error('Invalid argument: ' + process.argv[2])
-    process.exit(1)
+  // Defaults
+  if (reuseHashes === undefined) {
+    reuseHashes = false
   }
 
   return {
-    reuseHashes: process.argv.length === 3 && process.argv[2] === '--reuse-hashes'
+    reuseHashes: reuseHashes,
   }
 }
 

--- a/update
+++ b/update
@@ -183,21 +183,24 @@ function processDir (dir, options, listCallback) {
     }[dir] || ''
 
     // ascending list (oldest version first)
-    const parsedList = (await Promise.all(files
-      .filter(function (file) {
-        // Skip symbolic links with less then 8 characters in the commit hash.
-        // They exist only for backwards-compatibilty and should not be on the list.
-        return dir !== '/bin' ||
-          !file.isSymbolicLink() ||
-          file.name.match(/^.+\+commit\.[0-9a-f]{8,}\.js$/)
-      })
-      .map(function (file) { return file.name })
-      .map(function (file) {
-        const escapedExtensions = binaryExtensions.map(function (binaryExtension) { return binaryExtension.replace('.', '\\.') })
-        return file.match(new RegExp('^' + binaryPrefix + '-v([0-9.]*)(-([^+]*))?(\\+(.*))?(' + escapedExtensions.join('|') + ')$'))
-      })
-      .filter(function (version) { return version })
-      .map(async function (pars) { return await makeEntry(dir, pars, oldList) })
+    const parsedList = (await Promise.all(
+      files
+        .filter(function (file) {
+          // Skip symbolic links with less then 8 characters in the commit hash.
+          // They exist only for backwards-compatibilty and should not be on the list.
+          return dir !== '/bin' ||
+            !file.isSymbolicLink() ||
+            file.name.match(/^.+\+commit\.[0-9a-f]{8,}\.js$/)
+        })
+        .map(function (file) { return file.name })
+        .map(function (binaryName) {
+          const escapedExtensions = binaryExtensions.map(function (binaryExtension) {
+            return binaryExtension.replace('.', '\\.')
+          })
+          return binaryName.match(new RegExp('^' + binaryPrefix + '-v([0-9.]*)(-([^+]*))?(\\+(.*))?(' + escapedExtensions.join('|') + ')$'))
+        })
+        .filter(function (matchResult) { return matchResult !== null })
+        .map(async function (matchResult) { return await makeEntry(dir, matchResult, oldList) })
     ))
       .sort(function (a, b) {
         if (a.longVersion === b.longVersion) {
@@ -217,7 +220,8 @@ function processDir (dir, options, listCallback) {
 
     // descending list
     const releases = parsedList
-      .slice().reverse()
+      .slice()
+      .reverse()
       .reduce(function (prev, next) {
         if (next.prerelease === undefined) {
           prev[next.version] = next.path
@@ -227,19 +231,21 @@ function processDir (dir, options, listCallback) {
 
     // descending list
     const buildNames = parsedList
-      .slice().reverse()
-      .map(function (ver) { return ver.path })
+      .slice()
+      .reverse()
+      .map(function (listEntry) { return listEntry.path })
 
     const latestRelease = parsedList
-      .slice().reverse()
-      .filter(function (version) {
-        if (version.prerelease === undefined) {
-          return version
+      .slice()
+      .reverse()
+      .filter(function (listEntry) {
+        if (listEntry.prerelease === undefined) {
+          return listEntry
         }
         return undefined
       })
-      .map(function (version) {
-        return version.version
+      .map(function (listEntry) {
+        return listEntry.version
       })[0]
 
     // latest build (nightly)


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/9956.

This turned out to be pretty easy to solve without extra libraries, I just needed to read up a bit on the specifics of JavaScript's `async`/`await` mechanism and promises. A lot of the noise in the PR really comes from small refactors.

This adds an option called `--max-files-per-batch` that lets you specify how many files to process simultaneously. The number is actually the number of async calls per batch. Each call processes a single binary and there are multiple batches being processed simultaneously, but only one per directory. So by setting it to N you'll get D * N simultaneous calls, where D is the number of dirs containing binaries.

After testing with various limits to figure out what to use in CI it looks like we might not be losing anything by setting it simply to 1:
- `--max-files-per-batch 1`: time (user+sys) = 533+13s, memory = ~350 MB
- `--max-files-per-batch 50`: time (user+sys) = 523+10s, memory = ~1.5 GB
- no limit: time (user+sys) = 531+10s, memory = ~11 GB MB

Surprisingly, looks like there's virtually no benefit from async processing. Maybe the time spent being blocked on disk I/O is negligible compared to time spent hashing?

Since we were using an `xlarge` machine only due to memory usage, I'm changing that to `small` now.