### PR TITLE
Replace deprecated js-ipld module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
   },
   "devDependencies": {
     "ethereumjs-util": "^7.1.3",
-    "ipfs-unixfs-importer": "^9.0.6",
-    "ipld": "^0.30.2",
-    "ipld-in-memory": "^8.0.0",
+    "blockstore-core": "^2.0.2",
+    "ipfs-unixfs-importer": "^11.0.1",
     "standard": "^16.0.4",
     "swarmhash": "^0.1.1"
   },

--- a/update
+++ b/update
@@ -7,21 +7,24 @@ const util = require('util')
 const path = require('path')
 const semver = require('semver')
 const ethUtil = require('ethereumjs-util')
-const ipfsImporter = require('ipfs-unixfs-importer')
-const IPLD = require('ipld')
-const inMemory = require('ipld-in-memory')
 const swarmhash = require('swarmhash')
 
 // This script updates the index files list.js and list.txt in the directories containing binaries,
 // as well as the 'latest' and 'nightly' symlinks/files.
 
 const ipfsHash = async (content) => {
-  const iterator = ipfsImporter.importer([{ content }], await inMemory(IPLD), { onlyHash: true })
+  // Version ipfs-unixfs-importer@v10.0.0 dropped support to CommonJS, and it is now ESM-only.
+  // https://github.com/ipfs/js-ipfs-unixfs/blob/master/packages/ipfs-unixfs-importer/CHANGELOG.md#-breaking-changes-1
+  // FIXME: We need to migrate from CommonJS to ESM eventually.
+  // The below is a workaround to dynamically import the ESM modules at runtime from a CJS module
+  const { importer } = await import('ipfs-unixfs-importer')
+  const { MemoryBlockstore } = await import('blockstore-core/memory')
+
+  const iterator = importer([{ content }], new MemoryBlockstore(), { onlyHash: true })
   const { value, done } = await iterator.next()
   if (done) {
     throw new Error('Failed to calculate an IPFS hash.')
   }
-
   await iterator.return()
   return value.cid.toString()
 }


### PR DESCRIPTION
Fix https://github.com/ethereum/solidity/issues/12244

This PR adds a workaround to switch from the deprecated `js-ipld` to `js-multiformats`. It dynamically loads the ipfs modules that are now ESM-only. The proper fix requires us to migrate our modules from CommonJS to ESM format.

Most of the ipfs modules became [ESM-only](https://github.com/ipfs/js-ipfs/blob/master/docs/upgrading/v0.62-v0.63.md#esm), including `ipfs-unixfs-importer`, which dropped support to CommonJS in version [10.0.0](https://github.com/ipfs/js-ipfs-unixfs/blob/master/packages/ipfs-unixfs-importer/CHANGELOG.md#-breaking-changes-1).