### PR TITLE
Pass prerelease option to nightly builds

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -50,7 +50,6 @@ jobs:
           last_commit_hash=$(git rev-parse --short=8 HEAD)
           solidity_version=$("scripts/get_version.sh")
           nightly_version="v${solidity_version}-nightly.${last_commit_date}+commit.${last_commit_hash}"
-          echo "nightly.${last_commit_date}" > prerelease.txt
 
           echo "LAST_COMMIT_DATE=${last_commit_date}" >> $GITHUB_ENV
           echo "LAST_COMMIT_HASH=${last_commit_hash}" >> $GITHUB_ENV
@@ -75,7 +74,7 @@ jobs:
         run: |
           cd solidity/
           # Note that this script will spawn and build inside a docker image (which works just fine in github actions).
-          scripts/build_emscripten.sh
+          scripts/build_emscripten.sh --prerelease-source "nightly"
 
       - name: Upload soljson.js as an artifact
         if: "env.NIGHTLY_ALREADY_EXISTS == 'false'"


### PR DESCRIPTION
Updates the CI job to use `emscripten_build` script with `prerelease` parameter introduced by https://github.com/ethereum/solidity/pull/13581.

Depends on https://github.com/ethereum/solidity/pull/13581.