### PR TITLE
Free up disk space in GitHub actions, round 2

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -20,13 +20,14 @@ jobs:
       nightly-already-exists: ${{ env.NIGHTLY_ALREADY_EXISTS }}
 
     steps:
-      - name: Remove unused software to free up space
+      - name: Symlink solc-bin to /mnt/solc-bin
+        # It's now too big to fit on the main partition on Ubuntu, which is mostly filled with software.
+        # NOTE: We don't clone to /mnt/solc-bin directly because the checkout action does not support that.
+        # See https://github.com/actions/checkout/issues/197
         run: |
-          # These are quick to delete and large enough to make a difference
-          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
-          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
-          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
-          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+          sudo mkdir /mnt/solc-bin/
+          sudo chown "$USER" /mnt/solc-bin/
+          ln -s /mnt/solc-bin/ solc-bin
 
       - uses: actions/checkout@v3
         with:
@@ -123,13 +124,12 @@ jobs:
         with:
           node-version: 16
 
-      - name: Remove unused software to free up space
+      - name: Symlink solc-bin to /mnt/solc-bin
+        # It's now too big to fit on the main partition on Ubuntu, which is mostly filled with software.
         run: |
-          # These are quick to delete and large enough to make a difference
-          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
-          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
-          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
-          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+          sudo mkdir /mnt/solc-bin/
+          sudo chown "$USER" /mnt/solc-bin/
+          ln -s /mnt/solc-bin/ solc-bin
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/random-macosx-build.yml
+++ b/.github/workflows/random-macosx-build.yml
@@ -358,13 +358,12 @@ jobs:
 
     if: "needs.select-solc-version.outputs.solidity-version"
     steps:
-      - name: Remove unused software to free up space
+      - name: Symlink solc-bin to /mnt/solc-bin
+        # It's now too big to fit on the main partition on Ubuntu, which is mostly filled with software.
         run: |
-          # These are quick to delete and large enough to make a difference
-          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
-          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
-          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
-          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+          sudo mkdir /mnt/solc-bin/
+          sudo chown "$USER" /mnt/solc-bin/
+          ln -s /mnt/solc-bin/ solc-bin
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -21,13 +21,12 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - name: Remove unused software to free up space
+      - name: Symlink solc-bin to /mnt/solc-bin
+        # It's now too big to fit on the main partition on Ubuntu, which is mostly filled with software.
         run: |
-          # These are quick to delete and large enough to make a difference
-          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
-          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
-          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
-          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+          sudo mkdir /mnt/solc-bin/
+          sudo chown "$USER" /mnt/solc-bin/
+          ln -s /mnt/solc-bin/ solc-bin
 
       - name: Wait for other instances of this workflow to finish
         # It's not safe to run two S3 sync operations concurrently with different files

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -32,15 +32,16 @@ jobs:
         with:
           node-version: 16
 
-      - name: Remove unused software to free up space
-        # macOS runners apparently have > 70 GB free so it's only needed on Ubuntu
+      - name: Symlink solc-bin to /mnt/solc-bin
+        # It's now too big to fit on the main partition on Ubuntu. macOS runners are fine since
+        # they apparently have >70 GB available, but on Ubuntu it's mostly filled with software.
+        # NOTE: We don't clone to /mnt/solc-bin directly because the checkout action does not support that.
+        # See https://github.com/actions/checkout/issues/197
         if: "env.PLATFORM != 'macosx-amd64'"
         run: |
-          # These are quick to delete and large enough to make a difference
-          rm -rf /usr/share/swift/                         # 1.3 GB in 80 subdirs
-          rm -rf /usr/local/lib/android/sdk/build-tools/   # 2.1 GB in 450 subdirs
-          rm -rf /usr/share/dotnet/shared/                 # 5.3 GB in 350 subdirs
-          rm -rf /usr/local/lib/android/sdk/ndk/           # 7.6 GB in 1500 subdirs
+          sudo mkdir /mnt/solc-bin/
+          sudo chown "$USER" /mnt/solc-bin/
+          ln -s /mnt/solc-bin/ solc-bin
 
       - uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
CI jobs are running out of space so we need another round of #86.

~A draft for now because first I need to figure out what can be deleted.~ Actually, this time I managed to solve the issue without deleting any files.