### PR TITLE
Fix nodejs version to 16 in nightly builds

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -118,6 +118,11 @@ jobs:
 
     if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
+      # TODO: remove when https://github.com/axic/keccakjs/issues/13 got fixed
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
       - name: Remove unused software to free up space
         run: |
           # These are quick to delete and large enough to make a difference

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -27,6 +27,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
+      # TODO: remove when https://github.com/axic/keccakjs/issues/13 got fixed
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
The docker runner images of Github actions had the default nodejs version updated to `18`, see: https://github.com/actions/runner-images/issues/7002

Sadly, some CI jobs, like the [nightly builds](https://github.com/ethereum/solc-bin/actions/runs/4238005281/jobs/7365127264) started to fail due to requirement of nodejs version`16`, needed for the `sha3` library: https://github.com/axic/keccakjs/issues/13. So we are fixing the nodejs version for now until we fix the issue.


