### PR TITLE
Keep compatibility with CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "name": "solc-bin",
-  "type": "module",
   "version": "0.0.0",
   "description": "Current and historical (emscripten) binaries for Solidity",
   "dependencies": {


### PR DESCRIPTION
Having `type: module` in the `package.json` enforces that all `.js` files under the package scope are treated as ES modules, which is not true and will cause problems when importing `soljson.js` in solc-js.

The ESM support was added to solc-bin in https://github.com/ethereum/solc-bin/pull/125 due to a recent breaking change in `js-ipfs` that since version `0.63.x` dropped support to CommonJS : https://github.com/ipfs/js-ipfs/blob/master/docs/upgrading/v0.62-v0.63.md#esm