### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -28,7 +28,7 @@ jobs:
           rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
           rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'ethereum/solidity'
           ref: 'develop'
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload soljson.js as an artifact
         if: "env.NIGHTLY_ALREADY_EXISTS == 'false'"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: soljson.js
           path: solidity/upload/soljson.js
@@ -93,12 +93,12 @@ jobs:
 
     if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'ethereum/solidity'
 
       - name: Download soljson.js artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: soljson.js
 
@@ -131,13 +131,13 @@ jobs:
           rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
           rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_BRANCH }}
           path: 'solc-bin'
 
       - name: Download soljson.js artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: soljson.js
 

--- a/.github/workflows/random-macosx-build.yml
+++ b/.github/workflows/random-macosx-build.yml
@@ -63,7 +63,7 @@ jobs:
     if: "needs.select-solc-version.outputs.solidity-version"
     steps:
       - name: Check out Solidity source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'ethereum/solidity'
           ref: v${{ env.SOLIDITY_VERSION }}
@@ -272,7 +272,7 @@ jobs:
           ! [[ $(solc/solc --version) =~ [-.]mod ]] || { echo "ERROR: Not a release build!"; exit 1; }
 
       - name: Upload solc as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # NOTE: The name is used for the .zip archive but the file inside is still called solc
           name: solc-macosx-amd64-${{ env.FULL_BUILD_VERSION }}
@@ -366,7 +366,7 @@ jobs:
           rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
           rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.TARGET_BRANCH }}
           path: 'solc-bin'
@@ -382,7 +382,7 @@ jobs:
           test ! -e "solc-bin/macosx-amd64/solc-macosx-amd64-${{ env.FULL_BUILD_VERSION }}"
 
       - name: Download MacOS artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: solc-macosx-amd64-${{ env.FULL_BUILD_VERSION }}
 

--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -41,7 +41,7 @@ jobs:
           aws configure set aws_access_key_id '${{ secrets.AWS_ACCESS_KEY_ID }}'
           aws configure set aws_secret_access_key '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -42,7 +42,7 @@ jobs:
           rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
           rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           # Use the latest minor release of Python 3. prepare_report.py requires Python >= 3.7
           python-version: '3.x'

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -47,14 +47,14 @@ jobs:
           # Use the latest minor release of Python 3. prepare_report.py requires Python >= 3.7
           python-version: '3.x'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'ethereum/solidity'
           path: 'solidity/'
           # bytecode_reports_for_modified_binaries.sh requires access to a working copy with full history
           fetch-depth: 0
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ env.GITHUB_REF }}
           path: 'solc-bin/'
@@ -76,7 +76,7 @@ jobs:
             "$base_dir/solidity"
 
       - name: Upload reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.platform }}
           path: reports/*
@@ -86,13 +86,13 @@ jobs:
     needs: generate
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: 'ethereum/solidity'
           path: 'solidity/'
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: reports/
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/14059 
Have changed actions/checkout@v2, actions/setup-python, actions/upload-artifact, and actions/download-artifact to v3 which should eliminate the warning message. 
Changes are made in nightly-emscripten and t-bytecode-compare.yml file