### PR TITLE
Fix soljson path in nightly workflow after disk space tweaks

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -149,5 +149,6 @@ jobs:
 
       - name: Run add-nightly-and-push.sh
         run: |
+          soljson_path="${PWD}/soljson.js"
           cd solc-bin/
-          ./add-nightly-and-push.sh ../soljson.js "$NIGHTLY_VERSION"
+          ./add-nightly-and-push.sh "$soljson_path" "$NIGHTLY_VERSION"


### PR DESCRIPTION
Another hotfix for #142. The nightly workflow needed another path adjustmen.

A relative path with `..` passed into a script won't work as expected no that `solc-bin/` is a symlink. It does work directly in a shell but inside the script the working dir is probably the real path and not the one with a symlink. The fix is to use an absolute path.

This went unnoticed in the original PR because the nightly workflow is not triggered by PRs. [I triggered it manually now](https://github.com/ethereum/solc-bin/actions/runs/8299604541) so we'll see if it passes. EDIT: it passed.