### PR TITLE
Remove redundant libraries to compute IPFS hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "solc-bin",
+  "type": "module",
   "version": "0.0.0",
   "description": "Current and historical (emscripten) binaries for Solidity",
   "dependencies": {
@@ -8,15 +9,14 @@
   },
   "devDependencies": {
     "ethereumjs-util": "^7.1.3",
-    "ipfs-unixfs-importer": "^9.0.6",
-    "ipld": "^0.30.2",
-    "ipld-in-memory": "^8.0.0",
+    "blockstore-core": "^2.0.2",
+    "ipfs-unixfs-importer": "^11.0.1",
     "standard": "^16.0.4",
     "swarmhash": "^0.1.1"
   },
   "scripts": {
-    "lint": "standard update",
-    "update": "./update --max-files-per-batch 1",
+    "lint": "standard update.mjs",
+    "update": "node update.mjs --max-files-per-batch 1",
     "test": "git checkout -f && npm run update && git diff --exit-code"
   },
   "repository": {


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/12244.

@cameel I have made a research of how to use `multiformat` and how it can be applicable here. It is possible but requires rewriting quite a bunch of code. However, I decided to juggle a bit the code and founded out that here:
https://github.com/ethereum/solc-bin/blob/33fb994d977bbf271685f65b5137c7f547323baf/update#L19
`inMemory` function only append in memory storage to a newly instantiated `IPLD` object.

As you advised, I removed all the artifacts by `rm */list.json */list.txt */list.js` and ran `./update`. The only method from `IPLD` that was used is `constructor`. It looks like without manipulation with block all other methods provided by `IPLD` do not needed. Replacement with a simple `IPLDProvider` works as the previous version did.

If I made a mistake somewhere please advise.