### PR TITLE
Drop swarmhash support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,7 @@ version: 2.1
 jobs:
   chk_npm_lint_and_test:
     docker:
-      # FIXME: sha3 package fails to build on latest node.js (version 17)
-      - image: cimg/node:16.20
+      - image: cimg/node:current
     resource_class: small
     steps:
       - checkout

--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -119,10 +119,7 @@ jobs:
 
     if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
-      # TODO: remove when https://github.com/axic/keccakjs/issues/13 got fixed
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
+      - uses: actions/setup-node@v4
 
       - name: Symlink solc-bin to /mnt/solc-bin
         # It's now too big to fit on the main partition on Ubuntu, which is mostly filled with software.

--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -29,7 +29,7 @@ jobs:
           sudo chown "$USER" /mnt/solc-bin/
           ln -s /mnt/solc-bin/ solc-bin
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'ethereum/solidity'
           ref: 'develop'
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload soljson.js as an artifact
         if: "env.NIGHTLY_ALREADY_EXISTS == 'false'"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: soljson.js
           path: solidity/upload/soljson.js
@@ -94,12 +94,12 @@ jobs:
 
     if: "needs.build-emscripten-nightly.outputs.nightly-already-exists == 'false'"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'ethereum/solidity'
 
       - name: Download soljson.js artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: soljson.js
 
@@ -128,13 +128,13 @@ jobs:
           sudo chown "$USER" /mnt/solc-bin/
           ln -s /mnt/solc-bin/ solc-bin
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.TARGET_BRANCH }}
           path: 'solc-bin'
 
       - name: Download soljson.js artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: soljson.js
 

--- a/.github/workflows/random-macosx-build.yml
+++ b/.github/workflows/random-macosx-build.yml
@@ -63,7 +63,7 @@ jobs:
     if: "needs.select-solc-version.outputs.solidity-version"
     steps:
       - name: Check out Solidity source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'ethereum/solidity'
           ref: v${{ env.SOLIDITY_VERSION }}
@@ -272,7 +272,7 @@ jobs:
           ! [[ $(solc/solc --version) =~ [-.]mod ]] || { echo "ERROR: Not a release build!"; exit 1; }
 
       - name: Upload solc as an artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           # NOTE: The name is used for the .zip archive but the file inside is still called solc
           name: solc-macosx-amd64-${{ env.FULL_BUILD_VERSION }}
@@ -365,7 +365,7 @@ jobs:
           sudo chown "$USER" /mnt/solc-bin/
           ln -s /mnt/solc-bin/ solc-bin
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.TARGET_BRANCH }}
           path: 'solc-bin'
@@ -381,7 +381,7 @@ jobs:
           test ! -e "solc-bin/macosx-amd64/solc-macosx-amd64-${{ env.FULL_BUILD_VERSION }}"
 
       - name: Download MacOS artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: solc-macosx-amd64-${{ env.FULL_BUILD_VERSION }}
 

--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -40,7 +40,7 @@ jobs:
           aws configure set aws_access_key_id '${{ secrets.AWS_ACCESS_KEY_ID }}'
           aws configure set aws_secret_access_key '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: 'solc-bin'

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -40,19 +40,19 @@ jobs:
           sudo chown "$USER" /mnt/solc-bin/
           ln -s /mnt/solc-bin/ solc-bin
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           # Use the latest minor release of Python 3. prepare_report.py requires Python >= 3.7
           python-version: '3.x'
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'ethereum/solidity'
           path: 'solidity/'
           # bytecode_reports_for_modified_binaries.sh requires access to a working copy with full history
           fetch-depth: 0
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_REF }}
           path: 'solc-bin/'
@@ -74,7 +74,7 @@ jobs:
             "$base_dir/solidity"
 
       - name: Upload reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}
           path: reports/*
@@ -84,13 +84,13 @@ jobs:
     needs: generate
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: 'ethereum/solidity'
           path: 'solidity/'
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: reports/
 

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -27,10 +27,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-      # TODO: remove when https://github.com/axic/keccakjs/issues/13 got fixed
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
+      - uses: actions/setup-node@v4
 
       - name: Symlink solc-bin to /mnt/solc-bin
         # It's now too big to fit on the main partition on Ubuntu. macOS runners are fine since

--- a/bin/list.json
+++ b/bin/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0xd8b8c64f4e9de41e6604e6ac30274eff5b80f831f8534f0ad85ec0aff466bb25",
       "sha256": "0xfc54135edfe07d835216f87fa6c3b9049e1415c2825027b926daad018e09269f",
       "urls": [
-        "bzzr://8f3c028825a1b72645f46920b67dca9432a87fc37a8940a2b2ce1dd6ddc2e29b",
         "dweb:/ipfs/QmPPGxsMtQSEUt9hn9VAtrtBTa1u9S5KF1myw78epNNFkx"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xa70b3d4acf77a303efa93c3ddcadd55b8762c7be109fd8f259ec7d6be654f03e",
       "sha256": "0x7ad9fa9de246a33c5e5472127b6e0b6e713f3900c7ea360c7c2824f6e9202a0f",
       "urls": [
-        "bzzr://e662d71e9b8e1b0311c129b962e678e5dd63487ad9b020ee539d7f74cd7392c9",
         "dweb:/ipfs/QmWRGd4p3EUkvPh7QfFVoF829SdFFF2mhtsEsK6exaqdB4"
       ]
     },
@@ -33,7 +31,6 @@
       "keccak256": "0x07de160862e662ea027a5451b78a7d9db6c9d7dd11a314fc19c68b095cb1c6ce",
       "sha256": "0x7b65e00aee537a341df83de88125bd18e020b86a31ef6e506c3881142daeb35b",
       "urls": [
-        "bzzr://378cfc60e8801e992ec574511c050450e771d60cf9527c9d00353ec2eab4d5b5",
         "dweb:/ipfs/QmYUkyY3EM6JhbvrXNrPF48TbFsx4p3poL6vUNFrCq6bsk"
       ]
     },
@@ -46,7 +43,6 @@
       "keccak256": "0xa04df894a1fddc56f0a5e2ec41a858a17e1aca7cf3ad18bb78a026b9fd79e19b",
       "sha256": "0x850917e16b843162739269b1ba89722e08ef0fbe12d1e38bcbab97bf0eeaa2ef",
       "urls": [
-        "bzzr://91c514a73ad2d3ae4cf31c20532d4f325e28afed5b3846dcde7b7dd72a7c4864",
         "dweb:/ipfs/QmUctprYqMQdufufKgEhsf7mRDWr8qGRavLsK8qgqhFVuY"
       ]
     },
@@ -59,7 +55,6 @@
       "keccak256": "0x6212a9c0a8c43bd0aa65c6ea44df979c0ac8076c0caffb7626187f716494470e",
       "sha256": "0x2124f7474e31bfa0758decc2a2544bed47e9a4dec458fd2793ea4674186c47ee",
       "urls": [
-        "bzzr://dcce6719f72d942523ccc834fc9656c063026681999684df89db56d2b7b1193b",
         "dweb:/ipfs/QmX1YTFChDZKBv5Yh9McNKos35GHwhP6rU1KsbFAuen3xE"
       ]
     },
@@ -71,7 +66,6 @@
       "keccak256": "0x39ac3bf19dd7749006b19243aab5bdfd1e92b93133a2fa236e9d61af957dd444",
       "sha256": "0x1a806813a02d4925b180737aff1d58d6ee9bee38a528fb49dbbfd3e676d00a1c",
       "urls": [
-        "bzzr://05a3b37b2d7823363272c5b5648e12f3737457430a1f4e4477f6c3467592f7df",
         "dweb:/ipfs/QmeAjv4azyWQy7nZnPRChtGx3Uys2MygDc4LgzSsWDnWig"
       ]
     },
@@ -84,7 +78,6 @@
       "keccak256": "0xbbec189c18f89be0e8922a51ae5c36d8af93862adcebd7e56eefbf553294c1c9",
       "sha256": "0x26c003798eb828ccee0b1d658b3753a60405a21d72348722b290ec6a834f608a",
       "urls": [
-        "bzzr://45e946f18d0dd78d88405670a94c0a5971b3df495ca3cd8d744d3e0e29faa7a2",
         "dweb:/ipfs/QmfY5GT6PazoxHUEKdzb4fGGAA8hZQemgWcjikn39VtJ2r"
       ]
     },
@@ -97,7 +90,6 @@
       "keccak256": "0xd549468c636f2e3c404746e6c636fb7ec63b54b0a916e988e762721e83ccc1b2",
       "sha256": "0x919aabc2c97ea54d03c4ccbf23783c60930ece2de40da1c4756f5ec4a05b8e8a",
       "urls": [
-        "bzzr://95dc0995a929c94c2838f313ab4ad5cdb96d2e1c6eaecd219f5a8c226edbecde",
         "dweb:/ipfs/QmdMSYYVprFQGLyJ23qUfdXQTMCLPKsuQq2ZJXwCkwrKSi"
       ]
     },
@@ -110,7 +102,6 @@
       "keccak256": "0x327eb1581add1b713ec7059aef981d5f4434147db77c86bf0aa2d58925d4b487",
       "sha256": "0xf0578af6d3857538d138518f54c84ffc77df9f53e50c3e7539f345ce4eebbf20",
       "urls": [
-        "bzzr://d432f13d6e6e8f15977d6e3a445844651ca8220c8fb6e69271eb32c5e103a084",
         "dweb:/ipfs/QmNQ3GjRKE9JrnfavrE4wbDiynvvNgQ4SRY5DfgRxX7d2G"
       ]
     },
@@ -123,7 +114,6 @@
       "keccak256": "0x25ead85443c34a11c43628d4e0be18b99f916fde5af8dd72f04b99ca9d1477fe",
       "sha256": "0xdda6e95e9c3d1d7ad65d974a4293f2722c23784d4cb8b5d85a34a96c153cf85b",
       "urls": [
-        "bzzr://0845cd024eea931fc09bf97903e06fff00f2228205f46eb3b4dff5435538e690",
         "dweb:/ipfs/QmTMy7byZ7brgmhxaSNLBrrbdfzCpnohmhkuTeuZZYXD2M"
       ]
     },
@@ -135,7 +125,6 @@
       "keccak256": "0xc6b0944a8b55b534eb4eec02d3be54d26791ff60c99288ed5b2dc9c78ced32fe",
       "sha256": "0x34a1e8b62b5eae88ee59e572c8f941a375d587a7f3c21b6d24f415452bdc7a15",
       "urls": [
-        "bzzr://4da68f33bd6bf02fff03670b9501121f5ce75cc4a2a7fea657c22d3f4a625d57",
         "dweb:/ipfs/QmXuvThTcmHUAH9uxTLzYqMN3ZSTGrPFQSmMgKfhwajVF3"
       ]
     },
@@ -148,7 +137,6 @@
       "keccak256": "0x75a7f6ddc293fa833c3f8b9557f213646feb1f3acf190bbee9fd2ed3e5bb87a3",
       "sha256": "0x6e50b566c9e11b307e7c71e204cdba63e1eb555a623216010027a887d6b23d1b",
       "urls": [
-        "bzzr://b7b4b2371045cabd508187fe76aabb8cae89ce715907686a921f527a0725f4c9",
         "dweb:/ipfs/QmZFPdseGunwo7dgMwXu59oi6mT9a21RhYwCpfuV5Sj2Pw"
       ]
     },
@@ -161,7 +149,6 @@
       "keccak256": "0xd579bf0675fbd793da2e8f0aeb933c4c284393a559ad77aa0dd9820bcd376b3a",
       "sha256": "0x47e567199d3e0634410dc60f1bd10a66638ffec9abe86f683f40ef64e80bcad1",
       "urls": [
-        "bzzr://772f6bcb14c954334fb81a60e4ce3b4e5b8fc4646d1c1597600a6f4f8d85287b",
         "dweb:/ipfs/Qma5FBDGePoWfoT29ErfzYASnNLRGRS7i6j2kzbHxMe7RC"
       ]
     },
@@ -174,7 +161,6 @@
       "keccak256": "0x24b5812fa67638b45602f60322417f3988859f4f6697c6d612970192e11a6c53",
       "sha256": "0x81777160a0cb9286081e62cab64b62cd9f56a9a3463f5111da209e351eaa9eb5",
       "urls": [
-        "bzzr://1243fcfefe1b30690232b297922a01e7d3725eafc96d6d519e739c7c7c841ec6",
         "dweb:/ipfs/QmPGUTJQpFYH2aDCDmnqjcPmv3jA8ScFz83xXfiywj5DNf"
       ]
     },
@@ -186,7 +172,6 @@
       "keccak256": "0x9639c043ae6df7267b0d904c334342e83c95bc3786dcb2b7d2a7c15c9f6ad916",
       "sha256": "0x6c9bc5397f56746f928ce1d4e2522d2865052348d506f521b4f731f98f99c6df",
       "urls": [
-        "bzzr://c6533d87a48abff42c084159156c7fea1fe4fc8c7ee5fa64edaaa944cfb55603",
         "dweb:/ipfs/QmYpMSkjoHMGihr7xrzSzDCMJyXxBoeB8QqCyM367x3Twm"
       ]
     },
@@ -199,7 +184,6 @@
       "keccak256": "0xc01ec46c797646ca067a01d43cec9a299a93805c72141503aade1810426f78dd",
       "sha256": "0x9b4db172dd44e32503a63d9cffd2b50631656b2a0d232755086aa4862337f87f",
       "urls": [
-        "bzzr://577a71aaa373c25ca3774ef46cbd52f65744ebf7990b1685be0ecae0b199fa4d",
         "dweb:/ipfs/QmYaSz4mEPodeqq92bGwJE7v7VJYCaigK8Ekkkrfunjvwg"
       ]
     },
@@ -212,7 +196,6 @@
       "keccak256": "0x9e5f2d9b1ff308e931b680d50c56fb98b96a2b5ce68ed84d3e8ce8c86f08de83",
       "sha256": "0xedd5a1b49242c389308523a4713cf4f0a018593443a7d69ba2bb9a8fb83760a7",
       "urls": [
-        "bzzr://e849ae0a24b12802c723f4467e0932e0690179579207287229b5616f1d1b85df",
         "dweb:/ipfs/QmaLMSM9u3Fjbef9EJtKAYGoM9dkp6t2XwHrzuF2rF5c5N"
       ]
     },
@@ -225,7 +208,6 @@
       "keccak256": "0xb088fb8782528c5578b3bf2048e6a5b1874c2c2a1eee5fd1d48198e325ad4306",
       "sha256": "0xe99184b01e8e51209e8cd029cf2a08ce0bf9fa9e07e1aefe453a89cf2b8a8510",
       "urls": [
-        "bzzr://5ac6626814a9ce5a13031fbf74ac9769bf155b2920275f39acf9821bcd97521d",
         "dweb:/ipfs/QmfEJ5cjbWCddQDtKizkN2sBTnyP2J8eB7gBYLLkzQ6gSu"
       ]
     },
@@ -238,7 +220,6 @@
       "keccak256": "0x439145e3be4288b971aca1121c62b90cc2b148c859b4157ae84e9ab228f8e609",
       "sha256": "0x0703a9ff3aa268f027e1ee6fc8345720548b1a017cfef06c966e1d2a823ee516",
       "urls": [
-        "bzzr://1da661a66cc41b6b1751343cf5638adff12d698a8026a46bdcfa783c5a2c705c",
         "dweb:/ipfs/QmQ1Z9fhEe2ZVuuPGLSPba6SYXnEbhdfQyk2VwMdeSW4R7"
       ]
     },
@@ -251,7 +232,6 @@
       "keccak256": "0x52d9e3567cb9f2dd92d2be85dc88cb24cf8d90669e293e8cda17dec8eec22de3",
       "sha256": "0x8a7640c0dd89d349e38a0d9c35dfc52e93d70f3e338e694f074e817e4a2dc89d",
       "urls": [
-        "bzzr://6da7d3b8cf7170072c5ead6ce2140830f1d56581460a6cea7ce3bc4550043904",
         "dweb:/ipfs/Qmf2jQp3iJD2e2nuyuhTcY4E1UTRnS9UjPE2iihxugvchj"
       ]
     },
@@ -264,7 +244,6 @@
       "keccak256": "0x196e60c68548a1b0d09f79446300c7045d92a6c61e6f9d3103b514c628d6e3c2",
       "sha256": "0x8b3d0fc558138e22ece848678914305203e35dbbcb765b7597dcd60038245620",
       "urls": [
-        "bzzr://ba5064107498b2ae67b091d73febab2177fc9a2d6376ef0de73636a5a4853a81",
         "dweb:/ipfs/QmSWtQ7EDox146zawzHn38fz2ptz6xdyh1gZ2WBLtHVTRd"
       ]
     },
@@ -277,7 +256,6 @@
       "keccak256": "0x8d6dc6a11481a5bf3a197b2bba7c445f13a2652ee6cf5f31811b8c66204f81b5",
       "sha256": "0x8bd53ddecfcd1bdf47af3f6e06007281540f6b490c4758e9e0b797ea71df08f8",
       "urls": [
-        "bzzr://66e3417949d6eb9aff78ccca5f9b576b92f0af691f18935d07298140ebf4e34e",
         "dweb:/ipfs/QmRZMbPeox5bVhq2qjKuDt9nwae42o42cq4f43MWBi52ZF"
       ]
     },
@@ -290,7 +268,6 @@
       "keccak256": "0x52845ac387cb670c99560710fe649263fa14d28a79ba4b08381688d36adbc921",
       "sha256": "0x64380ddd7c409f0ae64144297927b24b9ad5338f9817258197da6f9e083917dd",
       "urls": [
-        "bzzr://e5a9fde92df9d40c7f8932ead550328f110144829b702f50cc61f8b277c834c6",
         "dweb:/ipfs/QmScgooMmGrX7QrCkWXPWPf4nKn9mQsuroxDnJXTt94KxT"
       ]
     },
@@ -303,7 +280,6 @@
       "keccak256": "0x4dd03f8976b78f217c9e12bd3100c25db7602e4bfa5e7ef9bca1e8cf976b3f22",
       "sha256": "0x1e16f8dbdf4ac168b95543e0753622354c05b1527b1eada470fa70cf75c1d096",
       "urls": [
-        "bzzr://3da23a3c9e2e7c844338f5927d7012a89ff8e33364a0c9b595eb0fcd6d2dabf4",
         "dweb:/ipfs/QmR7zc55VByZDrBRN3M2KPMWWpfYPzxayYmztMikszek5e"
       ]
     },
@@ -315,7 +291,6 @@
       "keccak256": "0x08610325fc49fb7dc244cf5adfd60a664c3cfb9d4845c90b30ef6f6abb748c60",
       "sha256": "0xb2fcb4f707ad6545c8a65b70164c59d4555cd607b97204844d51a803917a4549",
       "urls": [
-        "bzzr://e6eca935f031f31758db12507e10fe82d576a293b210caa3775c4246bb9679f2",
         "dweb:/ipfs/QmZQFLgDnwS3jpR4KBAnWC4ihTixXmmCUdoBKGooJQDHJ2"
       ]
     },
@@ -328,7 +303,6 @@
       "keccak256": "0xde1ac4213cc34cf4f06b201c20c3a76993a4fbf75fbaf305ed2bd75041193da8",
       "sha256": "0x81cf33f3ab4213c5ff84d58e5335611e6105645dbd1bd00d7b923488dfc9c9c4",
       "urls": [
-        "bzzr://9b8d7ae62dba09ab28cdc46b89809a5a68ae80ca089519b7c5c30da107ec13d9",
         "dweb:/ipfs/QmaZLxC3Pqq4DhhhmbzSYBxnm2F2ran7gfrag8i8CdKzEM"
       ]
     },
@@ -341,7 +315,6 @@
       "keccak256": "0x2a8137eb4898c4b8a1f58ec65ff1ea5f30b51b9c62c41514ac1a847b2631450d",
       "sha256": "0x738cb734cf02e76c5a918670258ee7cfc8f0af0457030795c6bf865fc9c18b0a",
       "urls": [
-        "bzzr://a38b4728e8eff74f1e93ac9faeac42452f449fe3624af1d43b8d4cc1ec39ab19",
         "dweb:/ipfs/QmNtbPkU7r4Yj2rBR6sCuz6Xx2bEUbtpRiwCBsJseP4mSZ"
       ]
     },
@@ -354,7 +327,6 @@
       "keccak256": "0x5550576ca6d1d81c9c8c3e5c16bf34b7500315cb4bf7b9ccfd221079354dd9f7",
       "sha256": "0x1022f09d15134a43692199a10955717d7ad4443b3a0623e44e86dc362d80b19c",
       "urls": [
-        "bzzr://01ae095d65a88a5e0c28b096b419b4643f393f3d8aa89a23a315ad128df8301d",
         "dweb:/ipfs/QmZ4Cpz7dPoB7AW8Qj11RQbA9uLhbYkqPkjcTViJ8KKmjQ"
       ]
     },
@@ -367,7 +339,6 @@
       "keccak256": "0x55778c0ba69297a898a8a613226d67fa55476004d698144ecdd1118735c53aba",
       "sha256": "0xd89f03b50b86fbae346f3da71771b6dc0273bb2f031cb816ad27080eed76ba48",
       "urls": [
-        "bzzr://d4922c0e7493b9b7b4beccb318cc12c0401583519f5919354dcd7306bd2ad50c",
         "dweb:/ipfs/QmZjMfMrEiwCK3REETVtKYvqmRB8cweUdmQmAiyvo2zsZT"
       ]
     },
@@ -379,7 +350,6 @@
       "keccak256": "0x90567736ca352a90da3bb8cec7e9f7c5793ec6a77686ed4a87f373b456781e09",
       "sha256": "0x41a0cbd38f6fb957ed3748688078f6e6186d9a2e8b6706de9a63dbf65c62ffd3",
       "urls": [
-        "bzzr://84c85953cb16cfb7da8f75b09853ced60ddc3b36de6b2570cd66032a6fe0e802",
         "dweb:/ipfs/QmQKXN99fA1rAi6B4wEt6vBDqEjXsZbepuTBxkUeLdc6Cf"
       ]
     },
@@ -392,7 +362,6 @@
       "keccak256": "0x31c46f8a8a47d4385e9dcb0a9903450a17b26dc4b52203ffc179ac71c32cb1c9",
       "sha256": "0xf784cd33a43589e5950fd52292b24532cf574b6884cebc4e32eeefc5bdf11b2a",
       "urls": [
-        "bzzr://31a83a8a23cd5122f69a99abfbedcb90376065cacbe5d8417dfeda64b212a705",
         "dweb:/ipfs/QmUi5nz4fYC4PLKiQkEB3y8ipx6Ae4tGzXNBJE3v8SUpsc"
       ]
     },
@@ -405,7 +374,6 @@
       "keccak256": "0xfa8823c0d24bf317d24a907619ff9f8be539bad7bd1fb9b05a33d149d90d8e45",
       "sha256": "0xf6541c3cd9632f1f3312e649da928b7bc80c33e05b17f8a0922be0084a120477",
       "urls": [
-        "bzzr://d234c88bb43f2a672516a33a570d8c4544401263b8476fcc3735fb3e856d1837",
         "dweb:/ipfs/QmeuUP4MT9LYQ91Dy53a7vrhEs1nk91BXTTdSLrLycihrN"
       ]
     },
@@ -418,7 +386,6 @@
       "keccak256": "0x26df2bfecf8ffc79c9f7cf55640278460cedb88b727c56280bfdd1650cc27038",
       "sha256": "0x0a48c9d78ecf52a25983efead5f30fa81c6d2f7d7ee29611eab16d95ea512ca9",
       "urls": [
-        "bzzr://b9dab610440a4903bfc5d792347eeb3f6a682b66f544f4acda3c4b5d36954e71",
         "dweb:/ipfs/QmcgiKGq1c5XZvRfaCvGJfPxb3PAscu1BfFpdhv9bCRKpi"
       ]
     },
@@ -431,7 +398,6 @@
       "keccak256": "0x4c29cc4f3ba731ee5c33817e072c493abd0421f032601a3fc1402e7b78b7c2bf",
       "sha256": "0x5f9127f04c325f4b2d984d54f65c9642fcd6f40dd2bd3c0c0087ffb5a2e4d23e",
       "urls": [
-        "bzzr://bc45e1adcfea736946f600c0ec49108485f9cbc3a785a2d34b05342e2d6524dd",
         "dweb:/ipfs/QmRPmh5F9uf4JoBVh2FzJCNPAJJSxcP4VBHisqzgXC8rLL"
       ]
     },
@@ -444,7 +410,6 @@
       "keccak256": "0x9f56a38168d15b186324f97794c5115cfb5d7298881bf3afc021f65b8fb0d708",
       "sha256": "0xb577c476477daac6a802d8f1a3ece2094c66b6bad3df4fa7d6cfa473d2fd4bdd",
       "urls": [
-        "bzzr://03475f702c7c9d71354a8f5c2147746df3e02d427ccc9dc926c5e68ef0076c04",
         "dweb:/ipfs/QmNQoD9W6T4wwmrX77nNLouAoyS8vduKz2mivHAKApUFBJ"
       ]
     },
@@ -457,7 +422,6 @@
       "keccak256": "0xa96c0961388eee841a155093d28aaef386f6494add28abf045cb0398f33b01f4",
       "sha256": "0x7ec49afe5c9e6c7bcadd78317a0a256319c839e953f6f3d9bf3b98a491a58934",
       "urls": [
-        "bzzr://7feb62fe9b6d14ab8aa9ac7058136acc9e0d703b89b36266be3eab0ac3048959",
         "dweb:/ipfs/QmcCNDkEPZjq4TamufutrJEiiVbrMF9rAcxTmhtTAS8t3h"
       ]
     },
@@ -470,7 +434,6 @@
       "keccak256": "0x030691f85a088857eac9401be6fd57c87434dab1f620e1d694c997377df01680",
       "sha256": "0xaaff86aa4826a22d5467d090b4d3c596738a3d73100c3f4b0982cbf53d5fbf00",
       "urls": [
-        "bzzr://950f83df1c7969dd9c79ef97d063e38e558cea36e04bfe9bf4b6f5fb57139caf",
         "dweb:/ipfs/Qmapk6WNM6k5H3ac1fQdXVhCKfupwAMASJ3YaK2gk89z4k"
       ]
     },
@@ -483,7 +446,6 @@
       "keccak256": "0x6a558a93889075c37b5bddea2c929f6352ef99d79a7e5fd17474fe51729d81be",
       "sha256": "0x12aa89dbf6b88c9c3ffdeedf50c8d1a0cf60d11b33ad31ebb1fe89799235bf57",
       "urls": [
-        "bzzr://00c5f3030740910755b2d81ac40fd33a00794c691025270585f86b8b345d04f4",
         "dweb:/ipfs/QmRGh5z4y1RZ2gF7i9DAy5ErDvZoLDSHLqq6Bwp8uNJacX"
       ]
     },
@@ -496,7 +458,6 @@
       "keccak256": "0x7134205d4d3b54c43851da8b2509b9d689a183ffb4e9df9b42c933379a34284d",
       "sha256": "0x3f18445e500d21bb0fa15652d8e5caff996ebae9e78e2a409b2a148ce8d4231b",
       "urls": [
-        "bzzr://641010abe88aad72994f6aa8609b2a25dfe2f6934ecc1c8e09235ca687cb4649",
         "dweb:/ipfs/QmXpgahHjzyf9CibKNogJ2YHH5H6ybjAcErdcDhhU6Scq6"
       ]
     },
@@ -509,7 +470,6 @@
       "keccak256": "0x37b8c54f603c41e5f428e24b318d03bac39a41379cb65cd25a4fea33fa5d8a7c",
       "sha256": "0x4380ed34c1604934f5293fdbc5f26686c0d2193e5ea65a1a02d3c238e6e0015e",
       "urls": [
-        "bzzr://1728b9ebeca09f568c1b4ddeafd962df26aa23b5e6bdf5947c0150e90101610d",
         "dweb:/ipfs/QmfHHmXeiCwmEfnr6o68aGhuhcoVxy38nXst4KL1UnsDEo"
       ]
     },
@@ -522,7 +482,6 @@
       "keccak256": "0x593d522652ddc1ee3db466c7c5606cde834e4c9b0a3204793ae3cf0be08d26b0",
       "sha256": "0xde4e7d17bace9c977c80e284af8f2a6b5e43a3b12ff3a5b9baa072834549b6ed",
       "urls": [
-        "bzzr://e8bec2bd7742f713b0f8cdcd7e8b666f828052e1aba94ca82d7b8330835afd2c",
         "dweb:/ipfs/QmYVpZZ3fbD3L9ttbyao7Q5NqMdQgsRgo9moePSVoaMWkb"
       ]
     },
@@ -535,7 +494,6 @@
       "keccak256": "0xad9f2b8457b137128ca2ac5d9e2c0859c20f3a50f4a47b5b003e8ad4c3495592",
       "sha256": "0xcf2fe2e6bc7f3c174c0714473580229042c01b8e96b80361ac33c5cd1c6f55c2",
       "urls": [
-        "bzzr://5e12fd41f1266f50a8ae40f1c688c155053424dc631ad370987754760f622e6a",
         "dweb:/ipfs/QmSFX1ca3nMHW2EcVEmikiK8wba8YTzUkYgHJHrjSEA6HD"
       ]
     },
@@ -548,7 +506,6 @@
       "keccak256": "0x8cdbe82379e54fcee7523d8f91da7847485af04dad12764b879920c346cfd5ba",
       "sha256": "0xd0410c6b86144f1c5d0f1ae08683a1f75e21009dd864f13b3648a8c3eca0037b",
       "urls": [
-        "bzzr://7e79f1970d7d627b9d5d044f92022d3d6b38b4cde007045134e326f372d113a0",
         "dweb:/ipfs/QmWwDtpPLFKoMyWzZjYHVUMiDqNGH8ABYUGjYghm7AvtvN"
       ]
     },
@@ -561,7 +518,6 @@
       "keccak256": "0xc72add9ee24838642fbafc8d119dab07bc0e438a0238c0510d635fc62132cb18",
       "sha256": "0x17ae0d5645cf3ff11d6a8e6ff53f4cad10924bd365d8887c88769d4055d92678",
       "urls": [
-        "bzzr://d2e0a7427bb8c54dcd1b1772b44bcdad3f0ebd53ce45f835726035a0690237f8",
         "dweb:/ipfs/QmYe95hbwQ3AHeX8mFnVyM2jGqFwWmUhKXjVVndj9SRPVo"
       ]
     },
@@ -574,7 +530,6 @@
       "keccak256": "0xe3be7fc0122058349ac82061efcdd334fbef8f58903888a2d3113a74e7a35090",
       "sha256": "0xf49e17483b623bc64fcb8bed77afd8680a5eb73d6fced894ea6f57d5ac0924da",
       "urls": [
-        "bzzr://ac03811fb9bc71abbf617d4f6b7f3a28bce233a09e10050e7d275dd02888d558",
         "dweb:/ipfs/Qmb8BmHPA828GWhdDPNC7i69WAYwrcgbvHtbiBGagkAZkV"
       ]
     },
@@ -587,7 +542,6 @@
       "keccak256": "0x1cc2cef112836ac74da29840c8d6f446ea8636d3f1333133b497dbd8db2be4c8",
       "sha256": "0xc63bddc9361264e02d90678420d1f6a579c14b54200834105743bccafe966bfa",
       "urls": [
-        "bzzr://8f48810e9960053e702cf8e8bd3e0d468e58ab8cb2e1df1cf3c968fd3257b9a4",
         "dweb:/ipfs/Qmdq9yWLXxgmYqcuBsedRThS128uHbH3MYNGg6oFtEWuhq"
       ]
     },
@@ -600,7 +554,6 @@
       "keccak256": "0xa584a215226c553db1b111cb7145abd529c3953b932e5609468a63620c7b4a90",
       "sha256": "0x49cc0745429ee6164b33f50a85780368a1dbbb6c713763d85e60797929d23a25",
       "urls": [
-        "bzzr://0d13f14050c5ea001028ad3d6f792121427813b2bc2738e2420b5fea9927ab70",
         "dweb:/ipfs/QmenLkN7wmvF1smGx6Sd8i3hQvkgiWL386A4TgoGvQzR77"
       ]
     },
@@ -613,7 +566,6 @@
       "keccak256": "0x758ede33c3b73649a869f7fce0c38515dd5b49622927ebb6a9251a654128540c",
       "sha256": "0xcac952694689ac2dbc8b6c76cb6bca65876fecce503fe175328b13002d1061a8",
       "urls": [
-        "bzzr://5e133f752c6fb1b7d47a5d6668f630bd06e3d7e1a3deed4da7e2d4d2787afd3c",
         "dweb:/ipfs/QmTHm17R25AbA2cFwbH9ffPAP1bUrH5ZRuAeAMTNzHHxxg"
       ]
     },
@@ -626,7 +578,6 @@
       "keccak256": "0x412ebe3a98a7a635389e0b7d8c334f6008195ca9c3320f668e7f7c4d8bfe3baf",
       "sha256": "0x00d8b32f435d33f66dbd2243d51117d0537da2d0a0fa3e4fcaf54c913bdff818",
       "urls": [
-        "bzzr://52078e8cb739d298e9949709f0267f4f31ad0b54cf420e8698b97b6282274764",
         "dweb:/ipfs/QmZ9KuWEFM2TdMJ5GGQG4X6LaKwfXk3w9r4n36KSFfJ186"
       ]
     },
@@ -639,7 +590,6 @@
       "keccak256": "0xe94af51137b5a298f211a4989c0a35ab1d2400c7d97e7ef24629bbe7ddf9866d",
       "sha256": "0xeeda38e019dbbdb0bad8016a4c9b6a5b94d420cef7e6a9184583521d72c6578a",
       "urls": [
-        "bzzr://0f1d06cafe2f3ed9545d8af7cfba26ce133cef765fcff529d84db4d099d57692",
         "dweb:/ipfs/QmdZbqU2P8YixpfcdEARtr4gSMzKTq14sQZhDK8yDaedEX"
       ]
     },
@@ -652,7 +602,6 @@
       "keccak256": "0x7bdca1c0cee84ed05835aabf31ab88ce3c7f02752f720eae48c72aa7e9deeb2e",
       "sha256": "0xb6ef61c1ce26b73103a08032a494cc90ae5a4796c0d7da363b0f059923b113f9",
       "urls": [
-        "bzzr://52996d628ca25a8d9f613b8f4cb066ef3fffd866f94cea9dd91a8ac174532bc2",
         "dweb:/ipfs/Qmap6LjjyPh2bGZQGoqRpLN1YboRkzrqZYUuaF1qCt5mMa"
       ]
     },
@@ -665,7 +614,6 @@
       "keccak256": "0x3ce149319e0d26a63fff9788fa742ee28b2b4dbcca4391c996e29d17fa23d5d6",
       "sha256": "0x9b8514331eeba425d566b3f63b2a7c207dce5481a85d3427f76331e6bf045669",
       "urls": [
-        "bzzr://30c30436e65119c80a122aeede3df52127ff9169cb8147364881a3b25ea65215",
         "dweb:/ipfs/QmYRwdkPZKDPtJUd3Y68PqwAKuEuXDoSndgx3jezr21wev"
       ]
     },
@@ -677,7 +625,6 @@
       "keccak256": "0x7d8ea0312905d250ec7554bd84526c3d97d05f6d5748888e6ec00629bd3ea7a6",
       "sha256": "0x0fa8617f2180be99751704256f2a50f05321a99a5a1aa537543c4fa7516dedfb",
       "urls": [
-        "bzzr://0848ea1ded5b47cbae17d915810d1bf0857d9ea625cb332a0da68550cb27c699",
         "dweb:/ipfs/QmSBMT6wATobR4wsfGiAEZnmrWYbWT1od2DCufRe7nfR8E"
       ]
     },
@@ -690,7 +637,6 @@
       "keccak256": "0x360ecffb369197bc1e25a02acfa5b5ce15a79ad79ae1fd3480c7b456eb27d116",
       "sha256": "0xefbe6a047ea868a4c0abd6dc5b26c13492448c64f4f6ff0888ce6b1cfe9334d0",
       "urls": [
-        "bzzr://056a14ac38df637e27887576d15f3fc59465a79a76982ba58721278355f0693d",
         "dweb:/ipfs/QmXDYVLQqvMF9PNwhTwHuUwFEpzHnEzUJpZJqKQt29ZyBi"
       ]
     },
@@ -703,7 +649,6 @@
       "keccak256": "0x969155bf9226e7424bd92c7b27fa370d34304946083078e71eaa00dce0b55abb",
       "sha256": "0xc029f0a9811d5aa07d9eba1b8099a2f3fe168d74f37087d4dcdea3c943f59fde",
       "urls": [
-        "bzzr://c5ff803ea42a6a2a4ca31292b1b823abd2d4b616e7098f0987daffa57b243649",
         "dweb:/ipfs/QmcuoM2oUGXFYqziptcnHxCqCZb3kq6893ybnsw3PpWPGC"
       ]
     },
@@ -716,7 +661,6 @@
       "keccak256": "0x4a11c814c6d5edd0d001f2263f7a161659c1a409d75c4b75d31681b75d274b91",
       "sha256": "0x27049ea57679865e26fb79a012e4b813fb81f30e603d64aa54ae8f8ea5dabab6",
       "urls": [
-        "bzzr://2de8538886c22b50bee685cf81a61f4ce0d5ac93225668023f2fbc9459f9a52c",
         "dweb:/ipfs/QmWjobGah8NUm54CBJGM4r7pYfM2oyhKSGVDXcdFnGoUx2"
       ]
     },
@@ -729,7 +673,6 @@
       "keccak256": "0xf2c2815c6bfbc15b9990443a5779b1aca67281b6b9a1e3a35560ccd27c65bc0b",
       "sha256": "0xdd7db5553850a232059c8f84d387584e089c69e807ecb66b3e589ae7b1bc3956",
       "urls": [
-        "bzzr://940d797dd7114c00b21e701a3e7b60382caa265eeb05d4aad5772fbaed5ab9f8",
         "dweb:/ipfs/QmVtrG1NiVmTqmE71TvDG6zr1LNWF3BZN5EHcTVKCZLD8y"
       ]
     },
@@ -741,7 +684,6 @@
       "keccak256": "0x7067e5792a88111c06a7078a23358641a64d0fa273b5220bfa5212029352dbe9",
       "sha256": "0x1f954fc43414ac9012125c6080e007508bd8502bfa180d23c3033aa6943c4550",
       "urls": [
-        "bzzr://5b84475c0815ab9cd44ca5b4dcf4cd14d5f7db0bf3077fc825234b648305b277",
         "dweb:/ipfs/QmZhD1pVi51kF63twouEb4ZGGtPQt8f45fPcoVZHZxWuwq"
       ]
     },
@@ -754,7 +696,6 @@
       "keccak256": "0xc32e1b53252aaa942bc1a0293dc9c0993369ed19bb53a50e9c15a757aec8f5c5",
       "sha256": "0xd1875c27922539efff03f57fcb2c320b652cb7ff5105fa443a377790d468555b",
       "urls": [
-        "bzzr://045304bfabc27555dc17006c0bda282cbfebcb5cb717001738f83d64af978d64",
         "dweb:/ipfs/QmPKpsZ9C1u3tHU74iRXC8iUc6fFvvD4ocFyE8MD9JPstL"
       ]
     },
@@ -767,7 +708,6 @@
       "keccak256": "0x8a61a7e1aafa218636afa78f44da1941f16b7bfd7a378d29bc57ace750b03516",
       "sha256": "0x5b77ec0ee4c24198349e6974a7823aef1f6cd8bb6ca6b84d2b9ce8b430d7f907",
       "urls": [
-        "bzzr://72a7b41fe2bc20b522694cbfef12472fa73239628fe38aec0fa19ea91131131c",
         "dweb:/ipfs/QmfQvAmqyHvphGmAYskGbWomAwsyAvkzuRfjPk4qfAvJxn"
       ]
     },
@@ -780,7 +720,6 @@
       "keccak256": "0x5af0df70309df2cd19586d47bcd34ed306681d12ce27d25ef89d9dde4aab1174",
       "sha256": "0xdefe744db4916d9022ae48e8425b23c71d75d94936d7f684a2820bf851799546",
       "urls": [
-        "bzzr://8dcad707031877e375ea8cafdcac8c113b9da15c3d2b29da1355431a02fb035e",
         "dweb:/ipfs/QmcdksHiNdwmCoFYGs4CPUegn4zhSpCTWYGGZiQ1CYw8U6"
       ]
     },
@@ -793,7 +732,6 @@
       "keccak256": "0x4baee97d1a0ee4ee6ed2948e817aea45423111e38068b83266a568bf4f7eb30c",
       "sha256": "0x0d86ba2d4f04a7c14073e89a0d5f6f2c5ae8be3a4e8c59ae681246d3bcd7026c",
       "urls": [
-        "bzzr://95f83e8530d0e679d107298ee21ce9e3c3d0287fbb3d9d302d6e12a637cb253c",
         "dweb:/ipfs/QmV5YPPWCJkrVezF9h9Moa9H3VSy51XQ8YpERjor4aewAZ"
       ]
     },
@@ -806,7 +744,6 @@
       "keccak256": "0xcb6b3535f841781088a92f2039b1de829bc33348ca11931a383b0dd3dfbbd9b4",
       "sha256": "0xe3677c825a9bfe4a102a4e5b7936484da875efe015d1b7d238da399f24737c46",
       "urls": [
-        "bzzr://7b3c018413f87be25b3d69c57bf7284d3cf92ecf00cd6397b2591778b186dee4",
         "dweb:/ipfs/QmSHTryeDKYc3uEDjNmG3JBuNTxyFpQTddLQNcwn2UEuxt"
       ]
     },
@@ -819,7 +756,6 @@
       "keccak256": "0x228fdfa9e09329885989b49fb21be808313ee966b84620f57b8ec100cc308516",
       "sha256": "0x0642c019003d97c2e51697ab3f394940322338c433a3db415bccc2ac30217158",
       "urls": [
-        "bzzr://a05dc23b4936010ad66949017003e242ab11f55ce13c0bbad6439bd4fe540baf",
         "dweb:/ipfs/QmYaLa4vkdxUabRoSVYrwvL9hm3TZPmJqDHdvdjY3MgaJ6"
       ]
     },
@@ -831,7 +767,6 @@
       "keccak256": "0xd7b4eac4e3bf9a128f4729fa44f2efbd865739d1fc513ad3a21129fea333502d",
       "sha256": "0x04f5e3c386833a5a0e15e204dec859a2499c8d7da69b89544e475c25004c4602",
       "urls": [
-        "bzzr://18452b4e52d051af96e6b1331a5d123bbe3bf6c52592b59b41325502b5eadd7c",
         "dweb:/ipfs/QmbKmiNg1L6SBeETW2CoszXW8XycbX8EcFbsUbToSy35Ec"
       ]
     },
@@ -844,7 +779,6 @@
       "keccak256": "0xa8abb73404da6db6a3ae96de3ee857ed5c9fc532efeb9e122c85c36e75447753",
       "sha256": "0x9eda87113669ab41e49bc82dc41dc97882a3b1a1ef4b26233a7decc218857112",
       "urls": [
-        "bzzr://5fc722ba4b94bc1b6aaabd79ee38f709a126b51a271eb2e790963e3646834bd6",
         "dweb:/ipfs/QmTy9nFLjavGb1rC222Ln4M1mn5ep4nxiqUn3hGbx8NuCo"
       ]
     },
@@ -857,7 +791,6 @@
       "keccak256": "0x9abaae03cce80facbf16aea914d2ba040afe421ee69e3fa63b7ed6a07c487f32",
       "sha256": "0x6bb343f3efbb301e11bde7cce219f3687fdae895e6e0c86d094c6ab0fdf71cc1",
       "urls": [
-        "bzzr://a1407ca844a88c8c8732754c0ac0da43285b89949d18e9755df9a872fcd689af",
         "dweb:/ipfs/QmWZwoXNq837qH3uqi8g97ggVLnTnD6Gw3SB5buNr3aHWx"
       ]
     },
@@ -870,7 +803,6 @@
       "keccak256": "0xc87e8cd1b4ef246eb76137265ea40490eb9be91024767b5d298c7dd0b46107dc",
       "sha256": "0x5c21f9931c341c9316d73c329c1dd9574708ba770cc651387b28ad46033fcd91",
       "urls": [
-        "bzzr://ddbb6ecffbdbb42afb09812ce9b02fabe053b0be8eac465e5686bc03f30a5043",
         "dweb:/ipfs/QmS3jxSU2nqLR4TypcHBG3HcLVGJuvEQDnFj1aLThYgTBL"
       ]
     },
@@ -883,7 +815,6 @@
       "keccak256": "0x941db66dc175ec3a7e26bf191480f13f7835c4e24fd19a0d081754451a617a40",
       "sha256": "0xfa7c6e62291eb09ec7da781d6ebe5f91f16d63094a05527d25e6dd37661fb022",
       "urls": [
-        "bzzr://845b79a638cc6e4c689e4eee8d7e6b65e67fc0f2c089301318fdd6f3290303da",
         "dweb:/ipfs/QmczDnbVkyYN9nanwGmeaL1jFvMQAUNYdwKxjyGBKkuZAX"
       ]
     },
@@ -895,7 +826,6 @@
       "keccak256": "0x454d35224a9aa036650acc809cf01f1f161aac5387f57e597b6e543eaf03ffd8",
       "sha256": "0xd936d1b755582da12f0d11acd3bdb85050c40dfcb779d736d8929ca2e50de9d1",
       "urls": [
-        "bzzr://23b5bb211fecf22617061fdba5037f1b82ac1e53e7cd031684fff8d16722826c",
         "dweb:/ipfs/QmVGkLXrv2j8ps84tX7jQfBD5ESFYMGo9vhwEAbtsQsKHA"
       ]
     },
@@ -908,7 +838,6 @@
       "keccak256": "0x3eaff752033f4b9ab4197421d1ba6db5ab657b6511384a54708f68f2c286b599",
       "sha256": "0x23b9bafecdc34d947955918416c51b8c06affefeab2a5b0375c18c2658bc6374",
       "urls": [
-        "bzzr://7f3e974be20dd1daedf899277356ee923562da891849f5479ca8b5b326413b73",
         "dweb:/ipfs/QmUkemJs5j2CSxZCXFAFq1FFBf1tPohFHubvz69SpX4ZAv"
       ]
     },
@@ -921,7 +850,6 @@
       "keccak256": "0x4d55a70a008bfec90c26e123ffd69e3be94076994d092a2d8bb27669ade15293",
       "sha256": "0x9bac65372666e6aeb2730c7fbceeef247d3029bbeb545d758d3ffc6181987e0c",
       "urls": [
-        "bzzr://e150cee6dc37cc86cddba4e5247baab8c0f133834a4fb8bc9d96eba9257fe358",
         "dweb:/ipfs/QmP2ZkAU2jCFE1WPnXRrczonkPhBoxsFvuVPhP3z8FkaKZ"
       ]
     },
@@ -934,7 +862,6 @@
       "keccak256": "0x3a1519d7454cdf037c7b56f569a79612264ae81db541fa357ba27336120ddeb1",
       "sha256": "0x3c72331f7b1dab3732d4cb4ae0883ada00206f28b36902b119eb2584deeaedf0",
       "urls": [
-        "bzzr://0858d22e45e237fe14762e664800bc6d8d03fe8f82912ef20eb0a13c33f28b7a",
         "dweb:/ipfs/Qmc5yW4wHskdxrKJob7CUGcrjvCTUXmZ8aMHQLtSy1WDSB"
       ]
     },
@@ -947,7 +874,6 @@
       "keccak256": "0xdb64f004110a9c99b5d5f0190d1cc3831c22aab4bf7cfff4ebd5d96e32ad2c2c",
       "sha256": "0x9406c1077814e3473aa4797191ef64cefa45b818a78a2129ec1b457a7c5f5636",
       "urls": [
-        "bzzr://3d6d1331408f7dae3e58daa061f87512098a3328c892ca467aa75f9d82f8fa3e",
         "dweb:/ipfs/QmchWisHV5tYCLKprAYHSbB13CZLA3Fwr7jEMPdffAUN4E"
       ]
     },
@@ -960,7 +886,6 @@
       "keccak256": "0x27eb47675846e5ae02d3e62cf4d7415c0512f0f001029a9e09fe7e735c32626a",
       "sha256": "0xcae27903aab649149d1db479cd80aee0ec0cd281e8a5fb2a1b8cc3b8634aae18",
       "urls": [
-        "bzzr://1fd90544532cd96b7d1c9de81a61b86ddd52ceb1e0c95a26a0583eb46fa44915",
         "dweb:/ipfs/QmetBJmXrod2pJJYRfbSJnapCggEWCqJpx22qSgqw4kbE1"
       ]
     },
@@ -973,7 +898,6 @@
       "keccak256": "0xcce9d20dce7941189fdd2d3b1e766b785c81830085f7d68c1ae8224df2497c2f",
       "sha256": "0x67bdc3ec543e1233feb237bc1c342b452ab1d5b8827cd41e2faf3972784377fd",
       "urls": [
-        "bzzr://7834d15b5ddc341b4d3b5c40801c5b288f0eb61ee222dee2e1d19dd83e0215c5",
         "dweb:/ipfs/QmUmsRFWQve8D7K2iivBpTXvvG4MTgdDXaPzmzJrzTWeGB"
       ]
     },
@@ -986,7 +910,6 @@
       "keccak256": "0x44064048f215bd393fa394964d6c7e29d31c98053312b0536ce4ba3c5948c25b",
       "sha256": "0xa6dd551109f4f316d9b6a469fa5066f94653db9682d28058eeeec49ae0eadfc4",
       "urls": [
-        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5",
         "dweb:/ipfs/QmaUBG4aatMXVivmBzEjzqGtAQhD6zNFfmnaqU8fUxmBy1"
       ]
     },
@@ -998,7 +921,6 @@
       "keccak256": "0x17b583f06e82c007ca0daf40344a12b5d93e85dd31969f076ecfe705db6d360c",
       "sha256": "0xaa7c0b18821a2f23c09da479d803f73976011445d2b512cf23e4a31d1a268bd5",
       "urls": [
-        "bzzr://2b86d6491012ec3289a22ee1c2fd6a093e68dd0d93675177f9a92c1f795b9415",
         "dweb:/ipfs/QmZiWoPyohpifswK4QAyBHubCAnqXHzXRxiv1Hq2bB3iyE"
       ]
     },
@@ -1011,7 +933,6 @@
       "keccak256": "0x7a5babe98735ca334e780047aabfc0500b24c0a9f48ccd34ca4070d68215b179",
       "sha256": "0x4a7dad730af26ab13ce5b32122f00fba59995ac2e6fca74cbef38b49cae5cc0b",
       "urls": [
-        "bzzr://d76345e68833185f3ba48ff5ca742afc14f928d624f0691cdfce1b77bae862b6",
         "dweb:/ipfs/QmfFdcHw9SqpK7ZZFGHmYU5m7fxM3xB2NdfsRPvpFjL3J6"
       ]
     },
@@ -1024,7 +945,6 @@
       "keccak256": "0xcdcf9aa16e51c7e214b4b491ab73fa1a294634cd0182cb7e0d9ae2ca18441acf",
       "sha256": "0x1757199d38c6f13c9aca0e72a973b9834b8b42027598d6fe85c69c321d8afaa6",
       "urls": [
-        "bzzr://e1e6c1c723fcd32d1cf75579e08c6db2bf207bd7f0290095310a04b6745f6167",
         "dweb:/ipfs/QmTbRPziZrwWQewkyU3qE4cGtqzqoMuZzmN7qR4r7sMXM8"
       ]
     },
@@ -1037,7 +957,6 @@
       "keccak256": "0x9302a446e60d678f385e58d8c3f1e33fdf31b75ecab793e4932b9b2bdaef1fe4",
       "sha256": "0x98a4f383aee5be5ddd769886ba36f13b53ff635466b24054bcc3cdf2956c4094",
       "urls": [
-        "bzzr://93a3d8388e347cd8b7a126e6a38cfe17b0de2decf808ab4799a0cad644a9709e",
         "dweb:/ipfs/QmUqBuwXgVpT6JJK3Mda3C6EGf2X16pxezEpY313xvad2C"
       ]
     },
@@ -1050,7 +969,6 @@
       "keccak256": "0xcf932ca69b3d62ee094f9e137b7113a3039a212ecdf10d081efad38940b36f4f",
       "sha256": "0xe8f761da6443701149f37b665c0fdf63544e4d7fa8ffd1deff6230c9240c5eab",
       "urls": [
-        "bzzr://9660b713dcfaa8db923af1c65aa9372a526023fe46d5a5b169d7ff8fa72bc6d2",
         "dweb:/ipfs/Qmd5To17yUWGChKVv6FLKUqWFhgikmHrxDbHvhrpDqziAp"
       ]
     },
@@ -1063,7 +981,6 @@
       "keccak256": "0x9489ef1b87235388b354970a4a340e37dcdd2d6dca017b2bb5fcff618913bb8f",
       "sha256": "0xd6260ff64662c6012e9156709a0f54088027b591eb3793a894495bfbf69e2d31",
       "urls": [
-        "bzzr://2ee65d3cab7594c7b7c5111e30098bb2177a6c262476876270b2ee75bba7c04d",
         "dweb:/ipfs/QmWuKsSEyDy7mvozw52ek6MiywDPEAKDhjbfrxhy2XHr9j"
       ]
     },
@@ -1076,7 +993,6 @@
       "keccak256": "0xde87b806132ac2e7aa80942e562aa07c0ae289ad6f8652795c73cc17a839bd8b",
       "sha256": "0x983d767691b17e60f38526eec77ea9408a3420f8fed8aa4b782db744d4e08614",
       "urls": [
-        "bzzr://50eecd81d0d0450ae1a9b96dc4b326ccea3b808d59b95db44b828c0e2dac5d87",
         "dweb:/ipfs/QmQie95qzoSXtaujNwZL4SPLhvPNWRiAnQCsmheCyrzBup"
       ]
     },
@@ -1089,7 +1005,6 @@
       "keccak256": "0xb6123a4f4145798d586cd4dab2bb33407f8bfc7fc4e3b888a69ff72b0fec3dc9",
       "sha256": "0x0d7768c896ab3f3bd62cbcc61f0a564f237f71518cc19a55202fbccda5a7d1c9",
       "urls": [
-        "bzzr://e6e12735593aea666821ccdaddff3f75bf1f59228060b28928cd54cd946397b6",
         "dweb:/ipfs/Qmf9uMUcRsCSRZWD6GMQpE3uwhXUZVSCBUTVMFEDZJ3SZn"
       ]
     },
@@ -1102,7 +1017,6 @@
       "keccak256": "0x02323bb8210fc523cd3fb8dfec278ea06b72b456114aa8c0bfde3c670e9f9daf",
       "sha256": "0xf9fe6ad475ee114b75431a3c2449e6533c38988fe83400719f016cae0aacc3ff",
       "urls": [
-        "bzzr://4ebcf240ec9d951c0a8a2a9336d53e531291afb7825da8f5339010f1032e3777",
         "dweb:/ipfs/QmfC3d2JYmhmxYxCf5Eof7SgVFmiSkaNeYDz1oaxUvQnqp"
       ]
     },
@@ -1115,7 +1029,6 @@
       "keccak256": "0x6fa50ba43b69830219f2670cd3fd707ef17e5a501c21071a4be8011e27235d6c",
       "sha256": "0x989accc3f979967ffe0c23b03ae9d7b3bc4d566ffb5899f3c0818291fc8a5ef7",
       "urls": [
-        "bzzr://0d2537be970544b5c934c3ae3148f0456fe24cf4b7b4f659664273794a8098a6",
         "dweb:/ipfs/QmSzEAncqGvZXNjS8Zn421UiWNeAKzzVAYASf8QzbeXQkd"
       ]
     },
@@ -1128,7 +1041,6 @@
       "keccak256": "0x2717dfe52d8b26807485664d813b926b046394b968ea6a7f438e1677b3748e4a",
       "sha256": "0x96f964d9c5c2542498abd84f4ce3b6c679664e325844649b160b7ac48b4a2a6b",
       "urls": [
-        "bzzr://a3ec1928f49d3f7c2eee99ac060feaf96d441631e3f4ba68d9732f735bfd597d",
         "dweb:/ipfs/QmQ6kHj9A42zLvayi5CJXdhtAxzusiNBryBf6zD15yzXV8"
       ]
     },
@@ -1141,7 +1053,6 @@
       "keccak256": "0x52d3bf239da2501272dcc5d223caad818689c117baca308504b3dcfc11becf6b",
       "sha256": "0xfe40de07cf670e952d2b56981493a878ac1b06efd821284a4976c96fb872c650",
       "urls": [
-        "bzzr://dd83f2d7364573bcafccd65a008e7ce9a03e6b7f81d488cb74a774ad450a2d9c",
         "dweb:/ipfs/QmWtEdd9sZnPDJyjsdgVXbcoajZVD86wAWbkvM1YPyh2Ge"
       ]
     },
@@ -1154,7 +1065,6 @@
       "keccak256": "0xf68c39478270ef3bbec58992038858cbbdb3a27486181e424bf28f167dd93d3c",
       "sha256": "0x9ad2a6f478769543e33836a763578a9b2d3931a1b3533aa89b3e631efd447690",
       "urls": [
-        "bzzr://717e33629edfa67935dc5ca9d4de2fe6532d30bdb9a58794434b3497ebd11939",
         "dweb:/ipfs/QmPZVpAs3X4EUKSqj4XQRetVDAgyVdXwUM7VBqDYcFahnU"
       ]
     },
@@ -1167,7 +1077,6 @@
       "keccak256": "0x7f686f0858b0ddcca9010f6388fdbf5bbb0273d20efd7fd23680e61522d8ec84",
       "sha256": "0x4a69e769223fbcf4067839ce02198f18a62497c344197639f7ca9ff2b05ba5f3",
       "urls": [
-        "bzzr://f412a6c4d51fab6c93726221cefaa61c251dc4e28fae7fc99cec21440000e462",
         "dweb:/ipfs/QmRRD4WeTvUK8HZ8mGkeNr9cKT3hPgcEbfTDQqKYtH8JK8"
       ]
     },
@@ -1180,7 +1089,6 @@
       "keccak256": "0x50d43dbae57b67c95c1c0dac16eb780f7b4a95f276e7180bc33b3afa8ece8a3c",
       "sha256": "0x75f4518035a031a705cb23b964decdfefdfaf1181454e69b5011047fbc92c3d2",
       "urls": [
-        "bzzr://feef476b6793e3003fcfc018cf98ac53c9de940194602982b7fb07de13694afe",
         "dweb:/ipfs/QmWnxt4iuxmodqgwQd8wtvha2VZhWFsKZCk254ezKcmfWZ"
       ]
     },
@@ -1193,7 +1101,6 @@
       "keccak256": "0xc7e1f69fc0fd67be01a07ac60fdd085425d0a93f04affe696e24d2f9145ee742",
       "sha256": "0x91a9569b69fc7f6676014bbd265d29efb09338b96d5880943bd6f1836e213b0c",
       "urls": [
-        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23",
         "dweb:/ipfs/QmNhg5AjrnTzG7PZV5ASUWpm68ff8MUjB8JdsAuNHua4Zd"
       ]
     },
@@ -1205,7 +1112,6 @@
       "keccak256": "0x44064048f215bd393fa394964d6c7e29d31c98053312b0536ce4ba3c5948c25b",
       "sha256": "0xa6dd551109f4f316d9b6a469fa5066f94653db9682d28058eeeec49ae0eadfc4",
       "urls": [
-        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5",
         "dweb:/ipfs/QmaUBG4aatMXVivmBzEjzqGtAQhD6zNFfmnaqU8fUxmBy1"
       ]
     },
@@ -1218,7 +1124,6 @@
       "keccak256": "0x30f3d3e92f3e4de23489aa99951d1dd8ecbc2912a9f95ad4cd408bb81c4a8f73",
       "sha256": "0xf9e7c89c42938aafd676b2a99ac697a2d7ed9af51312a9ac6ccb355e86c8e345",
       "urls": [
-        "bzzr://da158fda0b357e429c7fbcf2295e2e77e346dc2cd19ca60c7bf3c2252fa316c7",
         "dweb:/ipfs/QmfBj5pgaHEBM5Eb9Yy2PHMx8aUoaw5GThCEuERvVtwaAH"
       ]
     },
@@ -1231,7 +1136,6 @@
       "keccak256": "0x5ee190efe0d9a9668d9e8c141827e0c743b777ba0eec9f3722defadd53e9d5a7",
       "sha256": "0x6961a9da4c6fe3d7246ac11d8815a7bab8e1ae22a0ca0a06ede8c5afd5711841",
       "urls": [
-        "bzzr://f8e63d3aaceb1460fb4fba5b33507653b345aa7badeb23073f90aa947b58a44e",
         "dweb:/ipfs/QmPdNKcSf8fYm6iR56tajGjpUVFg5c3D4SHWTrMrSergP2"
       ]
     },
@@ -1244,7 +1148,6 @@
       "keccak256": "0x14496dd7e58f65f6d1a14efe54f0ecb45d4784d0f7e86f64b6ae09dff054bee6",
       "sha256": "0xc49cc2e003871c9255dfdf4afcd79b8d5b30a46236b71c7379ef442d12ad2fee",
       "urls": [
-        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216",
         "dweb:/ipfs/QmRUQpExWxf5R8FrUUCi11jguqhKNiTETKiXmK7CZ2tCtf"
       ]
     },
@@ -1256,7 +1159,6 @@
       "keccak256": "0xc7e1f69fc0fd67be01a07ac60fdd085425d0a93f04affe696e24d2f9145ee742",
       "sha256": "0x91a9569b69fc7f6676014bbd265d29efb09338b96d5880943bd6f1836e213b0c",
       "urls": [
-        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23",
         "dweb:/ipfs/QmNhg5AjrnTzG7PZV5ASUWpm68ff8MUjB8JdsAuNHua4Zd"
       ]
     },
@@ -1269,7 +1171,6 @@
       "keccak256": "0x089e90185871c24b23b3394fb5944c4b958005142c620c1209b0d9cdf3009aa5",
       "sha256": "0x41e7095d8be15f2bde31ff030ebd08e481dddff425622a930074eb39ec808648",
       "urls": [
-        "bzzr://c553878ae9a42dca9f43cb09ea424d936b674f4831e356ed37a33574e637f700",
         "dweb:/ipfs/QmREkqm6pZou8m39Ackg7JuhgFDE4NCfRdzSKxcQPP7EtZ"
       ]
     },
@@ -1282,7 +1183,6 @@
       "keccak256": "0x0833d27443c185f9c455c26db0cb11189b8b349670ae7f3c2f5f41940bee103c",
       "sha256": "0x844e0b1d3e4602636a372acaa29c1376cec6a21eb2a2c8e94a1cbbe58f0fc3ac",
       "urls": [
-        "bzzr://2c59662e39f450f870ed874a86c14964353dc43de70e819b89fcca234fee880e",
         "dweb:/ipfs/QmP8XFzSmpUfkoTyN3jUD1bGExGtiJxNDX3W41WeDv57rD"
       ]
     },
@@ -1295,7 +1195,6 @@
       "keccak256": "0xa0f6ea439a311e718ffb1c23c916de1ce7cefb073a0624b663e50e44d0067300",
       "sha256": "0xbbf16853b3b5b4dac3cc42a77838cd4cf3a6ef75c6a8a43bf4b0b1f6433c7bcf",
       "urls": [
-        "bzzr://3262712f165c7125d20d46282045a951540fa12145de2879a3fe18540301e551",
         "dweb:/ipfs/QmdqwbxPA1xo852Rao1QFgKvNFfYeb3oBHnWHXpgHg9Sqr"
       ]
     },
@@ -1308,7 +1207,6 @@
       "keccak256": "0x4f6f8c14187b2ea7e56bb909dbfca8ef4fe821e5e20fc32e9a78bf7fb2d939d3",
       "sha256": "0xd8227ec5ed2274b5704f50811cfd0ca86f86ff2f5fa72ff34d17672415d3a063",
       "urls": [
-        "bzzr://22292f4af992a7df152a7f9cd4c6d193a626413e3a97b656d087ab7200beeedb",
         "dweb:/ipfs/QmWpJNpEYX6JfvNiSBVpSPcSKQ1QAUjz4ixbEe4GXYr8DG"
       ]
     },
@@ -1321,7 +1219,6 @@
       "keccak256": "0xe12afc1c789ce1411099d38d7d7753a84639667c5ecd3baa2f0ed03b39566f9f",
       "sha256": "0x10f1818a2ab33b2c97341bfda3005449c8021622a1e12826784612c2b6b7544f",
       "urls": [
-        "bzzr://655262be96635213d044d344bbb5158ec70d036bbc3efe068bf89361eaa5cd80",
         "dweb:/ipfs/QmdqexNQV6FnDVeVhD1ogjrUz7nxdECyRxtHBZgPp6Kd1H"
       ]
     },
@@ -1334,7 +1231,6 @@
       "keccak256": "0xe12afc1c789ce1411099d38d7d7753a84639667c5ecd3baa2f0ed03b39566f9f",
       "sha256": "0x10f1818a2ab33b2c97341bfda3005449c8021622a1e12826784612c2b6b7544f",
       "urls": [
-        "bzzr://655262be96635213d044d344bbb5158ec70d036bbc3efe068bf89361eaa5cd80",
         "dweb:/ipfs/QmdqexNQV6FnDVeVhD1ogjrUz7nxdECyRxtHBZgPp6Kd1H"
       ]
     },
@@ -1346,7 +1242,6 @@
       "keccak256": "0x14496dd7e58f65f6d1a14efe54f0ecb45d4784d0f7e86f64b6ae09dff054bee6",
       "sha256": "0xc49cc2e003871c9255dfdf4afcd79b8d5b30a46236b71c7379ef442d12ad2fee",
       "urls": [
-        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216",
         "dweb:/ipfs/QmRUQpExWxf5R8FrUUCi11jguqhKNiTETKiXmK7CZ2tCtf"
       ]
     },
@@ -1359,7 +1254,6 @@
       "keccak256": "0xdccd9e4f31ae7869f37f28233a0334e81b56a6ce33fd44ce0bfd5ee113b8ffb2",
       "sha256": "0x3f7c8cf19ebacb1d38997424b5b23c92059ac0f74340e09e9630cb6a6805d225",
       "urls": [
-        "bzzr://95a45f6fa79667e6fef2affe32807d1bcb8262b3bfd848cd1e69707d3b508bb7",
         "dweb:/ipfs/QmZkF2SUSkVzMiqR9xUaTBo6c5f1yzXZYJ91tihT7MezYJ"
       ]
     },
@@ -1372,7 +1266,6 @@
       "keccak256": "0x6d238eb8d3e81b69e449af4843e84c47fed762c1ed860e5a23c1ebd9359aea88",
       "sha256": "0x00ab1b2d2beeb43eacd02ce5fba4dc0e23c86ff207c965a9bbbd0b374c874f0a",
       "urls": [
-        "bzzr://371398c2d4eb5d37b11657c986940e921227e8de42b51b98429a6a3de38a7cb2",
         "dweb:/ipfs/QmdWaPqVgGofyprioihFu3JfA5iX1wkwhhM6AaiacHUDdF"
       ]
     },
@@ -1385,7 +1278,6 @@
       "keccak256": "0xa518196452974241f4d14aee8c20852040d2ff991ba5cbbd810c7680de5a9a83",
       "sha256": "0x1d9504a5bc5d92befbf7024873e561ea5eb5b94368b4b638ef9d8da9284131fe",
       "urls": [
-        "bzzr://40b339d28b408f50726f2e1654e67350c8b59e44576e85c374c0295ca772c6a5",
         "dweb:/ipfs/QmPeFgL1wq722KgDQCyNKr69gjuPPNQkg5id4zo3Yi2Gk4"
       ]
     },
@@ -1398,7 +1290,6 @@
       "keccak256": "0x190b4cb86da0652deb7dd71c6947d164f3a23ddd36351aa74573dc9c9060aad8",
       "sha256": "0x3a74ac555a0564a5248a27b6a6b6c5bda3b0a6479e8fa2edec5f90438123e2f7",
       "urls": [
-        "bzzr://cc6a2642c8cc80d436f52f209f1cf007106dfe56e99814ecf46091b75980f010",
         "dweb:/ipfs/QmNQRKFqFX5XBr38eM14pv2buffSnUx5FjQBqbmZm4uDNN"
       ]
     },
@@ -1411,7 +1302,6 @@
       "keccak256": "0x1d37149521cb1078fb44046fc6e08774e8c5622f5601c89e749f3b175e156ddd",
       "sha256": "0xc4066e3a29cb222e726e90428596f75e4b5fc22cc21f580101d095d82e17c4ce",
       "urls": [
-        "bzzr://15c26f2bb3c161a935bc6725d0d648428a0c72d3c63934344573a9c6cdf49e9e",
         "dweb:/ipfs/QmQfjhHdDNa93UavdSCVAtQ8N9mhvM1qp4CibJRwJP4229"
       ]
     },
@@ -1424,7 +1314,6 @@
       "keccak256": "0xab46d1d570942bd31e24a53469a699d1314806cf6cf659b8a188af7179a6da5e",
       "sha256": "0x29d872bc3a58ded317e6ef7b0528d8e24c74c11b9078dbe36400a710e0385bfd",
       "urls": [
-        "bzzr://4c5a8418a4dd5223bd5fa3b3a751f0877ea3b6a0ca7143696b54b488b6b064bb",
         "dweb:/ipfs/QmP6RLYDEzCT7FgH8dqXuA9ukdqqfPw1L6RsrruiUNaAZk"
       ]
     },
@@ -1437,7 +1326,6 @@
       "keccak256": "0xb8fea6e749581356fd8c64962d7ac6fb888c826894de3749bd507ee28926ab10",
       "sha256": "0x17ba00cb71c45bcb3b2d1cbb75abc82439ad75b3073a23beb69f6e3e4844d3da",
       "urls": [
-        "bzzr://a2b92796642a552c96e91f31cdd1854e56953e53ae7b3d90e4d289f671b1ba9e",
         "dweb:/ipfs/QmVrj66LjcgCxGHD5GiCX3X555txKbod3TAek5YLfczXZK"
       ]
     },
@@ -1450,7 +1338,6 @@
       "keccak256": "0x39630c76a46a1383ae981bb6f30da89e0a3b3d75d5643d23e8caa8338d29fc12",
       "sha256": "0xdefca7ed84bfbd7272d19e9192ff4339789d02439092a6bd8dcfbe52007f57a3",
       "urls": [
-        "bzzr://db7a2290bd3a8a87a3cd956436001395813e19d611ec28b18393c6b9ab761dae",
         "dweb:/ipfs/QmaKQs6mhqnchuAqixM8HgyyrwUd3HzpamggvEN9S4VmwQ"
       ]
     },
@@ -1463,7 +1350,6 @@
       "keccak256": "0x8c69c60a349cf3e6715b7cbf83c5e8a49aba838d45129d95b55681a89b54ad2d",
       "sha256": "0x90f6d03989d2ba9af752022a3213f5b00c093caa2cfe073c3ca0f05b20c13967",
       "urls": [
-        "bzzr://1c0ba190b8700eb24630b041dec406da0700ed60f557f32019170870bf0d62b4",
         "dweb:/ipfs/QmRLva2J2uLmTvYi5VUouSFVfaTzT7kDNZQCaEYjyYmZTB"
       ]
     },
@@ -1476,7 +1362,6 @@
       "keccak256": "0xf3a268be89a29f9ea1827098f15227443cee10e4a48224df04524dc0c5cea6fd",
       "sha256": "0x7273fca7d805b39e214e0c7037dd06f299966dea4377ce89965eb5fa3fe9c545",
       "urls": [
-        "bzzr://bd61f26efb5ab70fed4536e43d6390fdc5e3bbad35d778929852e17ba972d6c8",
         "dweb:/ipfs/QmTAFBD1857ZZBRyiLD2tg9irrbaMBymG9cFZW78yTLztC"
       ]
     },
@@ -1489,7 +1374,6 @@
       "keccak256": "0x0ef48a43ae676add07b1c4bf1ca6a1365523ccbcecc9a1060b8429d4db7b781a",
       "sha256": "0xd77cd93f670cc339517ff4d9f9b9abaf7324cd3c2f39c7a2b2d80a322cddf710",
       "urls": [
-        "bzzr://f17c0dfd5f3b52053744e3d21649f75e6c51b314e841f932bdb460513af2a3e2",
         "dweb:/ipfs/QmUuqL7sYFReC1mnyWwzS5qkDPaErADo31D7waXBotjqjM"
       ]
     },
@@ -1502,7 +1386,6 @@
       "keccak256": "0x39198be14bcc06d084c566b5266c0e369c2994eedf6b4d8ed2bfdf97c70bcef9",
       "sha256": "0x32a49a03a93f638557e8bb1e40658060dc970e52425c2fc89887e70b2734e635",
       "urls": [
-        "bzzr://c18444aa5ea66c67976d1a0b0f39e2a9f2e49c0137806583e2002381f3040cd4",
         "dweb:/ipfs/QmU9hBwxHsMfD5RGxJpeu4JV6gnPVtPQAN316pSLDToDnX"
       ]
     },
@@ -1515,7 +1398,6 @@
       "keccak256": "0x5c547d48321c4754e700aff0bb457b984391fd354c5e517f9097fdb4121f8f78",
       "sha256": "0x6233a423c056ef7db9f943cef55d3f209b78e931071519afe8ff2c9abe612805",
       "urls": [
-        "bzzr://f4f29751cbf20f5113d14cd4d3dbd6ad6f989f6f32b2613fd07c50a030494cb3",
         "dweb:/ipfs/QmdRKF4DDgymJFXSCf1Uok8Ds5ecVhvNYv1GrMMh8SGbk1"
       ]
     },
@@ -1528,7 +1410,6 @@
       "keccak256": "0xe4755e9e63763cd841292288bbb372c353491b79755ede134302321053d20db4",
       "sha256": "0x506ddaa6e4cdd200a731313fa8ee08fc7c8d33390e864589c04062486f2339e8",
       "urls": [
-        "bzzr://6b0b6d36c5db8606f9bc1f0a1de9b6fb101f88aeb260060b557729a00ddc2424",
         "dweb:/ipfs/QmP73uHtWBh7pfeatQKJQvxz1G62hBFZ3H2bc5yYidp72k"
       ]
     },
@@ -1541,7 +1422,6 @@
       "keccak256": "0x5f98684c7f011ee13f870671849e846c893e9179c5e86ee3340cd8467c84b48f",
       "sha256": "0x4bae570aaecd1cf8ed82953fdbfa35d0151416017103f949d58d213a3c2afbb8",
       "urls": [
-        "bzzr://612dd41e8b4993055eb5984f7de323a91ce2d3288160a00126fb233120c6713c",
         "dweb:/ipfs/QmdH6rdsYG1C9aWFKvx7FkWDgTzv7fhdwDKiUFPCGenePX"
       ]
     },
@@ -1554,7 +1434,6 @@
       "keccak256": "0x9cdeb8e6a6e278eb0279ef3bd501e88e0d9a8ab5832b648be5ccfe4bb190e386",
       "sha256": "0xa3b4ccbb9f067b006bdd09be1c2fd42c95cea1cd577223bf8c5f66cf870b794f",
       "urls": [
-        "bzzr://b41dc93f2b2b8ffbe8e75cd7a81acc94ec9af105c1ed0633a296d9778dd89953",
         "dweb:/ipfs/QmdGziRSFENh5L8H28C2UYC9fURPct8kan9RPCw7ztVB1o"
       ]
     },
@@ -1567,7 +1446,6 @@
       "keccak256": "0x8357db2c7b425a685fc6cefe46231398825dbfb73c65f8d450b7773d119f424f",
       "sha256": "0xae32873b691e9b6325210f15ae0e137c6db95168b2a5f293c007be0ac64d7941",
       "urls": [
-        "bzzr://d02f684350666829cfb6cb4ba4601a5e5c76a601fc7f3c22f9c4d2e58c9b3297",
         "dweb:/ipfs/QmZ7T7LtDDNdqcwq9xgRBad7ViWEpEWgZgVaS9qBmCgQDW"
       ]
     },
@@ -1580,7 +1458,6 @@
       "keccak256": "0x4ea91be3fb98769417f8a803cd7b4ec01547d98ab62c3515288d9e8f6171494b",
       "sha256": "0x5d1fbedf26d7f7f762f00e48b4cb7653e002fede762d88ee1e29b37f00fa6143",
       "urls": [
-        "bzzr://5bed380d76833b1089872458c2089fb5c554c5d157ac906c8b0d372d334ac8eb",
         "dweb:/ipfs/QmSC7uHGuVYoDa2NC7PLH9Tfnx7c56gnMRw8E4DkyJuA4m"
       ]
     },
@@ -1593,7 +1470,6 @@
       "keccak256": "0x36f534c9442aab9688ab5d601ab7d116c4ff21599883a7332a0ab91e4e2c9efe",
       "sha256": "0xba6bdc053e5dc08842543c4df3289d55d354c5e92c0a11835f3b691a6dd76b5d",
       "urls": [
-        "bzzr://543e8bc5b103e41a0fe8de4148297ca7713d945ac9ba5bbf020cc2a5075dcffb",
         "dweb:/ipfs/QmPQkx7YdvoHSPx6dVPnM6z2Gc2dRcfRfjZvZkVpTUxA74"
       ]
     },
@@ -1606,7 +1482,6 @@
       "keccak256": "0x170aaf57cce5775e54d911e667f6fe429b229642d6bd2af64cb81e15c340b1d5",
       "sha256": "0x924af8ddd30f9be9ee46d3cddabc2ce8395a8bf1f620ab05848c7be941930d2a",
       "urls": [
-        "bzzr://779e608822be84bea08e72d7e2e21afe77592f46865618e4f3bee756d0d75bb7",
         "dweb:/ipfs/QmaFiiL5XCDMg7dEm42BgHUQVLAXimHxKtvYH5j9chj11K"
       ]
     },
@@ -1619,7 +1494,6 @@
       "keccak256": "0xb35ead8bcc99a124a721833d8d6f1d1c275f7585d1c356c307ca455aadc1eca5",
       "sha256": "0xe526fe0ce16b25c5b7c801e37da313f319491ef358f7a7c00f2caa42f3a4848b",
       "urls": [
-        "bzzr://302edd503fca336fe7d0cb2b17068d749558d264606776fa169cd485016716e8",
         "dweb:/ipfs/QmbjykYohzLMsjXAyuHLumDUp4nW44g7TLEQdjPDf77zYn"
       ]
     },
@@ -1632,7 +1506,6 @@
       "keccak256": "0x6904df8575c6c7bcdcc3343d0205a0798ad3428eef598c528434f91cef8b8b70",
       "sha256": "0x5da97b472ddf8be04645ecb1bd491e366adbf3f510bfbc21650b24a0ff4d4c17",
       "urls": [
-        "bzzr://eb32ab0bf958b70199e5acd0c2f9ed2a69f2cfcd1fe938ff2c02fb0288810d3c",
         "dweb:/ipfs/QmXJwZt7ohJqmjgZkUqJJijmEFwHnLynywsRK288DxtSTS"
       ]
     },
@@ -1644,7 +1517,6 @@
       "keccak256": "0x814bf4e5eacbb1849ea12377f5935b1fd846ff1af5ffa2afeef2619f94273994",
       "sha256": "0x3af892fabc38b975b96a242b13e0b6465d9c09f505ea11932c60b982c0d37705",
       "urls": [
-        "bzzr://18acaee3f543de385d445ad0e0f96b506a5a78ea36feb22e79b984f0ea9500de",
         "dweb:/ipfs/QmaHD5nZjQLVqVEdPyHJyaxEP46BAHSdYBXeeFtUb2bK82"
       ]
     },
@@ -1657,7 +1529,6 @@
       "keccak256": "0x92864619b8fc23eef5b1f345a473a2fdb309a2c993dda54f7d8f88b13fc7f422",
       "sha256": "0x8944c7493af67aba5ab623eb1980e1e2570a9453c7d16e637ea76965f85e4b73",
       "urls": [
-        "bzzr://d0617e3fd320de4900c59f4769b407d86ceedd24ca127761ab10ff3541738a63",
         "dweb:/ipfs/QmZoV9SKQvDyb389Gg8z4B6SMUpmq4rYapb26n1QmzULdg"
       ]
     },
@@ -1670,7 +1541,6 @@
       "keccak256": "0xa8d415da7b11a4862b3a41c64c8c3de36b714d1098a1b2f3fabca7c66eedca7d",
       "sha256": "0x87d194a0cf6abadc8ff77323639e5fe0441265dd63d0d756924fbaa133c938aa",
       "urls": [
-        "bzzr://488053f2ef36dc8120764d897ed3c3ba1c63035c0030b50675eda623376eafa0",
         "dweb:/ipfs/QmW49uWNZHRx6sak2FBDcsoyzFauRWHNYpsAVVzzyjKkgS"
       ]
     },
@@ -1683,7 +1553,6 @@
       "keccak256": "0x9f0aab369eba0ee040e48a1fe8a0bc32c5f3c30738086a109384aa004982ce1a",
       "sha256": "0xef67a7bb0a240f36fcdd6a5641a05b2742c856a796d644cfc3d6be0c1e730961",
       "urls": [
-        "bzzr://b529c664ed0eb282ca2401ec5b6b5a5991b8fad6e5a7674d90690a688b78b3ec",
         "dweb:/ipfs/QmYEQZmcovgdUAa4718akJX4JEtvMKhMgey96RgTjrDMkn"
       ]
     },
@@ -1696,7 +1565,6 @@
       "keccak256": "0xe56b296cd823483b2137ffa47eb6a1749a8b69c7d54dc051104b94da6049a987",
       "sha256": "0x7c91b2c8f9b228a0696b31e2d972cb35b617da7cd351895ac1086e10a09336b2",
       "urls": [
-        "bzzr://95cb5155dec82805ccf1cd4aeaa60f980d270766852d23e78c54b336bba67f12",
         "dweb:/ipfs/QmZnamASdfrwiPjNLhNLZtRSq8t9rmcq5XxGgUpVCn1kj6"
       ]
     },
@@ -1709,7 +1577,6 @@
       "keccak256": "0x5e17be46ee4eaae979757501958f9571c54b0427bb50d212cd1d167c208e5aa2",
       "sha256": "0x913a88cee49f91cbbcd1c993cf8ac0910cf6d263c82ead96357f2b748e739675",
       "urls": [
-        "bzzr://212334c88f5dbfd68f35f458268117bd28a48afcc9893985abc276c4d8369337",
         "dweb:/ipfs/QmP5uK5f6Zu5Gg4nT7723VYfU2ZohQf8EEzuC1Up37w2dS"
       ]
     },
@@ -1722,7 +1589,6 @@
       "keccak256": "0x3d06695f3199dddb04ec320071b1387326cd08089a543a50fd464454c1cefa89",
       "sha256": "0xc5b3e85ea8f0144be8c7a2938f15ca8453c20a2eceb0fedce135cfba08d38bfd",
       "urls": [
-        "bzzr://9d53dc09b854f40f7571e69a845e13789c5e6dc7de1c97c5ff10ac74518bbe39",
         "dweb:/ipfs/QmRkMNthLRqwBc2vDTqt71MhFRfyMPcZfrooaz1AvZxGeN"
       ]
     },
@@ -1735,7 +1601,6 @@
       "keccak256": "0x5e60afff6d4716500b9c6c95b7febb207cdd7478d4e164bfbfe28813c7111af6",
       "sha256": "0xc88a1fb9fc0221bfa6e76391af28d29b168ae4af924586553d21a528484196f3",
       "urls": [
-        "bzzr://299fc3e0e1747df8fb357f866562d2a7854fe5b661d891a5547c2bca2e2f0553",
         "dweb:/ipfs/QmcKLP1wvPLX3SqRP8U7p8NixeBck4TFZ445f8o5snSpF9"
       ]
     },
@@ -1748,7 +1613,6 @@
       "keccak256": "0x4f55a9a793fdde73c763f5d8bd83a5ace4e0027879cf808d1374f37a8e9ce39a",
       "sha256": "0xf9dd9bb6cbded9bca18551a404ee6656daf46145fed82b59253253d4fa725ce0",
       "urls": [
-        "bzzr://4dd4542dc36ccd79fddd66557a98d60870abc3319f453a1fbff17ee867681422",
         "dweb:/ipfs/QmekjQcu5Jik1pfKpL6ANmZF7VwRew289ukou6KrB5cbWk"
       ]
     },
@@ -1761,7 +1625,6 @@
       "keccak256": "0xe97dd0725fdd04e0e92bfece025b44971d91e114dcb195a5454337f8b53e2093",
       "sha256": "0x7d50bfbb3b3e27e2e2fffc8dfa0e52b3d30680dc77e4764bd234297c8b2adff7",
       "urls": [
-        "bzzr://de80bc9801dbe2327159f78d42991ac5c46c8e4546845e1f49e37cdc3ae4833b",
         "dweb:/ipfs/QmQgQTGsuzVrTCuLeFiuZnJNtAY9hmAvApkF9q4SDwExHY"
       ]
     },
@@ -1774,7 +1637,6 @@
       "keccak256": "0xd8b3fde04b75fc82fbd66adf46db650cd8599d1eef0051ec1056db554705ef11",
       "sha256": "0xdc948190e9f9fadde2113b958340e49bf92f93106c8a631b13211d22b5ae6969",
       "urls": [
-        "bzzr://c0fde4a7ee7bc67741fdff85e6431e19cf3dae3c62e5627ef01b57979284d731",
         "dweb:/ipfs/QmQomGiVYCcBqKfgWSDchL6yi91CuomY8tYAUhTNcpf4Ad"
       ]
     },
@@ -1787,7 +1649,6 @@
       "keccak256": "0xf394e7c3233ab57a442dc1c91bb4c4d5e214472d075e8eacd890f8b7c23ba79f",
       "sha256": "0x3b8b1e25febbdea63121414c0940154fb1e8db2f880525beb435a2838b8d742d",
       "urls": [
-        "bzzr://d254a7edd27c4b38c1c104bc1b93ba445913e97c3e5d2854b93ebfb6f9297a7e",
         "dweb:/ipfs/QmPDPmCY48NB2myRFPwPESSqxf3wzunivgs1TRfjjunDPs"
       ]
     },
@@ -1800,7 +1661,6 @@
       "keccak256": "0xc7a443e86a4cf84e301bee58b1f19bff697259490063f8feb9d131e3ce261ea5",
       "sha256": "0xe6f4f3ebd438cd95febfe4646b9d7ed10801fd89d3e0cd14342d471c9696a680",
       "urls": [
-        "bzzr://1309b21812bea4e7d81e2124329be9a298bf21363f4487002d787b12e533d53a",
         "dweb:/ipfs/QmT5t8AgHcorWzMMweAzU2NotgyHmfterQ8p3s86TefHEt"
       ]
     },
@@ -1813,7 +1673,6 @@
       "keccak256": "0xc8cfbccdce7880d850591554d728a1926112eb50afdb9274c87acdc23723a373",
       "sha256": "0xa001eced7329e4b59cce04dbd12b4d9bb6ed40261655af003c56571018ec5e1b",
       "urls": [
-        "bzzr://c8541c2b4e21e16f3f39f0e19478c5f1b45dee97503298550204bf21cd54006d",
         "dweb:/ipfs/Qmc9s85WYQYJmaL2rkBKBzhrzg1yCTdkhQo8PrfozPZjtq"
       ]
     },
@@ -1826,7 +1685,6 @@
       "keccak256": "0xceb58b6969d17c99bd5d5876950f992a5d6dfb6f9c6eab5233f792fc876ff75c",
       "sha256": "0x3b143b7d00a92d240fcd424dc968e29505bd05604c8b6be059238b6b0cc898fe",
       "urls": [
-        "bzzr://97e5e466b7f247d015b94d213c9aa1459972c1f7bdca7d40137bc5762736dc58",
         "dweb:/ipfs/QmViumS8cUuT4uKaJDfmWn2t39JHtbr2AZhZoHqQR6vkHx"
       ]
     },
@@ -1839,7 +1697,6 @@
       "keccak256": "0x5e7a98acf9284fdff76d57cb1ed33389cfbe23e03c146927a3369fecb57d9b66",
       "sha256": "0x178335e90508663ee878b366c94e789e24ff086814ec4429a0cc257fbf204cef",
       "urls": [
-        "bzzr://f2622867fefd539b869c6e4a87886b9e1af332f7d90293f89601308e36db6763",
         "dweb:/ipfs/QmbtVTiYKUvkyjv1XG38dgvRVa8EgXnhknURJxyNe245Dh"
       ]
     },
@@ -1852,7 +1709,6 @@
       "keccak256": "0xa1f0d10ecc53ef85d50056407a9c5a421180dcd6d55043f286509c463d5cbc76",
       "sha256": "0xad641b58b0e23538a6637ffc3d09e2437c9ceb36ef57ace19fb159854bd3f2b5",
       "urls": [
-        "bzzr://81215d492250c766eeaa7558780ecb7399812393fd572543ff08730b1f9cc179",
         "dweb:/ipfs/QmTGSKXGftVrTHwNpPTTFPaEBbnJrMM52u415dRKuPPrPW"
       ]
     },
@@ -1865,7 +1721,6 @@
       "keccak256": "0xc89a202c173a8631d821b2a03956f47b8139c090f4b98b2257431734b4eab770",
       "sha256": "0x1fcae8b7f04a5a1aae3cc5a3be805e53e94169944a4c495f288734dea78774cf",
       "urls": [
-        "bzzr://fdf71a1adf267ba907c7da683adb423cc29014c0aefd9166f84cbf1b69511eb0",
         "dweb:/ipfs/QmXHxNFnxwEQYAnG64WjPLRqetkhu3c3Kd3kWRAXv96Wqp"
       ]
     },
@@ -1878,7 +1733,6 @@
       "keccak256": "0xfc510185e5684b27cb1562a7f62f51cae8acc709432322a3958d280ce50a5d6b",
       "sha256": "0xf856cf0aaa21ef221fd10448c299254c1bc23cbceb1eb9a5d65b9a9eb284815e",
       "urls": [
-        "bzzr://cdfda44fabc968d311dd15c06d4a0b5b209299dc4b6725dc47b3612ee12b324e",
         "dweb:/ipfs/QmNTFWJefnw7H1ZAvDnFUkuXC7wF8a3CryugUSz6HhWve8"
       ]
     },
@@ -1891,7 +1745,6 @@
       "keccak256": "0xa35708f7de1484828e006d644d1252cd506d5e3f6d107ded13a9e86a161dd672",
       "sha256": "0xd32578dca1af62f09f45d1d49879cd873d92eda3ea11d634fdb61e2c57410582",
       "urls": [
-        "bzzr://164b6a0bb7e496c371f2618c55d993c51fc2054dc0e2a57ef5ac62219e16c564",
         "dweb:/ipfs/QmYWEqiebdEuUbyrESc6NwMtavnzqZYPFty1ZEioa96fze"
       ]
     },
@@ -1904,7 +1757,6 @@
       "keccak256": "0x319dc30739a506711fc564399554a8cbcea99893364885f9d97db1a3d9c2a872",
       "sha256": "0x49b38c7044d6b433897b0a7357b0d013ec0b89594e113f166d1b2a2b90145de7",
       "urls": [
-        "bzzr://aba902440367c42b0a9c2e31ac866925533da0c2d5f18ff233c3c98c71985fae",
         "dweb:/ipfs/QmXRhocMwYaANDZWhyymVBJDDqXeRNbuRe1JUZ2B68NQiL"
       ]
     },
@@ -1917,7 +1769,6 @@
       "keccak256": "0x2c8f16d50a0ef98268a6646a79e060498605c17ceb740da228415720497e6313",
       "sha256": "0x151d429eafe4d94a61845dc51f065e4879069943ce98e22360dc77d4b69a6527",
       "urls": [
-        "bzzr://39bdd8f3374e73fa3e6f8f0545ba20071f225977d5c5acde592c0d268158e4f1",
         "dweb:/ipfs/QmUmd9aJKHZtNjHVzQa2y4uJtSYiJ6DcV7VhQJnpkcXFeC"
       ]
     },
@@ -1930,7 +1781,6 @@
       "keccak256": "0x2f60875fb1ac841f01349af5d29e62a90c5e82765e9246fd6397e94f4b7bdcf2",
       "sha256": "0x370e906919c50998dfcb9db995413da1d65df341582af33f206758545053fd12",
       "urls": [
-        "bzzr://25cd6058fae8b2e95da9d810907d4b7e72e36a6a0616070e9e4c1df9b88ce881",
         "dweb:/ipfs/QmYLzVfTgt4awXUcs6HLUCoKhxdEVqNayXeWycvx79MSUn"
       ]
     },
@@ -1943,7 +1793,6 @@
       "keccak256": "0x26c168ff5e5e6504ca1282e498a61ba210bcad24a31ce748541f01ecebb84d87",
       "sha256": "0x8d90481b881e58ad4f7a90f108b94064f856956aadd6e05d96cda5dc352dce1b",
       "urls": [
-        "bzzr://4cfde586b16d48b82c2e465fdf44865edbbe3779fd7277a120bd3ebffbaf3950",
         "dweb:/ipfs/QmT18S9DnApquBU7uACDmSuV5v5jQE5XaRjZwpdkG6F7Zf"
       ]
     },
@@ -1956,7 +1805,6 @@
       "keccak256": "0x5886727970da24b78a4ff10fae5370f3c98a7803eb0aa56ae06f2b5dbed23ecd",
       "sha256": "0x7a56a3725819b91f790052e8b8d869784aee8100af4242ca3122020008bf35b4",
       "urls": [
-        "bzzr://4bb8949a5db01d46d9c0c5639ec23a5e5193d186746c971c4864f28baddebc94",
         "dweb:/ipfs/QmYBmE4jfj7XuDsEQiboJ2ueHsyBAP3ygSJJWEeDJjaipi"
       ]
     },
@@ -1969,7 +1817,6 @@
       "keccak256": "0x3b0ad3ceb01a7b6c64757ce534ae1407536fce7f9703d3ea6923d03ed6ae2efe",
       "sha256": "0x184a1f1fe9430008b49d9af5ff8e40214c7cb7f116a6ba57cbe7513050dfa505",
       "urls": [
-        "bzzr://390a81b677fd88ecbfb7de6fc75df81de14a6e50f411b9299daae343a82c16d1",
         "dweb:/ipfs/QmdkpCmaroXEGMbgFVuywGqLS2GBbKZ3XXkosCyr4a4XJf"
       ]
     },
@@ -1981,7 +1828,6 @@
       "keccak256": "0xca308f787d878ece018898f1a731de2760c23d95dea77345263d28a286010e22",
       "sha256": "0xe6092a90398b8519fe2ad7c582074b806e365ebd55fc86d7d2d5c27513732373",
       "urls": [
-        "bzzr://980e9ced0a6e1c174fa9f2244536f1ef1017b1cb2758bfd5993c54bc6c0debe7",
         "dweb:/ipfs/QmXcSiETZMMhrxqN5BMNS7hCAkxJnPN2PAZEGnPgDKdAv6"
       ]
     },
@@ -1993,7 +1839,6 @@
       "keccak256": "0xf39fe2338b22783588c6f69980ed87783808e3f853e976b46f4d2ad8570b5887",
       "sha256": "0xab1feba0069ac1adb8d09998871bce9af96fb88ee88d8e39235edc80a448afb7",
       "urls": [
-        "bzzr://1cb0fa22a5e12c6698b4dc03cd6e98bae2e3a3dd664c29b9108838d6a3d90d34",
         "dweb:/ipfs/QmYUYBQcRrWqGRgdwk9Wekriix2xEkZx9qzXAE6jg4FQpo"
       ]
     },
@@ -2006,7 +1851,6 @@
       "keccak256": "0x92e7c8dec3491faab53b9c0403fc59024caaedde033e2eb141db679f33ead0ea",
       "sha256": "0x4efeabcfd9ca1addede1e3e191ce6f37ff48bccb8639a6466bfc66e47f5d0a68",
       "urls": [
-        "bzzr://bf2f6a91eabb931d280bbf4b2a82e8ed832ac8f7dc70fb40253b6699d5693090",
         "dweb:/ipfs/QmaQeJbtSD3hTDTQMAWjQcSiQGfnxj87EtUiMdXz1qUiKc"
       ]
     },
@@ -2018,7 +1862,6 @@
       "keccak256": "0x415b193456056970a77c5ca6a7a611319ce197bdc845288a143fab1b56f032d0",
       "sha256": "0x4b50704e5b245c97da025c5adcd893a19c4e2dfd87aec064b7e45069b7b8333f",
       "urls": [
-        "bzzr://99bb321a5e5a90a7b192f409211960f8d971221fd0a0b2d4319133da36ef8882",
         "dweb:/ipfs/QmZ4ydjmqK7tYFWbLx3Ajk44K2scFnFaTS2oEGPNDrG6wf"
       ]
     },
@@ -2031,7 +1874,6 @@
       "keccak256": "0x71ec1424ba2cf9aa534ec8e77d0b98149e4dbdf2b76b0ffd3cca1dec9d898bad",
       "sha256": "0xae1417a27a3c13ce154ae948040cde94737c03fc052eb59e39caf9408be429ce",
       "urls": [
-        "bzzr://2b125783e8ed8bef47d6fbab14736069ea0e00a76592f7d0b84d82e4e7d9c69d",
         "dweb:/ipfs/QmaprvqzidVrpsmbmcVvYc4eGRKuqH4AYBskKvD831Eoot"
       ]
     },
@@ -2044,7 +1886,6 @@
       "keccak256": "0x1243fdb7e1d96caf2a00c383f0300bd57a8a95418d8f6b5996be1b5dc7d4901a",
       "sha256": "0xcdb9398fa8e885941f33842b978a1f831494d690a110c50c252daef8d7794fd8",
       "urls": [
-        "bzzr://68edba905b229fc3972552c91d1cc32ca8910c2ca23c0f8d0903afb14f9b2f71",
         "dweb:/ipfs/QmXWrnR9kwiUGsPfwH35Xs2tJ9GwkEzXVPMoofJnWj6QhX"
       ]
     },
@@ -2057,7 +1898,6 @@
       "keccak256": "0x8da9c3693c4090b428a08d1f9380fc3c03ab8cdc7a3f539bd453a855b29ee3d3",
       "sha256": "0x9c6413dc985cfa731795504415fd6413e0ee95c187551bff8572c4e6fe6f89c4",
       "urls": [
-        "bzzr://38e2d26bcb70d3fbbe01346f84ec6a22215caa4098fdc8e7daadba6a41b2960f",
         "dweb:/ipfs/QmXcbcXgpukorVvvjA8PfV4P2fqVs4m4fGvfpD3NN5XPsc"
       ]
     },
@@ -2070,7 +1910,6 @@
       "keccak256": "0xe7244f1450fb75b9efd863a1b056b49ebb6dc232b7bbbfeebf33350fae46e789",
       "sha256": "0x7a31f86357d045c80b5fb8464031d49bc6ed8ff36b6aa71367bfd71144f5fef5",
       "urls": [
-        "bzzr://6834915de9650f23babbb64a11fc47bfbdb3edee085a12e012950dc8c558a79b",
         "dweb:/ipfs/QmXubpciYJs3MzocpuYaVWs4iEVKCjkYmQfHDy19u4JE6Z"
       ]
     },
@@ -2083,7 +1922,6 @@
       "keccak256": "0x8431790f172fde38b9e3b8e632f5f5dbb9c49d3e254d24252c20ef0d903bd160",
       "sha256": "0x76600e972cf43b7d8610cd1351ac2edb80830ac4065f705f0f3506681105f54e",
       "urls": [
-        "bzzr://8e7cbde5a72e500c6c0185b7d580e7270e337fda18007f84ef0760cec639c063",
         "dweb:/ipfs/QmZtYo7bB6ze6BHzqRAK8oGn5DY7NCQd9N7yEu7KGwazfz"
       ]
     },
@@ -2095,7 +1933,6 @@
       "keccak256": "0x31c896ccaaca3c28b2f7a5d7af64a119449d64b7869df8279f6932b50b365493",
       "sha256": "0x61f379fe68599eab8fb6ee17f5b22656498ebff911e22a2112ad08454e8c3021",
       "urls": [
-        "bzzr://a5a3c021de2cb151dee1900070bad5df098f5c5c503088fd2f423b6391496bba",
         "dweb:/ipfs/QmabfhBtgysWFcjEAnQyaVVqJbLxjUjVLGvCQbKkmF5S2P"
       ]
     },
@@ -2108,7 +1945,6 @@
       "keccak256": "0x1c15a96e2770b1fc9b35f6df84495c7617c706ebb2525d6d5d535fb4268a83a9",
       "sha256": "0x16a2ae17a7187b78c7916d65a002a74541d20a6306793ab118bb7b07d0811fdc",
       "urls": [
-        "bzzr://fa006b14e97633f005f325b8de0b86412ab2210646ee54f97fdbf0ee52545445",
         "dweb:/ipfs/QmVKewzs6TG9Xedw6dwdLhzj7iSpqDgwJVRCmfuq87f5qV"
       ]
     },
@@ -2121,7 +1957,6 @@
       "keccak256": "0x9b7c7c122923cc27f3e09ee24027e2a5f0eecb3b1dfd2998b9ce755f7373cc46",
       "sha256": "0x274fbb996cdc4682c6d8312efc1fc8bec5f77af76bab9a287900be4a8dda35c7",
       "urls": [
-        "bzzr://dead9fdcbe64fa7a239bd0eada3a1cea7d17e3f66014efb902f3dae708fef4ce",
         "dweb:/ipfs/QmUK4v3beb58hp5HHDTdtkebZGELgjCS3Q94ykaSPSLtqL"
       ]
     },
@@ -2134,7 +1969,6 @@
       "keccak256": "0x885481922567c63d3cc2cfc79c0e08a8ccdd05b54912bbe8cea3d9ff15418c4b",
       "sha256": "0x7f715c7682140d286c0084d1780251c5fa90df07a2f4a5ea78b079bcdaa14407",
       "urls": [
-        "bzzr://85030bad5ca06b4b65ccd9698b8723428ce37dbc299bccd22d49ed0b42723700",
         "dweb:/ipfs/QmYf1v6SJQHSK1HQSmDRUBUgJBrG95eAAMzorPX2o9d4ja"
       ]
     },
@@ -2147,7 +1981,6 @@
       "keccak256": "0xde0145a4afbf8eee1f077f2e28b5b3dc838139b62cd42706a7186b6d03671d11",
       "sha256": "0xddbe1f050c9a5ea6b18bd76b09f7ec5bbc28c784a1f0c34c09ae6f9eb4263a59",
       "urls": [
-        "bzzr://9c66292e62a5fe01b3d3ea67344558fede467d86b17bd6a2c6db71e54ac7590e",
         "dweb:/ipfs/QmRmKvojEg85ggKSUgRUkAXKFVE1YDifEgGZYmjqeyA5mo"
       ]
     },
@@ -2160,7 +1993,6 @@
       "keccak256": "0x81a4bc90acf35e3a86c645e29a29811b243f5c965b954ada640b2884b79b66be",
       "sha256": "0x1a3fb42cdd5941a453814f096899d7359725ff0992311855f6b09744cd757554",
       "urls": [
-        "bzzr://61bdbdb7bc73509b90de3feb9ddd8506cf8ef442bb37b6b788374dc6e2e294f9",
         "dweb:/ipfs/Qmet5KSxZU4L5TC9CKxbk48ntMz4FGV5SMKvMVytPDkyJo"
       ]
     },
@@ -2173,7 +2005,6 @@
       "keccak256": "0x0bc4bff6fbafe09f54ea69d628b0465040e2feca302790e7d88e997cf9570722",
       "sha256": "0x4e25e34e8fc70a483bf02ffe3c951c46d8ec91aeb91cc5a7761cdfad9ef95806",
       "urls": [
-        "bzzr://7f3aad5a36603b6fe8391c7c3d457bb797678b00933e8780afdf0e98064f387c",
         "dweb:/ipfs/QmbyL17AVLcKTm2DtzmqxVZvCiBN9nyyioDE7EWniLMqDA"
       ]
     },
@@ -2186,7 +2017,6 @@
       "keccak256": "0x6e154734da6dc3c2470612a7dd339c5406bcce6e7ebf8f42b7e6f99a124d69f0",
       "sha256": "0x548f60bba9204a712c73c16e602bade383923c58cdb2be0934b2cb3bff365653",
       "urls": [
-        "bzzr://e892ec10727fefd40410b195f25e1bd50c217ba5e6eb6fa6645a20513f909d0f",
         "dweb:/ipfs/QmUSeNyQwE3BtZukhAMdVDR2oRSjTWaKqQ6Jpsjm1PsDBB"
       ]
     },
@@ -2199,7 +2029,6 @@
       "keccak256": "0x4a5e312ae2925d170cbc1106a67750944350ded8eec3a284fef8b53dddfd384f",
       "sha256": "0x3111383c2e04f7689dc005be9e487af24c99dbf283c51c180eafdf15d457d8ba",
       "urls": [
-        "bzzr://1e6dee9a77400ad71687d4df96f24cc0d79d67ab599b55ee93ffbd5c6dbcd945",
         "dweb:/ipfs/QmUx6ceTHCTH53owVGvGifk9LBwRvFFMAP633ETiQUfMZT"
       ]
     },
@@ -2212,7 +2041,6 @@
       "keccak256": "0x1c8a65610383be20c4988052d87bdacc434ec2f668a9689b2cc1462721703f60",
       "sha256": "0x93a83c643ad939637d16371f78f38e9c004554b9271b5311dce4c16f862f063c",
       "urls": [
-        "bzzr://fcf470331352ee04c9f6da950a3e3871db0b9635423029482fb2a336c5b3dbab",
         "dweb:/ipfs/QmT4jVAs1pnSQn4M4rucD2NoUdiMV9UwyC9MetSyeihsWf"
       ]
     },
@@ -2225,7 +2053,6 @@
       "keccak256": "0xd04b5d44a54f3185d92b39f59dd91d9e30c1795dfe12d88f4779629879ea4598",
       "sha256": "0xd3139c6789e7e51468fcff069fa2a932a32f5962d3f222ac90d52915513316f6",
       "urls": [
-        "bzzr://cad1705a03ca0e1aaabdf4c39e7bfc75a547ec58ec254f058544dd84e0d34375",
         "dweb:/ipfs/QmY7EbacMwd9DoTXPbNyDP9BaRvq4J5VKjDei4BRULNJBE"
       ]
     },
@@ -2238,7 +2065,6 @@
       "keccak256": "0x713d278bba46ba18cd5c4ac0c06d32410e67a50ade80faea0bf8e60142a13af9",
       "sha256": "0x8ed67232ea009840b86623086b3ba22fa2c9e5fff688ed0d4c2821d894ee8fc6",
       "urls": [
-        "bzzr://a3b10405d71a673fd7780772b2d592f067e2775c8b34c794b0c8797f62142414",
         "dweb:/ipfs/QmP3CcGzfunfMeqKvbhir9poMwgk5YN1JZ5XUow9XQ2rb5"
       ]
     },
@@ -2251,7 +2077,6 @@
       "keccak256": "0xb8d7216408ff21e5798c2c07bfa302a94b4d4d22f87034aec56ac81508c1d26a",
       "sha256": "0xdf84cea25611efc1652d57d8928409f28283f4734e52d9736e9e25998a2a95f4",
       "urls": [
-        "bzzr://f197c9c853eb9a4c644ecb8f2a804e4a35dc874f63c4d852dcaf59499349b79c",
         "dweb:/ipfs/QmY1wdZmpkGxXGuAoTaKaxiaPTnxCBhXu5uDMLejo2dvUD"
       ]
     },
@@ -2264,7 +2089,6 @@
       "keccak256": "0x90fc3fea19c9e94b0e32e2bf1b8594b2b444486df614935ed0b258f8a96cda48",
       "sha256": "0xc9b121a8cc25021811079bf2cba6b26dc610c280fb58956c0c0fb8cf1b54e1cd",
       "urls": [
-        "bzzr://1eb6520a43bbc06a9dc4410d628f3c0265e82c7f8eb70736f803d642f783859a",
         "dweb:/ipfs/QmSSCdNLVeUXjoLny2KE2m41MSVKSn34bw1NvZXo9nKb7T"
       ]
     },
@@ -2277,7 +2101,6 @@
       "keccak256": "0xe3d22a5ef8a06a060431ca47551878d535cad8f6942e67e720551e3759ce77fe",
       "sha256": "0xd7f3db1ef548ddf57e90c7053fbf134fc7d886840e9103b839c6f60cdf5baf1a",
       "urls": [
-        "bzzr://a38767a3d94669e2d598cc53c11eebc68086a249c81098ed941095368bca1b6a",
         "dweb:/ipfs/Qmc9BopqXx77baEsRfkxfavph8xpSQqQ3QXFzMsWP4cUZF"
       ]
     },
@@ -2289,7 +2112,6 @@
       "keccak256": "0x5ed0545ab2103074ae6feb777ba73fec90516676acfb53d7669708a751016124",
       "sha256": "0x5b30f5eab232f6ee5e384048688bfd9dfe1d6dd6dcda137aff72bda3a84cf1d2",
       "urls": [
-        "bzzr://17e2104b517fca722b4a78190a777d7781e0fa5f1ceaaf034e4c8d62503ee54e",
         "dweb:/ipfs/QmSzBi29JryZmeGKEDqRkxMLknbcnGGGEDqwAggPN4xwky"
       ]
     },
@@ -2302,7 +2124,6 @@
       "keccak256": "0x92cf26bb66862f3039f57a1444bc7e2f2e888c8ee46b5568ec390cb2746061ec",
       "sha256": "0xab73111716382d21a7a07a8dfedfd970c9aa885a4329e4d52a03508da714dae8",
       "urls": [
-        "bzzr://19c27e7a1a27ad4e3fb5bd6b6511c2dc4dbdba9b01326cb02577c9ab25be352c",
         "dweb:/ipfs/QmVAf9UoCbqtp86hvj3Ze9r7kCTZw3wCzP25gqJG7Y2LKZ"
       ]
     },
@@ -2315,7 +2136,6 @@
       "keccak256": "0xe57e5020061d293b7a819319d504f1de74bda1cdba0b7c2a970f8b7d22f6958b",
       "sha256": "0x4c0181df3cdb16f2a9d8c04109372fb8695de0c3b282bc80f58936bfceff7dad",
       "urls": [
-        "bzzr://ec616fbc8be2e8cb41dd6af0a8649c2e4bbd30f6b41fd3904c68d00cff55c5e9",
         "dweb:/ipfs/QmacKkxKXpgNEbu3EYo5qre36vk5PxJcgfrz2gn7XEe4Xd"
       ]
     },
@@ -2328,7 +2148,6 @@
       "keccak256": "0x5538ce3e3c4554786876e18523cfeb4f43db8def5d95a7bb5decb57035464fb8",
       "sha256": "0x9d8ee3fef896c7dda9db683a0063d952b63bc7a6cb4e02e36ce077c50ab71121",
       "urls": [
-        "bzzr://cbdead95bc26164a1fa9e26d72ff63699adc89a89a6420b1062d7d70bab68b1c",
         "dweb:/ipfs/QmcuyK6SxZoCRgXyc4XDbdfs9tjX1KwfQS52KvsGkorZsR"
       ]
     },
@@ -2341,7 +2160,6 @@
       "keccak256": "0x4ae7420ac2cf766172048ef225d1b5dcbd4474384f6dc7b5c54572ebb2a24b47",
       "sha256": "0xe463abcb9a5549e4aea4ecb8920514744fcbed9e34419bb40cf34d8ee4ff5061",
       "urls": [
-        "bzzr://cf308fcd4a8c6bfb3145bb1c0e698822a9dc45cbb9d81c872b167082a8893711",
         "dweb:/ipfs/QmRpwk96ofehnMLAqqdCbtTBKnsNf8ysLihJKnT1Fcc2QZ"
       ]
     },
@@ -2354,7 +2172,6 @@
       "keccak256": "0x284e8c407035673684a1d0797e0e82f00437008b55f38412564f378b3459825a",
       "sha256": "0x414db3fb1e2567da8c77f32e72c24fe520306522e7e9c2ef1e60d8e6e1c00a01",
       "urls": [
-        "bzzr://98c809f31f6d2e473940151532037dfddcbab6bbcf1bbe0b2401447dd5860782",
         "dweb:/ipfs/QmeGbbFR81XBcoM4zgQ7jj3RRPQyDEp4krtSVCerwjaExj"
       ]
     },
@@ -2366,7 +2183,6 @@
       "keccak256": "0x2de6e0cfb7526987aa4e5fd3504fc2e0ebe5e3630a3cdaaed5efd8b90aa58a3b",
       "sha256": "0x3ae6316fa03d576f4acd3c003b09d2e1b144c1f46d2c999add1047b8fa027c0f",
       "urls": [
-        "bzzr://573f6193469b559a4ad55e698473b8a296c70646f09472a78dbef05da6b7078d",
         "dweb:/ipfs/QmQSqen2kZKrPsgpMqv91pmbi5NycF3yq1h82F1T6W3E3o"
       ]
     },
@@ -2379,7 +2195,6 @@
       "keccak256": "0x2423a1226d374e618c04c6e33b583e0b87aabb28d17c4ce7b2be467cd30c8cbc",
       "sha256": "0x6d5ca7c1cb9a722ff3ff6162d603a79cecab71873819ff41d44c3b7ebb6a0e0d",
       "urls": [
-        "bzzr://899f75c1859e7e19aa1ceb3ad67d5b46921d082edf35c12767d6744cb0330d5b",
         "dweb:/ipfs/QmQu3Zwc7a54RUWj9tUyYh61WVjPM2FBm3umW2UQrZp9NC"
       ]
     },
@@ -2392,7 +2207,6 @@
       "keccak256": "0xdb5dba7f6c1ddac755434c4b195e43b30937d6c5611170344e8cd94a7d69aff6",
       "sha256": "0x3ef41fa78c78b35d7f9d18437818b714b002f8fdebc5fd1580a498f05724fb75",
       "urls": [
-        "bzzr://9793907564758c64acdec8860a4d2869da8ea40d7f60e176c4b6aad26ca455dd",
         "dweb:/ipfs/QmVzwDccZVjqzvPA3zpwY8uJVAetFsgSUZaGovJXpAes7k"
       ]
     },
@@ -2405,7 +2219,6 @@
       "keccak256": "0xdb3002db667bdf27d95db1ad8828410be8b69785c21b6563a85b736cef94211f",
       "sha256": "0x11c904f1d8eeec03d288ef6087a9db41d9ad1282f1b163db2394564f08bbada0",
       "urls": [
-        "bzzr://b64c0f2c990936ecf68d4958d4a97582550e516da5d40bfa36696f0d08d764f3",
         "dweb:/ipfs/Qmd3AhpwWRdq7HoZZaRJBgL34MJgA2AJ6Nf2XduQRHi617"
       ]
     },
@@ -2418,7 +2231,6 @@
       "keccak256": "0xfd0ce780668df32582b318a5c46d06f12497e89e4e69b9035731c3c6883646e2",
       "sha256": "0x4859accb0926106870d0f9f7287e3dda000a34bd094e534f588ff4c127e952cd",
       "urls": [
-        "bzzr://9d53508b2a1ca17abb71228a29bb18ee8eedca03a23d6ea24de6f99c02a082cc",
         "dweb:/ipfs/QmYgScn8vkSAyfmKvsVry73CRC2G85ubSUtzEUKwhV5rtz"
       ]
     },
@@ -2431,7 +2243,6 @@
       "keccak256": "0x4232a539a9eb54b28d3c57f93a9f9dd44670a793dee694e892172cd71ea6fd77",
       "sha256": "0x6c31b4ceb3cca126e94b6728bc8fda47ae85e411e93391c8225779c9b2056a84",
       "urls": [
-        "bzzr://02159abf02b3c76446924f6c8e95478557a067b6834ef2bc6f535d5a5ce33da8",
         "dweb:/ipfs/QmPXuJVvPt1dMXqqzEoETVA5t7PrnKyfQDnRnLfRcz9wYR"
       ]
     },
@@ -2444,7 +2255,6 @@
       "keccak256": "0xa46a2921139e001ec0df633e64ba1a039389d4e8ce3d7f183a458fd94c542daf",
       "sha256": "0xff69ea10e1e89d9c5af9b2ef2457778490bf2cca740aa73ef54aabe353ee92ab",
       "urls": [
-        "bzzr://e8cadfdff11214335434ca4bd5cd4739c488f4279db7cca60d1dede809acf453",
         "dweb:/ipfs/QmTFCFU7eathTcRWhPVFGDXY7PbQCeLEzy81EVbGAirDTE"
       ]
     },
@@ -2457,7 +2267,6 @@
       "keccak256": "0x90059a436e3df87c05ae44186cfced57bafa80fd8dbf38bce45aae9c25364e4a",
       "sha256": "0xcd7eeae8d4d3b48ad817c5b28350aeecd90b4a7db73e83d2e0baa63a0bd6ddb9",
       "urls": [
-        "bzzr://756cd0b01c327a0ac1994fa5531410bf44ad9657ef3ecb32a9f98f3120c1d9a6",
         "dweb:/ipfs/QmZq7s3LmUuKGmHj5jwKy8htbyVfVVhU5NKQ8rvnS2kdA7"
       ]
     },
@@ -2470,7 +2279,6 @@
       "keccak256": "0x3b9dce7d637c08a5143d178cdfb7511d007a6eb9f2a5693e356275bc3ddc7006",
       "sha256": "0x91f81c195ec7a931af75e0fa784a270d58baead29e8b8b59a4693301357fc453",
       "urls": [
-        "bzzr://b4690fbd4964ac3691c5eecfc6e62826b624628782e5ee6622977e3b52e244cf",
         "dweb:/ipfs/QmUue6uJpcfUxSkwE7qUWriL1SJfU81gSbnhjUaT28aNQm"
       ]
     },
@@ -2483,7 +2291,6 @@
       "keccak256": "0xf2e80c6aaf79da381797b87fe5478ace1f7874f8f405f08c5e89563eba206982",
       "sha256": "0x8bd877a91adaa8f9aeb539ebff80958fa3fedfff7b4a5ec92f385bf3ec95f2f7",
       "urls": [
-        "bzzr://6e6d4c1e88a43db174803a8846e7ec58bcf6c09a95f6df15a6a28334ef7d882d",
         "dweb:/ipfs/QmSTSV64vRx5d77e6SSeC7xDaUBtAEkhnif5WFtBDEkPBy"
       ]
     },
@@ -2496,7 +2303,6 @@
       "keccak256": "0xfb6fc96c6fa9deb50297a5d560594dda35ecd1f21a2ecd2f9dd71df18cb6490c",
       "sha256": "0x2a7a085babdf17faed1fa0ac378670e595f6b8c354aba4fe242121c694486c56",
       "urls": [
-        "bzzr://9336eaeb490fbcf613463575ba7034265746f2b14f4991038880f49136eaac55",
         "dweb:/ipfs/Qme4fA4VrkhNDszZntRRkkAqEAirV2JXgbvDZ8MxGnWHxU"
       ]
     },
@@ -2509,7 +2315,6 @@
       "keccak256": "0x139d7b90d61f5818a84bb1222236049ead456ec550d653f6902c0f2bc6bd5760",
       "sha256": "0x73981bcc91c595a3db2b48d7985b53b9addbe947281d0d7e2c714ce2a9b406a6",
       "urls": [
-        "bzzr://5fe7661ae0d7618371c63cca226286858bb3f997bb8153cb1fdc6782e13980c1",
         "dweb:/ipfs/QmXwo9TidxVSrRqt2on7MgfTNboKYwqpyNMPiyLVqfFPKj"
       ]
     },
@@ -2522,7 +2327,6 @@
       "keccak256": "0xcfa8e0e6173d38f141284eaaee0b6033975a19d1aed9fe908ac732d1084a8853",
       "sha256": "0xaf00eec04de425497ed1dc1b3bc3a917367d5b2c3fad2c72e005ec6b923967cb",
       "urls": [
-        "bzzr://515f5712807dddb5cf19f4d16bafabe07212e412bd649fc7c7589ae33b8c24f7",
         "dweb:/ipfs/QmbpXZ5MKBYQV2bJDD3AXB4SccjcLG2k9zc7VXfJvaZDbQ"
       ]
     },
@@ -2534,7 +2338,6 @@
       "keccak256": "0x7b418a09602d0b4c5dcd23998d3843934f8fff43337a1f3bdf324fd402294aaa",
       "sha256": "0x1425a06e0195580f7a8a0db7015f8e8b4402decea45bfbb19d5841b24e7ebf0f",
       "urls": [
-        "bzzr://de94c41f727124a5b02bd1db087e6bcba19a682c5d89bf3cdaa650e9fdd08403",
         "dweb:/ipfs/QmeLWKuwusKjbTNChaV6EjEwkPgDwg9bT7WUdAEi7TEnSJ"
       ]
     },
@@ -2547,7 +2350,6 @@
       "keccak256": "0xc3a54c91d98ae526a29f2a953c430311d2b6d5989c7d077065c7a94be2e6fc70",
       "sha256": "0x78494109146f3ef771eca0d8155c9c7a5b995bf7e17c1614ce6aa07dcea986b2",
       "urls": [
-        "bzzr://f94c5d0ed6b049b0726107df5264c2b1d2fa9cd4fb263de2bcbd134afde20c43",
         "dweb:/ipfs/QmeFcMAAFB2no1qwczdj5qDEGaWY1jzH3irZ7GK9pUnqpD"
       ]
     },
@@ -2560,7 +2362,6 @@
       "keccak256": "0xa0b2fdeec331d0779fc8a1f39cf11c847b17e0b4717e70c35a0f57ee7feef448",
       "sha256": "0x0f6ad73487d33eb19dd0f00a3b167410feb51e5b501dbcf9b3aaf85ed5160c5f",
       "urls": [
-        "bzzr://8a2ce829a9a8591c82eb5a6a33a98e9bd7db5c244fbe9faa81b75e580d2de601",
         "dweb:/ipfs/Qmf9ApvgoUu3Tdmb1sXqerdkUYpEnna7fT5fTsnr3XEoSk"
       ]
     },
@@ -2572,7 +2373,6 @@
       "keccak256": "0x25d22483d6a6ba6fd44e5537f796f8bf2964bed34a8dfbe24080fb3b901fc707",
       "sha256": "0xeef2854dffd1b108b68c3d6b3b9aeac642fa34ed6538401840f1b8c0a1fa4f6e",
       "urls": [
-        "bzzr://b873fa122233c91b1531527c390f6ca49df4d2a2c5f75706f4b612a0c813cb6a",
         "dweb:/ipfs/QmeMDLUZSeLwQQZ5JVMWenHWZSL6zdcXh9tdBspQp17pWb"
       ]
     },
@@ -2585,7 +2385,6 @@
       "keccak256": "0xff82281b250c640deda648aed3d048bb1cf460400709b5d27b7826b62d756742",
       "sha256": "0xa5fb2d25f65f5a353d71902f4843d5c05dce3d2974d1f608f8a896f7720a76e2",
       "urls": [
-        "bzzr://579bba41d4f1e6a31ec57340f06ed8bed22a53c406122bc02adf250bb5aa4449",
         "dweb:/ipfs/Qmc4UjDUKViV5gS9SZQXSugwfmdNQQgJeP1ywBK65xnyWo"
       ]
     },
@@ -2598,7 +2397,6 @@
       "keccak256": "0x200bd5377e860af5e6bdd82b594cf2aec918a8e3e5268b4830b8f06d83ad7587",
       "sha256": "0x37c7c8ebf3261a589f31500ec81ff94d19fc83d5e3a343e0e18777c99fe99513",
       "urls": [
-        "bzzr://8c0056a4656bed7c098f0f6d8332e2ad0f23d382c3e0c24f4d0ab3ea965a562a",
         "dweb:/ipfs/QmQbEh2iTXhEZw7caHbYLru4iseUQu27coPnFtZfHnRURz"
       ]
     },
@@ -2611,7 +2409,6 @@
       "keccak256": "0x6cefdf3e17e449776fc2cf23e140d2194852f490aa60e77c5b92c00b936a45fa",
       "sha256": "0x7abe88dd36fbe1b2aa385fe05185ad85d0bc4ef8b670818b68929bc94e3afcde",
       "urls": [
-        "bzzr://d757c52f140e51293c784df770cee397ba546aa8248b482caa07aa92c730d0e1",
         "dweb:/ipfs/QmQtPWXaNFLPeu8yvE86qTK5nUnhdHhS131iThQyx2TLLq"
       ]
     },
@@ -2624,7 +2421,6 @@
       "keccak256": "0x03284b61e326cda47323276fe603978aece296f81abf029e2c3432dc93585c62",
       "sha256": "0xccd9ba67a7023a253b6beb8bad27d334ade249199227dfc080d607def5d935b1",
       "urls": [
-        "bzzr://982113587c50cadc225b9ffbe29fc6fe018a3505ef61181c48a9b7dbe9ffc23a",
         "dweb:/ipfs/QmVFxgTZwBaPegWFi8Qy2e1NuRdMGJd6zZGWiYbeZBveBn"
       ]
     },
@@ -2637,7 +2433,6 @@
       "keccak256": "0x725b61792ed70f699beacc6ff2b038e9a79bcd1cb2cda19a2677b08bb86f76a5",
       "sha256": "0xb8ef1ad0a711b51a1beb72358e9cf84a07d657d7ab7dae8180115db10ff485f3",
       "urls": [
-        "bzzr://f6aab62ce385c682be651288b0b44bcb833053ad84becb11a5eb1b7dd2643f07",
         "dweb:/ipfs/QmdkjfUWh9HN59hRg7CigmVFWFpVFUBe2D4bwxhMcvfY6b"
       ]
     },
@@ -2650,7 +2445,6 @@
       "keccak256": "0x8bdb1847999584e2a30803b115a96f8af42bbd81b36908b684dbb5656238d5a3",
       "sha256": "0x3a3a308d73ab9939c3c41c55853ac25fa1720df00e5db315f4ee291c4b26e324",
       "urls": [
-        "bzzr://ca3c1478c981ec0780d4857ff982e8191726a2b552d18fe8133aa7afed2c9131",
         "dweb:/ipfs/QmceKA7CNJpVRawABYmxWEsP2KrBYZvZku8ENagFE9tgyk"
       ]
     },
@@ -2663,7 +2457,6 @@
       "keccak256": "0x3caa41a586e169ef66c4a8b6da45399aebe1226eec405469e67f999b36d26b6f",
       "sha256": "0x45e830cd64f68eaeeb5d0838a418efe30ebd424483d4eb3ab3a4ca737f931248",
       "urls": [
-        "bzzr://2519e98a22016dcf9f62201d7babf66ecd617223e95d5f8880b5bed9dc0c1e55",
         "dweb:/ipfs/QmarVNwzNQ3rUyPY47N6k41H42FbndsKM2ZAEADVJxg3hs"
       ]
     },
@@ -2676,7 +2469,6 @@
       "keccak256": "0x020db6709338faa3527e710ac899e328b17ffea1f35e5b9fc7930deaa3751f9f",
       "sha256": "0x5244059fd3e944258e33828055ef67ba97e1e2eb1c9cfa295709a18c27883404",
       "urls": [
-        "bzzr://e447d748326919bf72ac77696963769e92cd4b8d4a7effc7d0ec338346c8977f",
         "dweb:/ipfs/QmS6ccuzTtp8T21G7dr1qjyFkSFUdQ5LDfBejThhYhhPit"
       ]
     },
@@ -2689,7 +2481,6 @@
       "keccak256": "0x6b484be56879e19b51e2fc18b9cfa2552440bc8704a909f3cc85b7b362a628c5",
       "sha256": "0xfd511d46320441475af35fdfb8c32d420f1222504e550f0c888ae184a59393ee",
       "urls": [
-        "bzzr://3a1cd047780951298f51b546bd6881af84c63078e919dfa955f1e33b56e19b93",
         "dweb:/ipfs/QmRonMUVP2FLHMPNVexErDdrjCAjaUwsHrAqh83mXk4hzm"
       ]
     },
@@ -2702,7 +2493,6 @@
       "keccak256": "0x845861bd02e0417f12594920f8c3f6cade3a3185b0f39b9ace392b49b9241d6e",
       "sha256": "0x3e32d6139171bc324437d92b3bd71ffcfa6b0dd60f10ccd96420d5d2250411ff",
       "urls": [
-        "bzzr://c75b43937f012d8b9358c3464efe6ebeaeaaf702b0f6930918db80e9b0054d55",
         "dweb:/ipfs/QmXEUDXKpM4Ff1boGWinkqoa8tzxbYgKRgA3AxdJm3GThz"
       ]
     },
@@ -2715,7 +2505,6 @@
       "keccak256": "0x860d58660ad5ed99df5793bdf5cf77d803a2739687116dd91e6101926d8c310b",
       "sha256": "0x8556387a0968967cddb9a48e3e28b26f7716fb5e29e7bf02945a3d30e2977067",
       "urls": [
-        "bzzr://aba0e4b39623c0c9f7120108218662018de55aa4638a73297fb71ce806b25fab",
         "dweb:/ipfs/QmaFspym4mLJFW1mm7v3mPGbAiD8eejZdCoWuwDHNv1B8G"
       ]
     },
@@ -2728,7 +2517,6 @@
       "keccak256": "0x1eab4ffbce75d8e9e820ee979bb24bbbc4b231ef0de3f9e9728652d2f5207733",
       "sha256": "0x428ed385f4224bd2c4bbf1c3566aaa8afd99eb31acab814faa5f28e0a686415e",
       "urls": [
-        "bzzr://a2baa986af8747c5cf116bd071320af4838dcd8acfc8ddc48e1c35e62da18a4c",
         "dweb:/ipfs/QmSXwkmaZAU23UrjfaVVcEXv2CiZsQEi47nEQBiMJxqwGJ"
       ]
     },
@@ -2741,7 +2529,6 @@
       "keccak256": "0x2b346c8ff24b4c488d058136b20f0572e95d7ffe6ef068cd5b46b86064af57bc",
       "sha256": "0x8ba7542dced7b344750a30072d21d1114863e6c63ab05143c27379d38dc3d6f4",
       "urls": [
-        "bzzr://c3fe972355a50c6101bf03513475bb13a4c684682e9094461e481193acb16785",
         "dweb:/ipfs/QmSiA4LgGfzSBADDhXxPjqgNsBA2KZcedRiLVuLNKfuVqL"
       ]
     },
@@ -2754,7 +2541,6 @@
       "keccak256": "0x052cc7035608fc928d14000858f381b5f6b96cc9b7e417607275a493d0cb09a2",
       "sha256": "0x1041aa69c07755b626126e848eb0536aa5feb9a174167c8657b101a10c4bbd62",
       "urls": [
-        "bzzr://f7c037b1a9a3ee15a92800e6179c0e2ede1dca1f1adc5288fa8b29dd6f35a98f",
         "dweb:/ipfs/QmQqwiUsB7hza5i2CKzGDyga3dsw86ErNDpvu82pTe9vwB"
       ]
     },
@@ -2767,7 +2553,6 @@
       "keccak256": "0xb02ed90711e25413f1719f0cab667503fa9cc4e06872e4e7504d7f631da98236",
       "sha256": "0x77a84196214b888685b7880f3762cb59ae2dcc228fa88afad1dd9a7b7fb9579f",
       "urls": [
-        "bzzr://38071b5fe24efeadb0b85ae771732702fcce696eb73f2ada8a08f6db431b73f1",
         "dweb:/ipfs/QmfPApHFV4E1pWzUekQRYAq5xJzJxWmzspoqMZkB2hFQmx"
       ]
     },
@@ -2780,7 +2565,6 @@
       "keccak256": "0x43c92a71444f505375f18c015e5e910c288be15fd6bbb56ccda50767c43bedbb",
       "sha256": "0xa2fb38a16b708dabb4bca90ac2c877b4f9676149d407ccde3f4acbaec137a8b8",
       "urls": [
-        "bzzr://ad8781b35f01723b7e86f298b74d3ad5d3951a94a0484c79894130a461a1431f",
         "dweb:/ipfs/QmeXsQmzfdSjJQEs55T4saApVP24cBtQZemESsXiZn9V2c"
       ]
     },
@@ -2793,7 +2577,6 @@
       "keccak256": "0x245c638164782e0ae7fabfb79ab2a8d150716db65ec22802ca9c5431ac3584f9",
       "sha256": "0x2555175367408d3fa1a0ef7e59394d28554f66f9503dbfa19c786c383523ac06",
       "urls": [
-        "bzzr://8d10463500d4490d9753c141518f4421ee20d7393933ed024babbf848d4b1a3c",
         "dweb:/ipfs/QmVUCsAyL1vAHqoqG63FKoQifwuuKB9oDpsc4YhZmXw9uN"
       ]
     },
@@ -2806,7 +2589,6 @@
       "keccak256": "0xdd349480278c9499627fcfd965877a807b991ddda7c34ab953d598939e0f39d5",
       "sha256": "0x373aeb21ecb1539cf1819b9f02214d41ee865e6d8c0654244ea8388bc27a8fbe",
       "urls": [
-        "bzzr://2f9886a8dbc3fa5a6a5028e337cca5ab20054c1e4f0b30688e7be661a0bf4e05",
         "dweb:/ipfs/QmQfzE85ghyqxJhq1r3ywNipqAZR5fGxQVzW4G93PpXon8"
       ]
     },
@@ -2819,7 +2601,6 @@
       "keccak256": "0x08445822306cc488ebfa2db7903e4a0ca9806cca1c100bbd742903fd71bb7a49",
       "sha256": "0x66b645f398eee2b7787a7cdbb4791c8e02b35b1f725e84cc4747d28b35cecf3a",
       "urls": [
-        "bzzr://cce0fb3275ffffe8d8cdc0a28b4fbbe13d09079c5e606b06eb009fe212a33d91",
         "dweb:/ipfs/QmWQfEENp4rwXRsawm9VjoJ8vSXDA4e5EZUFyG35Y53FRG"
       ]
     },
@@ -2832,7 +2613,6 @@
       "keccak256": "0x015ace6c9dc677df55e4971763d9f41fc2d82c9bc04db555603241248994062a",
       "sha256": "0x3813adedcf8e19452e492429131371e3d092a4aca1982e70d93728ed650e6668",
       "urls": [
-        "bzzr://109cd399615be3853d54a0f67a540eab75683ac76b7ceeea9eeee69bcb935b4c",
         "dweb:/ipfs/QmSf7sdKhPj64J4DFym2ZnRf3NkayBAY8ne51J1rTk6YM9"
       ]
     },
@@ -2844,7 +2624,6 @@
       "keccak256": "0x30094baecaf6c36245ac8d56b2972915c1054827fe5b0dc6d1245e9d2e19e357",
       "sha256": "0x7272fe089382706a4c18addf63eb875bfb0767d9195d2538ac86b55f7b9a46aa",
       "urls": [
-        "bzzr://de00cf8d235867a00d831e0055b376420789977d276c02e6ff0d1d5b00f5d84d",
         "dweb:/ipfs/QmdmfBV5e4vcDZiAbpY8Mg5HQp6FVqt2szA2rqfa47EKf2"
       ]
     },
@@ -2857,7 +2636,6 @@
       "keccak256": "0x2cbde868d678337df44ac9ca3f3e0bbcc625b5636fbc449c485be6bac1824027",
       "sha256": "0xbb29565391111fd6d513d0383254bbf9e76cb96242857fd8e41a21719749066d",
       "urls": [
-        "bzzr://29af69fee84074a55cf229dfc5969f0c86ae78f4c2a3d0fd3c5ebb82f8aa77fc",
         "dweb:/ipfs/QmWjYwGpMZgvzxp2kUZt9rSuCbXHk2zDzz2WXTWNn9qZh9"
       ]
     },
@@ -2870,7 +2648,6 @@
       "keccak256": "0xd9905b86536de99eb85d75e750f3087b1ab1c5e431caa8539e7956344b538a28",
       "sha256": "0x04fc66c2c39ff853b2526cfb83ed2df13ef9f5de1b3cc54fd040358e1841600e",
       "urls": [
-        "bzzr://02a40667b66b38528ea30897637b054b037a3d26ec173ff1c526c05315279a16",
         "dweb:/ipfs/QmcndJasNEijVXZQJfhmaFhnn2sSLVHmFYdYC4RVpmjEtQ"
       ]
     },
@@ -2883,7 +2660,6 @@
       "keccak256": "0x62b3eadee7745d6a744deda7991f4530b095bf7acfdbf0c1fdfda1b29a74cdd3",
       "sha256": "0xcbf6ee3823581ac758a63f08f1a3a16c46655669a0c762d7e88e9324762e952f",
       "urls": [
-        "bzzr://efc91e567f86f36d610d5babe0a4a76cf31782dca56b4ec78b837173973c19f5",
         "dweb:/ipfs/QmQNRUT5UFVz4wT3A3cL5197S3Fmf8iQVMkCBVobbvLQeA"
       ]
     },
@@ -2896,7 +2672,6 @@
       "keccak256": "0x81ce6e85324e03362cd89399dec1bd62858d933d62bd9646384e2ba42918ab56",
       "sha256": "0xad48058e6545936ccba17c454fca326a8ea3525af7bcd98c0476e982ac8c2959",
       "urls": [
-        "bzzr://847dcd34c6c33b60890f427ce7efe34f3b5fdcd4e3c0efdc810ee870e4eb389d",
         "dweb:/ipfs/QmPtMV4GtgnXyaQRcoU1TDz5DNiXLy1vWZxs1b29E4MhKN"
       ]
     },
@@ -2909,7 +2684,6 @@
       "keccak256": "0x66f15ceb6c4eccf0422b3a6b76bdee1bc499c01df61f2d1938f326d283688a50",
       "sha256": "0xe3d62ca3e2bea45c3a4683e2dd846a0bcbdbf25d28b9386bf9c255b970fef19f",
       "urls": [
-        "bzzr://bdf0e335cd28ad0ba20994a8adf9a2d4a1fec02910ab9655d98246ea4fe6c511",
         "dweb:/ipfs/QmQKNvMHjzwEeNcsy4arqRk4zcYt2XUwBfYF87gXboqz1U"
       ]
     },
@@ -2922,7 +2696,6 @@
       "keccak256": "0xb719a031166d6ef81caf1c7889959c39f291791bc8a2dca2f903479478c4579b",
       "sha256": "0x769e1a4c30613350be5a498465a9fc57d5b3c6ebafe814efc84cab2c0cf2691d",
       "urls": [
-        "bzzr://45f178ae7aa8ea036a4d5a4fed818add4bb38eca8587aff919ae40139967a6f5",
         "dweb:/ipfs/QmdvxBwoyCJG7d6Kz8udkK6xAsTZ7pLc5A7jhaRrBb2d19"
       ]
     },
@@ -2935,7 +2708,6 @@
       "keccak256": "0x4198b085df22d88b2fff91c047cc6a7a7f1e1be9e8888c4a47137eeb3031eeaf",
       "sha256": "0x277257e8b37232adc98c3519a048b78a93e2a348804000ad5b1a0d3f5bb10e24",
       "urls": [
-        "bzzr://081ffdd64349f49a044a737dabd3dfbb9147a5afaedbd9cd514049f4eddf4a5f",
         "dweb:/ipfs/QmQ4Q3kvVA7c8MrqGUafXPE7YtXgbLZXkCWXZNy4dFU8Vg"
       ]
     },
@@ -2948,7 +2720,6 @@
       "keccak256": "0x3b0162ed6a0928a883256ef68ab869350840368f77f05737c6a789c73e3b68f7",
       "sha256": "0x380f8d3a8524cb5e345dc38ab8cb5eee0d749f810c234944b1b91c1468d287c0",
       "urls": [
-        "bzzr://9efece3937b3ddfdb28f01b7d446fe715a897d667495ee91e61a9da5abbc3371",
         "dweb:/ipfs/QmZ9r5KpEARKbC7mebQ1A7kwNaHk9LbbQTy7gP48pvPXYr"
       ]
     },
@@ -2961,7 +2732,6 @@
       "keccak256": "0xa64bf5156c06ba26c0c3cbb3eb6c395b272e77a2f4cf93ad5b603c2476670489",
       "sha256": "0xa837095ca346cea821b9b56b9a0418b53de446638d093cb83cce71ef5c336eed",
       "urls": [
-        "bzzr://a464cdb77d23d1d761a00a81f8a48c85424df1e8e349b9c87a0ba08ff8c11ca7",
         "dweb:/ipfs/QmZjEb5nsHEcr3FMY8R67mLM7omdWStqe5mfhu56zx8yHL"
       ]
     },
@@ -2974,7 +2744,6 @@
       "keccak256": "0x0cc481e898a63c59114481e1355469a696400c656a7512d9c359e31066da37ba",
       "sha256": "0xaf6aa971f754a5af0f5d1bca339cfe52258bf87373b7acaee3e815ddacd93633",
       "urls": [
-        "bzzr://4b21f82883390e6e4a0962bc1a1ea017698650155dee557c722a1fb7395064ed",
         "dweb:/ipfs/QmeiziCVHwECSjRVw4ZcQ5GhYpfQQnn98MTLrm9qeBUjNm"
       ]
     },
@@ -2986,7 +2755,6 @@
       "keccak256": "0x61faf6e732d89464f022a3146a1939f204472c0a243e86b08173e1ec41cb4a7f",
       "sha256": "0x34f26cddd538c7d66fcc1ddbeb53a432731b06e493a9899b87291a8d111caf83",
       "urls": [
-        "bzzr://17c083e0ec2a29ec7a5c33cbd40a773dce5448891f2eb22a75898c9da8dd03da",
         "dweb:/ipfs/QmUtPpVGL3ophmbm9f3Qgy9UaxkgZ9LSppmhwH1uEDxu8Y"
       ]
     },
@@ -2999,7 +2767,6 @@
       "keccak256": "0x52468bb04ac59b76008fc478e7a0140548ae8db4e3202537b9b65bcc851acb14",
       "sha256": "0x13cddc83ddc367b0546b7ade72f759ccb9ae6e9ec8cffc73c604f0757c667535",
       "urls": [
-        "bzzr://03fe83a75078ef227b25868f123c448a9944d7a937836b422717c15c868c052b",
         "dweb:/ipfs/QmWgGxfpe99VF5E65jVips1wHaT7uercANBpReAKpbhmgc"
       ]
     },
@@ -3012,7 +2779,6 @@
       "keccak256": "0x44894c0017201f7f98caf4b18282a7b56dc8373ba4ba184c9126ea3aedbddeba",
       "sha256": "0xa881c1aba1880cf37bde4f5267b83af43f6370d575a0883078361d3f8d8b989f",
       "urls": [
-        "bzzr://efa52f61a58b7800d3ae9b765866693a4b1b9a4ed9ac6df786d6b99804a8f27c",
         "dweb:/ipfs/QmP4MeoJHtRvAEtdmmNfP9P8EEyP3m2DBjLeng6vLM3FsL"
       ]
     },
@@ -3025,7 +2791,6 @@
       "keccak256": "0x8b836be8975cce726a3c03eb586c3bb30e5e76a81bb95659c595c07a1a5def1c",
       "sha256": "0x24e7328dd43d5457811f5a9dd965dd102f65065a3833f53327ab44af2c9cd3ae",
       "urls": [
-        "bzzr://342c69978f0946acde07e57be98f0739dcd6847f0a741ff460e948479bacafc5",
         "dweb:/ipfs/QmQ6YekhcHDf5i2uBoEwjZRQ2KCuPhtvMJKkWAagu3pZqb"
       ]
     },
@@ -3038,7 +2803,6 @@
       "keccak256": "0x3698650dd8a7cfe95f067f5049c888d6cf926562e04afc84aeaa5faba94749a6",
       "sha256": "0xb785452d98544bdc381f7f6cc161bf81eeda0d580feb563f5dd8093b163da64b",
       "urls": [
-        "bzzr://bb95908da92495bef375b30ceb75e5cdf99150af8f7eb32042cecf85127e6d15",
         "dweb:/ipfs/QmQ1MvcFZMMw7DEVCxUgfVBHqBmX7tDuF72XxrSjJDMBi8"
       ]
     },
@@ -3051,7 +2815,6 @@
       "keccak256": "0xf97854056bcdf43fbd5a34ff74f0c85390036607a9bd6ac4d5e7a7007a0839fa",
       "sha256": "0xc16276e518c285260db48d06020ecc2e55ea61010c7de93f9cab156941148efa",
       "urls": [
-        "bzzr://537cbdfd5076fd23966ab1f6eb0eaa9a3d128ea486f0836b8e95e2d88c0c24f7",
         "dweb:/ipfs/QmW2WHc1SnneYcwaZzN7C9vvcTm3kCctky3e1NCPLNpnuR"
       ]
     },
@@ -3064,7 +2827,6 @@
       "keccak256": "0x83199e85c4703e7e102058682d7f9af6d8312424bd0bc2f46eb7d24a22909816",
       "sha256": "0x3e0972fdc92dd19f482ec831a5d6f969652ff3789f984233d56e525e72d43267",
       "urls": [
-        "bzzr://ed9eb0cba1f7eaedd48793f53e22291f30d51347c4646764ea03852b7e794427",
         "dweb:/ipfs/QmYnEFA45NohQZVZZkwN9kBB2sdxTZ78ZFFfauqM14qA7S"
       ]
     },
@@ -3077,7 +2839,6 @@
       "keccak256": "0x17a810b10a472e673f89a7841756d383e84eaad27ed316ee16ea3c70a28b4b5f",
       "sha256": "0x5ad4d03c7aa91c12e999acf0c03dcf6b4a70adc6a92deeff3315c73e9bc1ecfc",
       "urls": [
-        "bzzr://805930376561ce5bd34e05107acb6f2c4f07afb438582905762d48f77dfdb0bc",
         "dweb:/ipfs/QmYcE6dHsjYzaGPTB2w2r4Abh5aXL28fhR1dkrzQmHMRj1"
       ]
     },
@@ -3090,7 +2851,6 @@
       "keccak256": "0xafd842946dd0b5a0fc61f1681ac00ea946cefc7be242599f0de2c98e0764b3d0",
       "sha256": "0x8d62bb2fb6785d9748e8cd60e0d4a8cd1af99592ce229d9a81d81d99c5341908",
       "urls": [
-        "bzzr://1a24446260d61ba55b7290f05eeee8d570209c5ae8fc45edeab24d7cb1a621a1",
         "dweb:/ipfs/QmbGe2LNi7Raj2HhE8iLEePbY1RhGgwQjYXg9wfcQhPcL9"
       ]
     },
@@ -3103,7 +2863,6 @@
       "keccak256": "0x0e9060a7909c31629512ef7e70c8cf71371213c47d4615aae4737f92666a63b1",
       "sha256": "0x2314eab7430cd02346fcc01947eca55c98582fc0098401bee4a1f04ab41c507b",
       "urls": [
-        "bzzr://1644992b48aa15e199a248db342aedece0d05373f549a087849c57c730bf2ec7",
         "dweb:/ipfs/QmZySqgTdimXfSWhpbAQB2ATuL9h934EcLewAy5aehGVhJ"
       ]
     },
@@ -3116,7 +2875,6 @@
       "keccak256": "0xb633fa3cad671a7418ee2678edb82bf4740fc0a1d8df4aa48680c4b356a195d4",
       "sha256": "0xf6393d4597de59e87fcf3776f1eba3520c0afdc22b41f97581ac08cd9e512406",
       "urls": [
-        "bzzr://d34012b13f76332152c77e30dedfbd8c4be070278f46b0ce2b1efbf5df4a2a59",
         "dweb:/ipfs/QmYF74Sg9Lq3ri8vG4YjnwCAp7FYEmwgMGLet1dCayMC57"
       ]
     },
@@ -3129,7 +2887,6 @@
       "keccak256": "0x8b649f10fcb5fee1437847d6c9836a11cc0a878786e15a6be5e5e7fe24a58564",
       "sha256": "0x9ff884ebb4ad9af8a58dc7a05d933748fe5599a80cf61fb128d39066a811c171",
       "urls": [
-        "bzzr://aa46bd87aa0be9b5756353312f8041d4525e70df56b9a57c937537dd2a067e43",
         "dweb:/ipfs/QmQgPyrpRAjJzLyGSU46fgLCExtrZi6DReY72j1ooNrMyr"
       ]
     },
@@ -3142,7 +2899,6 @@
       "keccak256": "0x6367e9e2e577cc3f285bad3dee463b43f4e87b986a6dd25ad4e846e0579e0f38",
       "sha256": "0xe8e297e2bc7e5cd6f9437db96483ed27812b79e915a1fe408a9746fa390ad428",
       "urls": [
-        "bzzr://953745901e7ed81fbde119ed4d841e1fed88d504bc272ed78cc90a02960b413c",
         "dweb:/ipfs/QmVxNcYRCSSLhVp2dLntL5BFw47Hu66QuV2JLtW1vyqHgE"
       ]
     },
@@ -3154,7 +2910,6 @@
       "keccak256": "0x2b3e45f09075c576d599cadb2e749105b425bb2c8ab30b48170f0e23adcab1aa",
       "sha256": "0x7e93fcc7202d25ef37409541e799c5785efaafc1046cb2b4764e4a706d5dcbd7",
       "urls": [
-        "bzzr://677fdc9a1709aa44b50bcdfc9610f2694ac92e4822e659db458afc1e77eb533e",
         "dweb:/ipfs/QmTGhdXqkvHG9xFtnfkDS6MMdhWtoVmYPeB6U1o1vE9Ly7"
       ]
     },
@@ -3167,7 +2922,6 @@
       "keccak256": "0x27853c1125649aece6a481276ae68a9dd9f0b58a6362559b29ebab8c9e13a3db",
       "sha256": "0x8ed400106456ef02329e59392e7a7044be05bc58928dc8d37f45b381d7e1db75",
       "urls": [
-        "bzzr://da68bcc3ea48579543c3cf86d94ef3e6819c710f4fa6b451154fae7cd89c2bd8",
         "dweb:/ipfs/QmUW1aaCE2LaQStuv43QNfzcUPsfsg149vT1ZFgcA3vPvy"
       ]
     },
@@ -3180,7 +2934,6 @@
       "keccak256": "0xadb0ec8752b92aefff5738271e65c8dfa786bab2865cba7b063fffea86a95a38",
       "sha256": "0x24d9e13cd8255d17d31091029ffe06193e3c4d9352f4ff7796ec16e7625f052c",
       "urls": [
-        "bzzr://562a94f287bd624d034332b5a73e16a60cbf6e1b57a949e98311b912f43f05ef",
         "dweb:/ipfs/QmR1SZ4rGXE6XJ3BCUPRYYws8EsDx1xRooUmqLvFj1au8Z"
       ]
     },
@@ -3193,7 +2946,6 @@
       "keccak256": "0xf4da1ed28bb20e825c0dec7c218cfd2eff1afda8236b2ce210f7ab2ca0090a7e",
       "sha256": "0x8908b9191faff7e0ae5960594957d487f3b94de3835541c50cac0a260bf54049",
       "urls": [
-        "bzzr://e070ee8cf21e72bf52a319da2301d2283a7b744c620a3bbd42267d317f879794",
         "dweb:/ipfs/QmQBEx2mJJaEXExFYhsBWdsBiMmXvTXUZ1L6GGa3uFKV1d"
       ]
     },
@@ -3206,7 +2958,6 @@
       "keccak256": "0x57d402a63f93b96e9ad82018f2b738338e6c0214d85d543fa4bc896fc584f614",
       "sha256": "0x2450e0d72f7dff47bfd971d7abc67a6bc744d2a2a7cd7ec6864395c9dc520652",
       "urls": [
-        "bzzr://da5ad071ac2f605b5d0340f70e741a167416eb47f7aee0cdb56fa8768b5b329f",
         "dweb:/ipfs/QmfXjfBp17zvEtSgrunMymhyg4zQFNDdgZpkLgDBt6dxVE"
       ]
     },
@@ -3219,7 +2970,6 @@
       "keccak256": "0xc3be8bee3c65b911bb16c7d06770cc0ba01fc282250cedfcb5b1035f09c391bc",
       "sha256": "0x46aaff2a2a5c801be4215469533b6336f3c37303a30c98e717dddfb0df45fc60",
       "urls": [
-        "bzzr://c2fffa2f7719b9fd0b695a38acab9696a9df6d372f16dcda17119e04466786d6",
         "dweb:/ipfs/QmQVRTHzBwS4upTzvNZLj2RHMXec2B86cc25icd2VYdsX4"
       ]
     },
@@ -3232,7 +2982,6 @@
       "keccak256": "0x89bbdd5b749926cdffa9d71864ed9a22d0f935ffe6abb74f6fec4aa0bf983537",
       "sha256": "0xd6542157ec1212bca3625cf934d7002b307bfc3d590ff5bac08d0a37cef533d1",
       "urls": [
-        "bzzr://2915e09f3d4e50c573b6232f1526748d15e6f09cad02d3547e912554d58d7dda",
         "dweb:/ipfs/Qmc81Wh9DnPvfTWHVuMQqC7Nu2FjGRNZWWdYyDRDyL3CBu"
       ]
     },
@@ -3245,7 +2994,6 @@
       "keccak256": "0xc7978b3242a2b8eec4c6f28538ead7c0cfd23d0c139cd30967972b2bf02f7205",
       "sha256": "0x9141904a13991db84359f9fd723e18a6dfc5632a0d255f8599276891e2d87ee6",
       "urls": [
-        "bzzr://f8b31a2adfcf5e39f8b54280af4589bae700139e4fc4f6fb73afe19035841b1f",
         "dweb:/ipfs/QmYYTaWSahx3yYfaf7tSG1phzHftkYPYN1HCQmBxBV1ACS"
       ]
     },
@@ -3258,7 +3006,6 @@
       "keccak256": "0x0ff6a045ec8e6529f92471086775247c7c84bf910f7b77b7c313a7b5a6e461a1",
       "sha256": "0xf23dc686b354f2c8a787bd7a9685505b34f085a4f16d064340fdc77781ffd5ef",
       "urls": [
-        "bzzr://c9afd22adfbd6c1e9a78583c823da532e3545a51326a71a4f8b4240d28fe6c85",
         "dweb:/ipfs/QmV2Ghk4UReQp2523QmmRUU4BxUgSgToSnKqDkFCuaK7vz"
       ]
     },
@@ -3271,7 +3018,6 @@
       "keccak256": "0xdf270603a00242ad205538924b0964f28cfc62b119103a3eb24638e9574a8258",
       "sha256": "0x320ddfbeba32e1d5c9f07285643d0e3bb0578b355c8d458f0ed5fa06e64a250b",
       "urls": [
-        "bzzr://462defe8f5eab87d42c318a489f226feeb258092bd0399e4e661103e219969ee",
         "dweb:/ipfs/QmPmAgjsQt3tQ9Ea76pXQvViUT4zR8zp5XKncX3NjaucM1"
       ]
     },
@@ -3284,7 +3030,6 @@
       "keccak256": "0xf7b827795fb265b98dd38f7e65438efb37504cc522217ab15debc7a28c5eb635",
       "sha256": "0x2ae76c08d5b7b6a8de1020914a780abbc23b7528d335ef03cfe64670de8488db",
       "urls": [
-        "bzzr://174816df4ad3e1a3903372c9a221ad3a0148895820331ecb6793b2bbecc67847",
         "dweb:/ipfs/QmdobACZxUzzD5nD3KG13M9di9pAEWvmXSp3jD47oqC2ao"
       ]
     },
@@ -3297,7 +3042,6 @@
       "keccak256": "0xc2f2394583ba68fc2d07c30c174c941633dfc21ff1b452230b7220f0a2090c9b",
       "sha256": "0xd980a92411bf996eb7c82549f3b27d9608fd851c2d62e243f34822ecd492f368",
       "urls": [
-        "bzzr://a9e93bd228ba609c3ea46ef3110bbf433113d72ef33087deb754838fe36f436a",
         "dweb:/ipfs/QmPgVVySemPVwtHSHN8CWCTPv69rxGzjs415cp62pX4hqe"
       ]
     },
@@ -3310,7 +3054,6 @@
       "keccak256": "0x9b83e905b4e8f95735bf01fbb576e8b76ae7444eea41267dbe199b20a93daf28",
       "sha256": "0x590ac0a91f4b72d7519c29d824c6a9f41a7b8f1c380bc1b9743a915f2accd9b7",
       "urls": [
-        "bzzr://c8f1ff36edd68cb73f3d58194808362b8a49b2db845f961cd76e6e884d0f79e8",
         "dweb:/ipfs/QmbssHnUN4tCndgqdUn89KQzGYAvG278kNHzqrmZF6wjWG"
       ]
     },
@@ -3323,7 +3066,6 @@
       "keccak256": "0x7da7be0cf1dd02c98cf439584289908b2f46caa2491f0ba15644873b14bcfd88",
       "sha256": "0xd53475b9c80f9d1e56c2330f508b377bc36535ea62729c7dbf55511140aef18b",
       "urls": [
-        "bzzr://261ee95541fe9d51f4e45856be9808a3dc5695085579aa062b9d478b34256827",
         "dweb:/ipfs/QmZP58ecCG4Z4PhKzdGCqhMnw7tr5hP7U276jjK3y94KfY"
       ]
     },
@@ -3336,7 +3078,6 @@
       "keccak256": "0x9282f19bb985c615761706f02a46724515e4794ee24e5e8a7b61603fdd9490f6",
       "sha256": "0xf6b596be83eb2c2a4aa91a7526c61a0f26260331b1d6050841e5393100334a53",
       "urls": [
-        "bzzr://a3e8c74973868470d25419007fffc454a5b7ea43b1e6a83de54540db56a6c695",
         "dweb:/ipfs/QmQqsU1cU9iDspKZehpdCrvvH7WAt9wHgonjFaTc7iKi36"
       ]
     },
@@ -3349,7 +3090,6 @@
       "keccak256": "0x8ddd0f9a359816695d5450fb71305e8e8d09f2cb467e6ccb7a9363804cac2409",
       "sha256": "0x19feced2553f2e5190030d6e93af47c7f5636340a2f688b3d9ef5b6d43c5fa77",
       "urls": [
-        "bzzr://2bd4cefbdbbd57f9ae25534c657aad9f50fdffc13f2ade77dd37da135e4b8181",
         "dweb:/ipfs/QmQwadH4cQXYFskSdQDJhCNueieXB54XHsxciK2NTsBPWp"
       ]
     },
@@ -3362,7 +3102,6 @@
       "keccak256": "0x053ba18197a15de856cf34002c58571614cc37f66201966c492277b70ffc9de4",
       "sha256": "0xe6c9cdb2a8f43bb2ed5eeefa101f661d6a3fc762952889cf095ef4288c0ab6c0",
       "urls": [
-        "bzzr://31e9341bf7dcaaade502e746018c575ca68304bf0fd1c0824c79b6a7b8284cd8",
         "dweb:/ipfs/QmQDqLdKxSJKpDLLhETppECmx3ohkFTR6FXkgjJsaQTe2w"
       ]
     },
@@ -3375,7 +3114,6 @@
       "keccak256": "0xb3f071286c58e6e9ba99bbade626d7fda039ae7e6c0458d776f7f30b8690e2d3",
       "sha256": "0x77a62d29b4c62ec7b4b0af5b190b31f9637ddddd390893dec6f81596e4f982b2",
       "urls": [
-        "bzzr://a83f1eac4e01fa2cbdcaa42337aa2a6d47fb962bcd792ab96796c737835a969c",
         "dweb:/ipfs/QmYFMwN9hcqbk1BDN4VtcFKuSGrcSeCvcDUZD2RUHKpRJ3"
       ]
     },
@@ -3388,7 +3126,6 @@
       "keccak256": "0x6c668e2bebe80f8825767ac23a4acb9cfaa1b211d5e910e6368807d3f20fcf0d",
       "sha256": "0x5b2540adbfecd3795d1cf723b7add9930df53da6a6ca029a81e72649d85bc4e7",
       "urls": [
-        "bzzr://a1c17c36828a44036164bfd4922626efe0da64aac8a3f0954fa21d9fa315bc4a",
         "dweb:/ipfs/QmewRUPBceZAxgSYi3VttoxZa2ZUpeBbokA759BpHZmegV"
       ]
     },
@@ -3401,7 +3138,6 @@
       "keccak256": "0xd7f7f5fde6ac70f654050c85e4ceb8f20d36224d6c00180c7a1f6ba7387175b4",
       "sha256": "0x5260652e4fad8521fb5e9e6f84262f5882c04b724f52a349ac1165ccc7b58e97",
       "urls": [
-        "bzzr://3ed5ec31709ab23a4aed5450b1ddfe79edd90ddc0929760d596504c64e23274e",
         "dweb:/ipfs/QmP1e3hwGEtHM8HMJG9b2XEpegnsV1fL19ajpiMuMDHge1"
       ]
     },
@@ -3414,7 +3150,6 @@
       "keccak256": "0x5b08e32949085a8bd3e84832b688663250f2a66e6c30ee4ebcda4ea63deb7da2",
       "sha256": "0x0c6c542b922139b8b3947268209df507f693d80fa924913e624bee4acebb8c25",
       "urls": [
-        "bzzr://1bc4dd1d361a7515b3ab254f90a66cadffc94128fe356020c48f5d9426a98dbc",
         "dweb:/ipfs/Qmc3PqX68gyZdFYR311VLgEbquafxW6HDHHAXiE43uAULR"
       ]
     },
@@ -3427,7 +3162,6 @@
       "keccak256": "0xc7b2cad2a817b9be0b9f685e82591cf19e3b78dd2300303159d483508213ea3d",
       "sha256": "0xb1485a430b2a92d8854d63f8111da81c714eaaaafe8d0a144ebe1586cbe28efb",
       "urls": [
-        "bzzr://88f30ce7d192694c2bdebe1b71ed4270a430e5a4c12566f9efd5d6f809bac446",
         "dweb:/ipfs/QmbESdd3wXFM9fEJNEh2h9RvamUGfqyywsh5bfkKjYEg78"
       ]
     },
@@ -3440,7 +3174,6 @@
       "keccak256": "0xff3a0ab91dc0bdc13e71f6fd0975c5186404784cd95a0555508c4fd52eb8e8a2",
       "sha256": "0xecb060ce34aa0ca33a126582a495a94532e07507eb0dc98e901aa83eb6483657",
       "urls": [
-        "bzzr://acc2a46c64b49a9176b620a274244e46d729de172e4c56936c53cd360c15f8eb",
         "dweb:/ipfs/QmVTanPh2T2BxzQc8XzRDVVzcLvD1fyTp7zP1fRzEv2Fkv"
       ]
     },
@@ -3452,7 +3185,6 @@
       "keccak256": "0x090c0843563e30fc7e0d6a66daa6ae0ff84dbd48e79a17d187905f25df73d1e0",
       "sha256": "0xf26d712a3a7d0ecd835eb077e23a3eae8d0b2054272baeb3eaa7feb64c69d1ea",
       "urls": [
-        "bzzr://a6bb732071169230d3c5cab20d5381d618bbce35a1a1413dc52940d03e2757bb",
         "dweb:/ipfs/QmcRwRvoCQNuAA7kp27diMtd1WFv93Kvm9Cy3Yf1r9SomF"
       ]
     },
@@ -3465,7 +3197,6 @@
       "keccak256": "0x97e203b2921ec806f1b6e45e9418acab6c2276cfcfbb7c432f1e08faceecf3a0",
       "sha256": "0xc721d7a91aee4b47449c3741a357d7613caf26430e6ee07a78c4cb73303a130d",
       "urls": [
-        "bzzr://732a0da24158418efe41b72fe9b08c4184be82cf0505e3069086b4e0f5ccfbe8",
         "dweb:/ipfs/QmeQXrVbSNCMVxfX5qakZrtxHhWLfpCz4Jy8pwJuMmUe9p"
       ]
     },
@@ -3478,7 +3209,6 @@
       "keccak256": "0x31413f72548aba3ccf520bf24d019b3257f1af43ee7a317cd75c836ea1fec7a3",
       "sha256": "0x59d1c64754fbf559937791e51b4e4acbf47ebb44c309e9bfd2984fa10ae4cf5c",
       "urls": [
-        "bzzr://4af15bcdd98ac98d2d1d85796a7c5f5f457decf4d398298f25e91922cc5cc276",
         "dweb:/ipfs/QmY1t8hqWAEHE2T1JzAH3FAi8vSoK5pt4HPLaqSWhUqbz5"
       ]
     },
@@ -3491,7 +3221,6 @@
       "keccak256": "0x589d948e7287c43f5f504bf6adf30029927d1e38f78e5ece084a5547014b1f2c",
       "sha256": "0x4af59009f77d4b38f842105b70702bbc0b94332a98ecfdd7c9e5ce2a50bf8f8d",
       "urls": [
-        "bzzr://0616e866fc0b269f1f6d836ed57d02c7a09535775875c4b9aa271b7ad1f39a7d",
         "dweb:/ipfs/QmT3nkhfkZx8sHEZacKY1sRuFABNGy8o4GBnZAKLTBLYkw"
       ]
     },
@@ -3504,7 +3233,6 @@
       "keccak256": "0x9bf76dc688d0afcc654a43cf9be5592b5201d1b75607ae5545307bc3daf9ab82",
       "sha256": "0x031444c193ff5224386058e6376f8abe86199b27ff220a0280a4ff5ed08575a1",
       "urls": [
-        "bzzr://3fe260cd8628710d0ba2f728ce562d067c5666e4276ea3ffa3f444e0ae8a34fe",
         "dweb:/ipfs/QmZ3GQhK4vv2HQ1jaCYuSYgzh9JKWNpt3HqB6PcF38GML4"
       ]
     },
@@ -3517,7 +3245,6 @@
       "keccak256": "0x5373e8c6494d0929b2727bee98ac11d341d6f621e7dcda078166f029e0d02a88",
       "sha256": "0x362d1c82ad8768ea52ce522fae187c09a9960d42aa361942e1063507c55b2487",
       "urls": [
-        "bzzr://cea3a09144b21b080614d6009551e7fe0d4b12b48bf135d1dcae80cc91bb9bbd",
         "dweb:/ipfs/QmQ4bwHN8LQuNSHVnvdTzKJZNGwbEEoo7cTgphAuiHwwbK"
       ]
     },
@@ -3530,7 +3257,6 @@
       "keccak256": "0xa3452348d641f4508e830170158f2687eb7c281c273ae0cb2e6d29884cdc494a",
       "sha256": "0x4db168426195027d9566a6693cfb16da349ffdd34115feb76c8b691ad2ab46ac",
       "urls": [
-        "bzzr://667a02155217c77483dc73850869686c91f7b46ab88eed20784da2cb76fe595f",
         "dweb:/ipfs/QmPvF84hft6Dv1x2VZxBom4ZmWH8aL9sL7pwkuxpqhJ99L"
       ]
     },
@@ -3543,7 +3269,6 @@
       "keccak256": "0x2218e03b6582815c51f04e9279a19098b5770d1550be0825503c9084e9c5114a",
       "sha256": "0x7756168829f8e3b0df6c417c98680bbec236b76b55eda4bd165a8a95f26e97fd",
       "urls": [
-        "bzzr://7ec6a447b0e9a20efb4449f4c09ebd14b8f6e4e10618b6e2a7a50fe5354a8a37",
         "dweb:/ipfs/QmUEwtWJ9oLQiFRHs5qfenhEMCB8bfiPf75pdXmi2ky8fT"
       ]
     },
@@ -3556,7 +3281,6 @@
       "keccak256": "0xb9cd7939ed03cd975d6c53b0c5ecf6fd01f9e36bb7d64b653e05b5b97fbeb18d",
       "sha256": "0xec0962facf8779be7707fbd489a3bc003152ae556c9d91f07a65bf6b240c3287",
       "urls": [
-        "bzzr://e99e3378624fb8660c0034fd2a65ec716c3d556f5d71b545bbcc18234c632c50",
         "dweb:/ipfs/Qmf98qX87vdz5wed8jLQjYLu3FinwFqqryAngmDzDxqQER"
       ]
     },
@@ -3569,7 +3293,6 @@
       "keccak256": "0xf06c6c2b515721bac8748c599a931cf63ace2379da95867b1b1821dbfc59da5c",
       "sha256": "0x2be6ca22c688810349f7f0ac5a19b9352af2e1dcd457e5c05606951881a357c8",
       "urls": [
-        "bzzr://77ce85ca7fc337b44aa348cad6f5b63009389ab39da31290a1b7defd2746f59d",
         "dweb:/ipfs/Qmdg69Uk2XHcfAjt7L9qUfiEqLgDNszCuMGVTZPnnZe4N1"
       ]
     },
@@ -3582,7 +3305,6 @@
       "keccak256": "0x182feb9cd30710479ea8d33ddbee2fa8f5b87da1fdfeaa0a1749f69a77664ac8",
       "sha256": "0x8d6934bfec7eeff36c21a6431dc13359342e9de7d7b1e0d69a658af9b2ae44f5",
       "urls": [
-        "bzzr://5863614a5a84607493bbaeaea7b41c5cfcf9c71ac0203e62b889a5119e33aea8",
         "dweb:/ipfs/QmeUuS2FS4Aodi9jUPKBgWYHKs3FMK99Fk7dGgJnMYhTTw"
       ]
     },
@@ -3595,7 +3317,6 @@
       "keccak256": "0xaab8cdbf247750b1a6b8fa0d2500a71c6e71583bd7bf0ab9dcae53669b6b38b1",
       "sha256": "0xd840ffd82f2c3ad0b295862b90ffad6776a307baef26075103818c32640da4d5",
       "urls": [
-        "bzzr://cc56edba0efd1b9d9e7b2b498314458e2e6a08fbec47d7b24667a6baeeef7836",
         "dweb:/ipfs/QmPRypdSjhzkhZgLDqr8jr2BM646r5PX8ub7xMrfdLjNFy"
       ]
     },
@@ -3608,7 +3329,6 @@
       "keccak256": "0xc75a32762b96b08a6f29f433439646afdb4e7aeb12da71dab8918a64309a6ddb",
       "sha256": "0xe5fad4420534da517358dc4a6e5d6f1d5f11b3cda998031baa81188ffd287a61",
       "urls": [
-        "bzzr://30f49ee1beb6e3a95dc82808f1ae4a584c2e86d02b89678be7008caea791dd2c",
         "dweb:/ipfs/QmRqRWZ67BXUeyBzzwTF8RJsaKsMiREsHbrhJ8C4dNyypn"
       ]
     },
@@ -3621,7 +3341,6 @@
       "keccak256": "0xdabc18b755fe8e4ede71dbd9f6c063ab12d5c0fc37946ed5240277f34de54254",
       "sha256": "0x35e619e40ca32856cd8416381d67a6fe73effc2a1a42621ce7b7408d68015691",
       "urls": [
-        "bzzr://ccfcf3026f1dc1fd70bbac1f270c38c4c68cd11c40e2f496ea759c571b03f070",
         "dweb:/ipfs/QmRq527pWhRfwRmmFauooVthonVjThhdheSHXACGiwu9ig"
       ]
     },
@@ -3634,7 +3353,6 @@
       "keccak256": "0xbe55e1ff8c1cbb2dd4c540a76c3152347e87966de262e3be9a1a976b83388dd5",
       "sha256": "0x042654a2a1abc266916f7cd560bfb8233c6e9f9e81a48f1e2de53b7ed63853d3",
       "urls": [
-        "bzzr://123dd95e671be4b84cf0cd6ee6f63db168cdb9e1db51c219e3e377de2869336d",
         "dweb:/ipfs/Qma841febhbzJSx6qfWhTPDXJ6d6LdCe9d2z3ZGUdg4Giz"
       ]
     },
@@ -3647,7 +3365,6 @@
       "keccak256": "0x5d2d921c7a290afc052c381ebadd52bc68b88fed044947761fb14adbad6d9636",
       "sha256": "0x417a9550da3d2d8d3f7341d49dde639cee10764c3fad83c5ef70d2d8346998eb",
       "urls": [
-        "bzzr://fce189eb1f8132ce47d2d7c5eb3ae9dd361640c23fc8de574d24082ac4868e92",
         "dweb:/ipfs/QmY5q3VwvpPHBNywsgXfqFDm7tQiezibdMyzFHBmB8xZHY"
       ]
     },
@@ -3660,7 +3377,6 @@
       "keccak256": "0x9191e86fc4a6b97c1f3ad3817f2dbb7d4dd16ab0158cf9754f8855bfd6a46daf",
       "sha256": "0x4b582664de4678166fb115358ba09739cc160b7c112b9aad97fa5d2998bcb763",
       "urls": [
-        "bzzr://1cccc0a1f58b8bdfb680ceae28cc5d9ddc48affa4b2557d87705be78d568831a",
         "dweb:/ipfs/QmcguTqW9kGpNe1G7iNAuZyA31UoYESDMGnKvmkEof9wWo"
       ]
     },
@@ -3673,7 +3389,6 @@
       "keccak256": "0xa548fb24161930b2fb0fec48268da2de5cf6bc5a4803481b779027cebfad69b0",
       "sha256": "0x74c2663bc2670384aac0ed5c9281f1aa8bb0bd7e91581d7458ed0a02270316c1",
       "urls": [
-        "bzzr://d66192a2aca3630b9cd33143276cfb1667c7d11971f3734add4b127035f4c627",
         "dweb:/ipfs/QmP7njWbGvVifWgzqb1Jmm79HCsnKS1xYyP9oRKdsyKaJi"
       ]
     },
@@ -3686,7 +3401,6 @@
       "keccak256": "0x27dd369deea0f9d731f6528dbe6e508ea25c946dbd5dd18747c21000f608785c",
       "sha256": "0x3c0cc24b0cdb6ea513035f95da86a2726480e5ace47cf4ce7648fb68c0b458b3",
       "urls": [
-        "bzzr://879db3cfa8dcecbb11a33f19a515859e3f375b08ba958ffe86f2af98b20ad577",
         "dweb:/ipfs/QmbX9pTshzChr26kxtERZ7FNwhRjpo4LLQ4ajjpy4V4eqj"
       ]
     },
@@ -3699,7 +3413,6 @@
       "keccak256": "0x7e8cdd383ac1cfcb52a8ed26ca016a728e8d4f7a42945dc15239456fd2d0dbd0",
       "sha256": "0xee4c723e01f7989c7d0eaa84c9b4cc16c0afc577d83763340461e2ad0dae80fa",
       "urls": [
-        "bzzr://4d70d00a3fba256b5405005d5c6f65a5cc45f5f5c314e78fbaa8f581eb62a893",
         "dweb:/ipfs/QmPJWSQ1VXfZLENy3XMybFCm1LpfWMQXWu85VvZPgpxKRv"
       ]
     },
@@ -3712,7 +3425,6 @@
       "keccak256": "0xf3e30b1ad80634996abac4e8717d468e037598355652111529cac405522aa23b",
       "sha256": "0x51376263bfcb6145f6f9df7cc11efbe3359e4950d3599bdd9089102657625cfd",
       "urls": [
-        "bzzr://a9d7cc97e7cbdd47727b4f6f61517b10a2b0a2f7c76b2aff681187b5db429ea4",
         "dweb:/ipfs/QmZ8VoafsgwSYkHfEZH7LM79bW3Ds9ETnDFmADnPKqPNtx"
       ]
     },
@@ -3725,7 +3437,6 @@
       "keccak256": "0xa606a3c180feb1cbad388fed27a5bb216cf7706c5ad394c8b1dbf4cc7c54a9bf",
       "sha256": "0xc8a412910e01dec19fc4c3af94cd57fe6b42aa2080cff0faacb28478cd4c1479",
       "urls": [
-        "bzzr://0defca04937e20c903e225b78f3f506715a3cdd55ebfe89fb8ab1df6685bf1a4",
         "dweb:/ipfs/QmfSo1KRpTRZJooFurQK1P5222FnPsPeUWJ7ZgNonTQthK"
       ]
     },
@@ -3738,7 +3449,6 @@
       "keccak256": "0x55b44298e53193fd7c145915ce2d7e85a55e5b37de86fcb5f0464209786a408a",
       "sha256": "0xe6a1548990b8572f74da321844b481a9c5e43637bba2d10a3df6a0de1a887e9a",
       "urls": [
-        "bzzr://bf64d601e60c8dcbd047939492bf7fe3bdf85131a7c6fbf775a9c77d3d8682fb",
         "dweb:/ipfs/QmbQ3MJqbn5HcEHem7BDyt7tuGYnD6bozXk59foZtkQBwZ"
       ]
     },
@@ -3750,7 +3460,6 @@
       "keccak256": "0xde17e284da94d3d600c1096f05d83af794eef746d2aba2e4e066e3d3efce7abf",
       "sha256": "0x6cc5b7c2c3c640daeadc8a41ab5cacc085b4fef667c2e119767529ff23075111",
       "urls": [
-        "bzzr://21a06f49cd51d05d4f40a0f2ade84309e5d411ccdcbaf8b93d14163e42716f7f",
         "dweb:/ipfs/QmWfzqxs26GMHLZiFiNxTJXtZSZZYoqMorJj9fwhKpaKJy"
       ]
     },
@@ -3763,7 +3472,6 @@
       "keccak256": "0x396c1b84020fce45d1a35090051f00960c511e15409a63d66496c3fedc5a3054",
       "sha256": "0xd0d565478bd167cb0ca2388207dd98644dbaad8ffca3936577740b35c4ec9f70",
       "urls": [
-        "bzzr://e762aa0e54f8769ef0c30d0db7540445404e10bfc07d6a439f0dbd062e97f649",
         "dweb:/ipfs/QmPmhWQWuVfbuKBZkVAJUh8PVs4NZbnu78vQXhMvaZuZAc"
       ]
     },
@@ -3776,7 +3484,6 @@
       "keccak256": "0xd3d49469c1de628ff984683af3069ea6ef946ea821325d6a9ee57c2dd7963a3c",
       "sha256": "0xee17f64f73952a31913484f1523accb53cdd0a7623a3a9daf6f573b83c382ff8",
       "urls": [
-        "bzzr://225e409241898c6a909d47c737ea6df8ec00e26c39b191b3250c0cb1b86e18aa",
         "dweb:/ipfs/QmVc3mWUqqPejb6c7jxoKjg92DCeeBQxHEWrq9mC4hvAJi"
       ]
     },
@@ -3789,7 +3496,6 @@
       "keccak256": "0xd9c6fbc9a46fca4faa9fc5dbb824c301cc0502e35a6af755e60f4321a0da6737",
       "sha256": "0x627b1204e8949871d049b2e8657512ad2905a39863d5de58b9eb51b5acc4b089",
       "urls": [
-        "bzzr://a84aa7495441d1c5c915f4754ab0c60b212f9fef5a99fc471282ed5473baefb8",
         "dweb:/ipfs/QmZhRrpbXr5EyYUqCX3SC3PMRD8K55g513kGC4KxMQtvqa"
       ]
     },
@@ -3802,7 +3508,6 @@
       "keccak256": "0x76e72a1b1ea30b7978e9257936847254ef6ec4f1c429db1b5bebc0eae5f2d226",
       "sha256": "0x81ecddc3a48abd8af4566806f0baafc20ad851eaa69033eebd82791740059732",
       "urls": [
-        "bzzr://09bdf24fcbb516ea8edce76334ae45b05e809f133702ee46be81be56301d10c9",
         "dweb:/ipfs/QmasDkLgPMc2bYD8YB7ugF324Ug4UzeLTYHccTdUdRdbZ4"
       ]
     },
@@ -3815,7 +3520,6 @@
       "keccak256": "0x523aad809a01dd03acef4f99b6517f5eb8af86c39f8a61f6c92f7ebb30f260ea",
       "sha256": "0xbac6994887687c17fb4be032db96951e9d737ea01cad22890d6282e07eb50595",
       "urls": [
-        "bzzr://d29f5d0f837da18fdb70d45f6985991e06b3402046a74efdb01a688391b15996",
         "dweb:/ipfs/QmZVeKkC6kNtY8iVFCWTrThorEzCxVEm8trnB2TRg1BiMA"
       ]
     },
@@ -3828,7 +3532,6 @@
       "keccak256": "0x27a6f5263607f302a32b5a334498fd2ef44827a521ef93d84ab0f0dde1e9d065",
       "sha256": "0x668112947890530c374b967bec9ed89df4d2524d6691f94d270c6638c277cd26",
       "urls": [
-        "bzzr://77c5077147bfafdb124d6056e2f64452b7144bef9f3d14a8dedcfa1201064dd6",
         "dweb:/ipfs/QmZ3Qxw1BfUPjnv8ssQwUqpge2raUGh3VS3P25BTNh43QY"
       ]
     },
@@ -3841,7 +3544,6 @@
       "keccak256": "0x7aab62a6e91206df254b6df9e2660f6933e5d4dfcf254f601dc858552c1aa2aa",
       "sha256": "0x671d766014fedd211007b53ac81bd36865402704b8030afaa1b23b967171acc4",
       "urls": [
-        "bzzr://e2c63519284680e984471b6d7140cd719f25d64a8486d805007e0f27277a62c2",
         "dweb:/ipfs/QmdW9Pg9Vendb5NN5NzjJLqq8MuBJPVskAeipBJRbhadAa"
       ]
     },
@@ -3854,7 +3556,6 @@
       "keccak256": "0xbfe270fe6dd2ac7fb1d7264e7d044e98fe45aa656404d25253f33d27ba514c85",
       "sha256": "0xafeafad1b3a8f6dee89baeff62ace3e8a8f190ff26290a46d6a04869315fb9c4",
       "urls": [
-        "bzzr://5d49b77818e83ca3abaa7679524d94237dd50eb0584e250ce0c01566614efb34",
         "dweb:/ipfs/QmZpcZKpNEh9MoUH6YiTQmUrK63mJxbjY628n17WrJeQnA"
       ]
     },
@@ -3867,7 +3568,6 @@
       "keccak256": "0x67066565c9caa5c0dc8a0e907664b62c3f4848d3272b64bffbcce3d00f75c134",
       "sha256": "0xf3060498be1ac8ef40bc9eb3be4cc68fba7e265c2df465537d8b20f6f59e803f",
       "urls": [
-        "bzzr://6fb9ba92832396fa81f243be506af7628ec0adda6787e6b6e6f6a47efb4f31f8",
         "dweb:/ipfs/QmWR7sCjcbAruKsKn7T61776EaEtGbSCJsNWRxAFiNgHfS"
       ]
     },
@@ -3880,7 +3580,6 @@
       "keccak256": "0xbf38c0c07901a749a013be811aee4d7aaa8bb0a8571da629e267e03b0f8768da",
       "sha256": "0x5c65c50e7b27354c655c7b17800cc855c73bee7dbd13f0fa057d4bc1772a5798",
       "urls": [
-        "bzzr://52fb55569fa5c1657fd225e32193b6038dbb7cfe976db1bc27bf99abf302dad9",
         "dweb:/ipfs/QmXT9gHTKR1Yy632R9KGjGnz6FquTz4hgynYf7wsUYtNuY"
       ]
     },
@@ -3893,7 +3592,6 @@
       "keccak256": "0xc772028e4617430ad60b04ff190dbfdf1b86efe8f42bb9740af471d2802ba5c6",
       "sha256": "0x71a92bf73522e627fa89aaafcc191b5e60347a8d01c165f2dd7f6582b36d49a0",
       "urls": [
-        "bzzr://49e933d4a6a5f5e30dab4402bd3b0d3aded6f41de0dffb393257d076c6e854f6",
         "dweb:/ipfs/QmaH6aUtKxHHMuEh5EDzM8VgYv5DoDgrbfgG97FUXtNBtN"
       ]
     },
@@ -3906,7 +3604,6 @@
       "keccak256": "0x65f3e05f09ba0505da1134e1460498a37484df10dfaf2c9b03361643998ad13b",
       "sha256": "0x33a776cf04613f3e00f70c9e0c8ec4d459d75ee876f1f4a8679022860cbc2411",
       "urls": [
-        "bzzr://32bddcec6a9331c1bcb8c2ddc491e4f4bc21689df6838c093d0643b9a91770c9",
         "dweb:/ipfs/QmWFX7KFDw4DgUoVjpnq3G3s3uazkpT3XJ8dEVuNWFbvoR"
       ]
     },
@@ -3919,7 +3616,6 @@
       "keccak256": "0x7de59a4629a0e7e56c7fc1904a41bd94d7fcdc91480989c77f99a3f1a62fe89d",
       "sha256": "0xa7748bf8ef857ee37c11b30ddd547a6adfd8e044b130b58ce0b9c2235406f3c6",
       "urls": [
-        "bzzr://78e39a6bbc66938f183dbc7f72aa453ecc0ea750b41676dcb1bd5caaf58d272a",
         "dweb:/ipfs/QmUpf2Jzsb2YQkATzJKfSa1Rm8jrkbX2Kke3pUV2Td2B8m"
       ]
     },
@@ -3932,7 +3628,6 @@
       "keccak256": "0x0dd40d13f41f8a30f798524333ab9cf6293a1b8828611fac7aff84144740a06e",
       "sha256": "0x9707478354490b825bda486ba1a6512e87ebd65c0ecf23428b18e0398cb0126e",
       "urls": [
-        "bzzr://a9f97e4c1c0e2355e275b20c83ec6a9af3145aad8d7a8ee56491de60ef4ddbbe",
         "dweb:/ipfs/QmRiSRur4HQvY66SoeruCJeCXq6xSx29B8EZ3yvnxzysJS"
       ]
     },
@@ -3945,7 +3640,6 @@
       "keccak256": "0x4dc45b3275ff55c5c73c3e70231c3978ade5f8ceb08a621f09a464a10916e229",
       "sha256": "0xd6e92ce21a8869e077bd2fb5c5c77f25684121716e52348b383543b35d8341d6",
       "urls": [
-        "bzzr://6f170431c21b8a151f26a7756c77111d60bdc49940408a9676f805d78285683f",
         "dweb:/ipfs/QmWCgARk63KkFph4wieSUoJ2ZW2VEJ4LKJJTc32HCYZvLg"
       ]
     },
@@ -3958,7 +3652,6 @@
       "keccak256": "0xb279d6640df060660cf71a3d2d8dcc09bd2d41dba1022a56d475a17d27d92717",
       "sha256": "0x6844d35035955cb3e10dd8754d88200b6be7bf4c9dfbeaefb1ad83a39851d1f1",
       "urls": [
-        "bzzr://cfacd958ff32a194412ba0899627d121a1c9a5f62ee8cda161a5c2981a9db5a2",
         "dweb:/ipfs/QmRzEsURu79TbiTMqakxKed4LjoDpiDTcWhU6j2hxke7j2"
       ]
     },
@@ -3971,7 +3664,6 @@
       "keccak256": "0xbc082d1158366cf40604029b04957aad96a1e857be7a70a2e2116a427848c038",
       "sha256": "0x61035713f45874cb2a748ee21c2da681c34d0ad0acce772c9b9b39a85d8089e3",
       "urls": [
-        "bzzr://042bbd304cbc161fbdc0c1ba4a548e66ae79d8624102ddf1fc0c175c8cec1da4",
         "dweb:/ipfs/QmYMVSrkfaQspSMxMb9mLtomDNDNu4NP8X46jMFcpXjU36"
       ]
     },
@@ -3984,7 +3676,6 @@
       "keccak256": "0xb90a616f667c86dfaf01162c35fbff1a7621af405aefc33c916dff110aa708e0",
       "sha256": "0x8c0a3cb79fb36912538f1216a6b33a90df77adcb26c1333c5d93e3173c324fbd",
       "urls": [
-        "bzzr://d230347894a4499245a4386921a58472d5e8ad4499cdc3a8b07d3aa23e913e2f",
         "dweb:/ipfs/QmPuyqzr7dGCpvAfKS557YX4vkgMQ5Ja1iQwbR4vQQPWXT"
       ]
     },
@@ -3997,7 +3688,6 @@
       "keccak256": "0xd9053424297047a145869e886bd8e8bef44dc4c5b8cba0b29007f38371b8fe5b",
       "sha256": "0xbf7e5eeb3c7590c0b8f97ec82867d144f1cd23493aeba5c69d57b06d8f03b2c2",
       "urls": [
-        "bzzr://b59a8ed1fb5ef8e6ea6803b223e38647b11eec971368a1dea03fc46b7ebab712",
         "dweb:/ipfs/QmNS7XHKF83EqnJ6SShoUhUbRZxcHFc9VwfL6jF1Z9a2Kd"
       ]
     },
@@ -4010,7 +3700,6 @@
       "keccak256": "0x0d86e48a220c36faa8d79bc598b2173cc325768b524d08ed1d58e56c697db05e",
       "sha256": "0x2c3cc4feed9e71c1cc58d2053f2ccd5f8c43cdc9a574e7c48e1d954f7dcd2039",
       "urls": [
-        "bzzr://4ae27dcadea053e98ef93d5e759b8cfefb71bc68dc83b45b5939b1989041d307",
         "dweb:/ipfs/QmNsHL1NFUphsHcR2qmKny6tiGh3FUxUQmhSJp1VPh7DaP"
       ]
     },
@@ -4023,7 +3712,6 @@
       "keccak256": "0xde8fd86b5b0c7f74ed76c00b9859bfadb0f09da5431081c3d030c6515826e48b",
       "sha256": "0x623f4314c87d9ec8019c445bd78bee2a370845464de7d9642482bb9b732b95a7",
       "urls": [
-        "bzzr://8ff2348d15d1c73c8e0eaca3d33e5c00a2075d2956617622b916e9ea9483f83b",
         "dweb:/ipfs/QmXHzaZGDM9GByYjzw7VbHnskx6B2Rjo3sUUpcr52fo7t5"
       ]
     },
@@ -4036,7 +3724,6 @@
       "keccak256": "0x9e41ecc4813a5c2ad3a7973ee6c6bd8377505e8c166c15c7cf08eda2f6148a65",
       "sha256": "0x9132345ea028a5ffcd315b14321eaf46dc9b7a81d4b3267ed6f58d3498a5a78d",
       "urls": [
-        "bzzr://08930a2c0914ff6132b0dc35b8c0526ea09be04483d25c78e528e969e06439f2",
         "dweb:/ipfs/QmZTmkNcaLxNTJD7kY4geTjkE7vPvPwm3To4trFo4UrFoh"
       ]
     },
@@ -4049,7 +3736,6 @@
       "keccak256": "0xaee06f8570c6063ba411bc5e5ab4df5a3ca36b4721288b992ce2d30cecca9dad",
       "sha256": "0xe8620865b5ea272b9d35aac01b75963a284c3f2500d00744bcfcf1a54d06c7ff",
       "urls": [
-        "bzzr://cc67deb8fdb4320a6499b49a0e1c8609920dce1eae73b23359be3dc86cba7a6a",
         "dweb:/ipfs/QmV4s6EVR7PzZt6Mijg3KkvhBxGRbXS735uuhjV1NayCQJ"
       ]
     },
@@ -4062,7 +3748,6 @@
       "keccak256": "0x5c306a4f51e3cc5ad89db5dced6be516415d4b85809c0e7d3c01ac981754814e",
       "sha256": "0x72104744c954de2bc5261e7309a8f26fb52d79d4808d9a39788f2899f5633be9",
       "urls": [
-        "bzzr://b142f792e0c40f2a0440c4146467e14fbd778c229ab73ac45faec085131d97af",
         "dweb:/ipfs/QmTj4TmHr6VzQU7Widuj9QnsejNDsi5paHBJuutGzqaCZh"
       ]
     },
@@ -4075,7 +3760,6 @@
       "keccak256": "0x22fe806bccb4270e73d97a77f2c18257aebe89b086c35c382ad017fb3810ad11",
       "sha256": "0x4c4a73b594307892dfcd931a727119268c254e9b9d63d24e03625acebb8284b0",
       "urls": [
-        "bzzr://58c509807b16931c04fd39008dc6c67debbb328bddd20f5a9729d6fa31bfa600",
         "dweb:/ipfs/QmXbQZszUTysuCgMEzx2642VGJg9bsR6KExAwChTUHVmQe"
       ]
     },
@@ -4088,7 +3772,6 @@
       "keccak256": "0x92f34e20c629168f03922d57e41005a02937b179af9e3764b25891ca27367db4",
       "sha256": "0xe61216c8d8dec9d12efc977cb105df979ab12ecdb601ad0e4237c22b239cf983",
       "urls": [
-        "bzzr://b57b2bcbf49a8c49972c4f70d43d037369bb89fa492580df4f4fb253e6690dab",
         "dweb:/ipfs/Qma5Q77Xtr9sdNC9iw9kz9ALXkteC4pYo65F3fwum9vLKG"
       ]
     },
@@ -4101,7 +3784,6 @@
       "keccak256": "0xf4e9ea4b4dcdb4e569a1e8e73f1efb0662da260aa0c1c904c69d9eaa56c38e7f",
       "sha256": "0x1fd3ade106981a0ff8aa4103e493bbb7bc8bd22f5f8c07597a21d49f5181d18e",
       "urls": [
-        "bzzr://20cf2e5d42cd0f76ec87b93587a42b50368da83511a2f5eb8c4a6fd7269a01ed",
         "dweb:/ipfs/QmNdnzQhY5WpGLyHrYdCM3kYPCu5CRxCX7XJ18hV3axt3P"
       ]
     },
@@ -4114,7 +3796,6 @@
       "keccak256": "0x25223a0f6059ac1fe907127c40b93e0a6bf2b8d78cc58084f4160aff7c2d9f6f",
       "sha256": "0x028135d2ccd890d976800c882e94a4e968038aa75b7bf24dc13544f222205830",
       "urls": [
-        "bzzr://b579dbcb741862e1ea3606678c6a7d061d95ac739f0f53978d5e64163b148b42",
         "dweb:/ipfs/QmdsUzrwAHX6Dj9PLqraV1ZuVdxpurjRvus7CQoc9yK3TY"
       ]
     },
@@ -4127,7 +3808,6 @@
       "keccak256": "0x0f6d05b95849cd5cfa6bd2314267b2cf23ccf15a7835deb528f5c6cec982c723",
       "sha256": "0xa0543821cd1335d8594ac9fa6b9601e44685301a489425aef4fab785807b5e10",
       "urls": [
-        "bzzr://a0aec1a83fd0ea2247012524762b3b7da63a92027baf28aad586136d53327b4e",
         "dweb:/ipfs/QmVaYh63nPEN9B2H3LRNeoziFpu6tHbQEpywE2vGtG8jK1"
       ]
     },
@@ -4140,7 +3820,6 @@
       "keccak256": "0xd0d8e7f5c0a87ec3866167a0178837328ad29201daf67ee8bced03422b661686",
       "sha256": "0x7516e0d33a986037a7c4285893616d330870fa0171ec2a4896599d229875d722",
       "urls": [
-        "bzzr://8db895dd0a5ddc31f39b6bdc866e885d708c46d419a503af4b403d00fc11b4ac",
         "dweb:/ipfs/QmeVToye4LZtMWEqgqyiHGXj8YSVMEYX8LFnQsHkBE3RQz"
       ]
     },
@@ -4153,7 +3832,6 @@
       "keccak256": "0x4539f5b912a98089f29a8a0f11b77bffeec23493ab490303a11d9e32d68ac8e1",
       "sha256": "0x9474854840ca59b5d4102109a241fdaff36a7dab8d44099d9f9c205372b6f165",
       "urls": [
-        "bzzr://af41edb300606bfd74ee32d358c08094742afa44b703b73f4d33c964f2147c5d",
         "dweb:/ipfs/QmNpPzeaosB6WVoQMZ7p1zBnH1xctVyTJkkY5U4Z2sXJ4T"
       ]
     },
@@ -4166,7 +3844,6 @@
       "keccak256": "0x3d8d35f89b9ba84cc985c25f46aaa6f5f54b64ce6cf55cbf820f0ca546df4903",
       "sha256": "0x05e0f826afeddff488de99c14ed0bba303145b8362d15a9985ac3ce381fff156",
       "urls": [
-        "bzzr://cde5467786137658b6647d1cc504371257a0d751e34e7161a130f44d56966108",
         "dweb:/ipfs/QmbPNBSCB2bsQoKBwyNJRmcyAX3SHt5sXYcCHThMVBrQrr"
       ]
     },
@@ -4179,7 +3856,6 @@
       "keccak256": "0x26a64e76f12b7c02d302e8706d00dde642fabe4f17bc02771b779499eec6395c",
       "sha256": "0x2507b0a4d67390c7a3902fa8a7dbaa33d1784350a54c0316b9af9ff72b06fe94",
       "urls": [
-        "bzzr://1da83a4c76fab7e683afe53b7dd9f699fc4fe05df31469267623fd1c6e593599",
         "dweb:/ipfs/QmWZjrv1wfbPGCDqKwVKtMpcxinLYbKPS9LAB5iPru8NAE"
       ]
     },
@@ -4192,7 +3868,6 @@
       "keccak256": "0xd8ffb8cdd675fa0fea4f8350cbfeffc3ca0301f511c3bdc952d06929679af0b1",
       "sha256": "0x3426c871565d6d8a3503013e5fde7985c533b3af50863442acf7b410e43fe88b",
       "urls": [
-        "bzzr://d6752cc6e94a9bb8525b61c5b2ed41096c4471015d983a7e9824dd7a7ae3a273",
         "dweb:/ipfs/QmUkEquN7rua6MuAuESVwCks4w8bDQS3rKgA67TT5tJz3t"
       ]
     },
@@ -4205,7 +3880,6 @@
       "keccak256": "0xe894e2a9f611995e09a4b03d8e218b88a8f78808e9c39530945776ed5607535a",
       "sha256": "0x42162e33c17fde69d1964d2d96d18b0454c99db84469baec1f93e97ad419e504",
       "urls": [
-        "bzzr://11bc1cf271bf18c8e9868891e76f9fa88407f161030fd405892bd3bc3c87761e",
         "dweb:/ipfs/QmUHegyhteryND61934vjLV4vHnmJEEqfPrEHFqCfo2YH7"
       ]
     },
@@ -4218,7 +3892,6 @@
       "keccak256": "0x4b94255e10b4d49873fc3d5827965d616fc9ce6c47dac9d33b76cc8ee09076d5",
       "sha256": "0x108409dbab821a3e3001691571a75634a54567ea71fc29b328766e3541d4d936",
       "urls": [
-        "bzzr://4da4c61db1b627348fdeba2c44893a2adfbe23e28fdff5941d60d680f504d550",
         "dweb:/ipfs/QmUhCAAqY68kb5M1X1rAsCuTcN84Y6E7d2SMEVEmUNcHXz"
       ]
     },
@@ -4231,7 +3904,6 @@
       "keccak256": "0x763ae0e1023f204864e03dcecdb8adb4d1d3419e5d2389a02aa227acd802317b",
       "sha256": "0xa39c5ea6598386313b0bd9249be9944a17f43c83cd84054898ffa6abaa60c450",
       "urls": [
-        "bzzr://0daf2e6f16891664ffdf8611018b23d890f6ba1228a3a9949b86603820f806af",
         "dweb:/ipfs/QmV9n6zguckhg2PDg23FbMihQhWjR2USNjkx9aNATC6tar"
       ]
     },
@@ -4243,7 +3915,6 @@
       "keccak256": "0x44dc961e7512f70b660555c7d900632c1863c1bf6234b0244a90645bdddaa53d",
       "sha256": "0x304f7b092e9493525867b49dd8a833bec53ca6ee5ccb408daca7e266e17a6cf7",
       "urls": [
-        "bzzr://021fcea53baf74dc83891d864b6d6a63a0d289dff9cd4542d901b9d62124764d",
         "dweb:/ipfs/QmaJpZwtLAzHjk2nZpXY9XNknFopYNZbMhiPHHTijSd4Yy"
       ]
     },
@@ -4256,7 +3927,6 @@
       "keccak256": "0xc9b519e58fc7a7d049d57f896a266caddec19bac75a6502a4bcd048309a40f78",
       "sha256": "0x68d12edcc7022ab71ae3fd82478f0b7577ce027255ac1f7a128afefe1d508b27",
       "urls": [
-        "bzzr://bf94ddbee14908240a30da8e29749add1ba6d03421ac840ce954d87fed7101cd",
         "dweb:/ipfs/QmXfdAuuFcRyEjhg1wVaA5ajcYHHvkK5D32zTnaArq1Nnd"
       ]
     },
@@ -4269,7 +3939,6 @@
       "keccak256": "0xaa8785f49532e117551a7caddd501bc0f3936c613cb07e032c8792b9cd8d7a80",
       "sha256": "0x79bad2827e422c06debf6f8e8c80f4441249674d4642ce31ba15ddeefe20cf7e",
       "urls": [
-        "bzzr://6575be13d595c17665d591e38a6f84dc3b19478d02a8201db6e607c5f621290c",
         "dweb:/ipfs/QmSuUrz6Lh2Fv4uVw9p1RzbMpNbA826Gfw6axaZ1LAs6RD"
       ]
     },
@@ -4282,7 +3951,6 @@
       "keccak256": "0xe79c1d39a38663a9937a3cc0572953ed4ebe00e4b8833012b7b243842ff817f1",
       "sha256": "0xc2470e880c1282b079510282a510523279771a467da812b8fdb758e8aca2c0ab",
       "urls": [
-        "bzzr://d14baa1f28a1c06b6f4042abb5adcfa05c66aaaaed3492d0b5f6361a104f7b7b",
         "dweb:/ipfs/Qmcb2pcvEKwgGaPfEeDu1NfpXx5WdmTTWW2sbFm2DT4iH3"
       ]
     },
@@ -4295,7 +3963,6 @@
       "keccak256": "0x5c280582a7e7c443948b49fc8772861308eca13c2aa4a4ad9511af83b7556de0",
       "sha256": "0x611924301e223543719953f77c5ffb86c5cb41bc481bdfdffe35e087812791b6",
       "urls": [
-        "bzzr://43ff7b42df2ea5ec21b51da9e2fdfc146938b886069c562ebcd71cf3be8df849",
         "dweb:/ipfs/Qmcp6LwPTxqq3JPykL3seAzUrmDNSDnkW7Jwr5GQuWvQdb"
       ]
     },
@@ -4307,7 +3974,6 @@
       "keccak256": "0xbeaf9919ff94d1e339187d97290ed45bf4d6b87a8efc6e9435317f3be35b76de",
       "sha256": "0xf359e1a7d60cd6259caa91a641e29d99faf97a47d7e75318516196248fdbf862",
       "urls": [
-        "bzzr://c8bd3b51963b90d0c76daa19ef2f966a28b5bf3849cf26c4c3b2f5c48e9c5b52",
         "dweb:/ipfs/QmeVdLjq74LQT5Lw7yTBwar32bCj5ficAoEKTZVTw5PvVk"
       ]
     },
@@ -4320,7 +3986,6 @@
       "keccak256": "0x63b6d23a97022b6246a756fd3d261ebf81b3c3949268c58c9774422ef0c4fb20",
       "sha256": "0xfc780ba581708b82a99d04bec17451c1bc884fcfd86d9df6900ba4c8f47d2348",
       "urls": [
-        "bzzr://956d6a4cc848ef5c380217415f11a9aa4ef1da292f577c166d9ac1664281afb2",
         "dweb:/ipfs/QmTe7qTXrGRYsWGftRUHTEKuSJt5m1hqYHwAfXYN4Ya5ME"
       ]
     },
@@ -4333,7 +3998,6 @@
       "keccak256": "0x1c92f5eee1796f36ba400ca02c5a9777a76330b7b10eae2d732aa97590842f4e",
       "sha256": "0x52573c107dfc51a2ff3cc6b74fbe9adac95959aef0593d1a2536f923a24e3bf6",
       "urls": [
-        "bzzr://d4b962455e1249c270148dd565dbba79413c345fbcadb9f52f76bb7531789186",
         "dweb:/ipfs/QmViYj6wdo6oZ1JatC9KCTAszZphNdHsLRBcRbwXmCwkfx"
       ]
     },
@@ -4346,7 +4010,6 @@
       "keccak256": "0xbf8b3763e4acf72edc3e194528c9e0072886d77d80dd4705719c8c182a5a83fa",
       "sha256": "0xc0b41b85e8a18f0cc98697c71f7135c824898061346ab68bdfa3262a9b02d2b6",
       "urls": [
-        "bzzr://3a3e0f7c2d6945b6e8105811c5e9b8772b6aaa55d694fb9a1c3f56783f8333e6",
         "dweb:/ipfs/QmYKuG91pc1ZJAHspBKUUFpCETjnmzMcocFXKsgc959aLW"
       ]
     },
@@ -4359,7 +4022,6 @@
       "keccak256": "0x16ce67785cd4cf90ffd12da8e19afa86f5658a26c9f906e597b9dbc8e63ccb9a",
       "sha256": "0xf857a9c8f89968df8fba7403ab95dd1bfcecdf205559567da199b19cfa320e3c",
       "urls": [
-        "bzzr://f3d4f03f1aa222d06bcba0fb7d092374dfec57cb297df4b28b17f886c90eaa40",
         "dweb:/ipfs/QmVvVf6xhHBsyUqRLKqZm7D19M5Sykh1hiTdkrK1JYjjXc"
       ]
     },
@@ -4372,7 +4034,6 @@
       "keccak256": "0x10c984bf673032e43f4af05000ca3d3937741bcd9525fc2ba092b27e21350347",
       "sha256": "0xce3e78c84dcae0ed917907622a46301308a766d8d0761338fa9be30f6f89191f",
       "urls": [
-        "bzzr://d43c996f3b07f06b4416965de973ad085e60ecf12060fd7d3c79ea1ba463a259",
         "dweb:/ipfs/QmZbvK2EkLFjeU6JnJb6AdnARJ4vmxTZJC8BCbaTdU9ur6"
       ]
     },
@@ -4385,7 +4046,6 @@
       "keccak256": "0xced2bc71cb62a2a1d67184a3fc7218140dbaf292aa3d3e25c5af2759eda986bb",
       "sha256": "0xe75dfe4b07a8a7507a3d49118f51c2c86bf577acb7397e5f2040d0d49108c44c",
       "urls": [
-        "bzzr://6f00fbb534ad352e5e39cd0e5e81adbb1d25307de00a103b36fc18e9599c6b5a",
         "dweb:/ipfs/QmQMArEKynq7rUq1JR7rWgZUMmVYXKdR9iuaLakdFVBCfg"
       ]
     },
@@ -4398,7 +4058,6 @@
       "keccak256": "0xa35a06bd5e726cb781f95908799019ed911e1fe7ad4a8bc32bcea81f998a4bd8",
       "sha256": "0xcf5943efab73dfda55641c743514440b6245883a79b9e9ad0301f239b1592b9c",
       "urls": [
-        "bzzr://ca27a1103305a2ce56b0d44b9fab57dbfdb2c1a863aba3caa1c1422f081201a8",
         "dweb:/ipfs/QmNhXD6Y8G8q6Yn9v3RwTp7cxB6qDeKTzebB1ubVefbSUz"
       ]
     },
@@ -4411,7 +4070,6 @@
       "keccak256": "0xb8d9b384acce988ab469f21b86635bfcf863464861248fbe7fb606e1f99b6b46",
       "sha256": "0x21fdf2893d7b5a69a126a8016633af80e12af503a8199350ea81d20f0b2ec4a3",
       "urls": [
-        "bzzr://b307bea18c41236a6e5e7165a7cba2a471d3e45e2c2e6bc3ce32547ebe094756",
         "dweb:/ipfs/QmWPb3FySqqqM6fnDo991qpUXfRcFM8WXrhMHPUuneErzv"
       ]
     },
@@ -4424,7 +4082,6 @@
       "keccak256": "0xe5cd15e4d87a00e6ee7c316a71ea15d98a78434e65eca41f8132ccf058ee08a3",
       "sha256": "0x9b17778a7d64d731cacfba11551946ce23353acc0e07ea9b762dedfe17b1c423",
       "urls": [
-        "bzzr://300e5d57343cee348aa09401a4b80921e7a4a5d7710641062704792fd72eaf68",
         "dweb:/ipfs/QmcvjD8wYjq4zTQ8z8CAtDB1eYpSNUKeE91vpn5UFQaMJp"
       ]
     },
@@ -4437,7 +4094,6 @@
       "keccak256": "0x40b2a4be6694b9db98542e4a2c4c2672a03c8199fb576e755e2e5e6ac233358a",
       "sha256": "0x5aeab72c94108527f05aa19fb1386cd4dc4cfbbff8eec66493b63d0f685233c7",
       "urls": [
-        "bzzr://9bfd5c909d53a66c73ae9333fa9aa2bf2da47a2459388f96c592c15503c46d46",
         "dweb:/ipfs/QmQEyvHWHenGjVWMKTVEb1u2pDDXef7H4PNbvyMv9g1QBP"
       ]
     },
@@ -4450,7 +4106,6 @@
       "keccak256": "0xd6f2f5565e897bff40aab1aabe26627c223ebaa2fc3208aace7ed99cc76c5b48",
       "sha256": "0x7dffc4b8038902ca8a5fbef0ed18ed689d570d269bc1796a7ebf17824fbd48fb",
       "urls": [
-        "bzzr://903e0aab35348928b4694a294c8c61aad558fcbc6d086a680b1e3ead9ae53bc6",
         "dweb:/ipfs/QmZwsTFZCc2RFsxbB5yf6wrD6JrXS6JEUceserESUbiGQy"
       ]
     },
@@ -4463,7 +4118,6 @@
       "keccak256": "0xc7050009ead8d5e342c0abd753be3d94c275363c132ba9591284425672d1c60b",
       "sha256": "0xfb1d836a944b5c1a1936119215c13140c1c9c4bbffba29c013d5151a9706ca84",
       "urls": [
-        "bzzr://90dc3bf643d95d7e99a1c748a5d71b2f814fa7d5c40caf49f4362d8ecf64d860",
         "dweb:/ipfs/QmYTqpqE77JBMqn9sTtK6MGMKD5Kg9ZccUz6s6DWaaCtU8"
       ]
     },
@@ -4476,7 +4130,6 @@
       "keccak256": "0xe8651f23478fa1c8d2d67655fe0da4dd99606caed9284c4ccc432ebbf7b183fd",
       "sha256": "0x4d6955e1eed7deb07001eeeffe7121cd456e3c392f64e865f2393cb146646b43",
       "urls": [
-        "bzzr://f4c32fc63b1e3401b56cdbf77757bb8baccde042f49f5c461012c5ef20d3212c",
         "dweb:/ipfs/QmYYG41xTH37pnBbKNSobj28xL24CqJXyLjR9i9m7F88An"
       ]
     },
@@ -4489,7 +4142,6 @@
       "keccak256": "0xa334b5e85e431f21c4a8076d2e3070e1a27501b12b523743c62a9030b9b21009",
       "sha256": "0xab6014ad53913b50d752d424d4e97422aa80b861a7dd0ab3528a08ec45093b17",
       "urls": [
-        "bzzr://4449c6e01fcd93df2ec26de67d18148a7f3b817222409790e3183e440511bec0",
         "dweb:/ipfs/QmUBN7GvaYeqYDP4GDmRqhnKQmXr8DiLnN63GNxcuquced"
       ]
     },
@@ -4502,7 +4154,6 @@
       "keccak256": "0xa3d8441e1bf173f258489b346a23b2a2537c6b6f48d98cb5fd452a9469a2e096",
       "sha256": "0xe1d4ac60aa19077da2646a91338333fa4674627e19eb52d4e194ec9ac67dfc3b",
       "urls": [
-        "bzzr://1d7bf68f6c7dd3732893019b362e39bd6a2c449939a26899b2a571122519b9fe",
         "dweb:/ipfs/QmXfwVbSU1sX3DTASAvC9qmG9vSN7FiJUSit9xDUS33vV4"
       ]
     },
@@ -4515,7 +4166,6 @@
       "keccak256": "0x676d328a9388f2efb95649fe9dcfa612528c4b66c06ecae184beb72938f9612a",
       "sha256": "0xa633dd2d04697764baa0273318f30a74cf930371333995d6b15cd18746564c4e",
       "urls": [
-        "bzzr://17589f5a1b619e9652ee9997b3570bcae4b9690a4ac39aa81c31b9f474119f6b",
         "dweb:/ipfs/QmXr2ufnt7L7VqeD3RCjio7v5KqSKDqfQKxbmdUwHWK9q5"
       ]
     },
@@ -4528,7 +4178,6 @@
       "keccak256": "0x78248f50bcf191822a49dcc52d4ae67f90ece38ecb78e7791f6ae946f0e493d5",
       "sha256": "0x6c99cd6d642a1eaa6201e40ea9df9e30a7bdf7ed40e4d75b3dbcc4fff67a5a74",
       "urls": [
-        "bzzr://08080076abc848d6cf0cbe6f9f3381c6af86fe2fba9c3ab12aa806ddb025d5f7",
         "dweb:/ipfs/Qma6MfXnLQuHxKcygPvEhnS27dtHc4CTHpNuhhsjKf2j7E"
       ]
     },
@@ -4541,7 +4190,6 @@
       "keccak256": "0xa9ebc613d4a89abe9224d1262d42b11787e8ab8742a8727bbeceaa2d5ce0d133",
       "sha256": "0x868bb52b5932b6e47fc1e08f5463341f379f91ce12babb8fd011c004febaba24",
       "urls": [
-        "bzzr://79238d491e84955acf997518d2bf60ebf2313ad581bd348e7ddbfbed81ed2c2f",
         "dweb:/ipfs/QmTLVGwkJZxYTtSR8ChHCrK2iuQBjXh8SmFA1PFemegWBX"
       ]
     },
@@ -4553,7 +4201,6 @@
       "keccak256": "0x3dc0900782c03e034959cf33b5c5784265ed6e9daaa101b653f2038c2b12ac4c",
       "sha256": "0x83cbe2d5eea94bb7c37ad2f4f9827a67c133852468f8d7c69ea72b9bde0d4b48",
       "urls": [
-        "bzzr://6b69ee5d38284e52a0cc5d8f14c30b4ecc234fba2d77a4124a1f80f3bc5ed8ae",
         "dweb:/ipfs/QmdLDrvouSEwCy4gtJ5rmCdjjzDAF7XKt3sCpXbg19oyd2"
       ]
     },
@@ -4566,7 +4213,6 @@
       "keccak256": "0x66661e0c3954f25a1cbd863d5fe08eb7ae4078a4e3180d1e0fd38f8dedf7af1a",
       "sha256": "0xe8bc1807d075a0058ec5cae275e2586b0332f8008bb8696df326dfe7f000587e",
       "urls": [
-        "bzzr://22269fd15125cbcfd141a811efffeba5afbd7b5b005757d16c6cd22b3b105aad",
         "dweb:/ipfs/QmUD4w9aGLgeemqL79EJEAN2zfSfBB98j9SLrcHvsGW8nV"
       ]
     },
@@ -4579,7 +4225,6 @@
       "keccak256": "0xcf2856bd4125ab8991ebc07d88b68b2ce94336ded54d394faa09b2d23253ff3c",
       "sha256": "0x568969cfc662c57a9122c21115dda54b6f033fab0b1b703f763deb0977a5a791",
       "urls": [
-        "bzzr://3959762c33eabf268ad9e5a2eb469de360daa3f42f8a8fcd21e1832d5917c33d",
         "dweb:/ipfs/QmeWSYb2vi7Q4LsfymSJKLcq3Cxs9Sm4xXXEjVtyG3aG2i"
       ]
     },
@@ -4592,7 +4237,6 @@
       "keccak256": "0xfdf5ad170888daf701b640093c1f29f619af567c1fb8388a2509174004574dbe",
       "sha256": "0xb47a4376a3fecdeb3c16ac8901e306e24b9db4730d5301a90eafcbc2bad56c12",
       "urls": [
-        "bzzr://8532bdb22615fd5ce150b7e5273417bf6df37f03a0d4e8feb6c657d5be887f11",
         "dweb:/ipfs/QmXY7iJ1ekam1ngc3Zk5Y7Z5XKsv2zJ8s1LbJvJZ78wXb7"
       ]
     },
@@ -4605,7 +4249,6 @@
       "keccak256": "0xf839140a37e819995430f5accc898c38700a795aff043b761ee75a77be723043",
       "sha256": "0xbe615ba9c55b40f10c61e93313998ada421d20704208d2e69d171e66a7e09998",
       "urls": [
-        "bzzr://72439840a33a990b7800da33e74481f0838bb5b32d4cf5e13b8ec69d1d60923b",
         "dweb:/ipfs/QmUPTqU1g7QbsZkRohgfMSyX1UFkHq5nVwu43iAnDwTcwW"
       ]
     },
@@ -4618,7 +4261,6 @@
       "keccak256": "0x2285d48c0b390c4a0bebbf389b0b41f849ab85305548f70d2cced4a286f3b88b",
       "sha256": "0x21af3c8e6d8e28f44271d360fda055b59925da68176fb0b29d958a4e585b4cc1",
       "urls": [
-        "bzzr://7a042cf77acad01dc5a042f5088fd256f197c5827ea9a7c118bc6ae14e5a5744",
         "dweb:/ipfs/Qmb9sbvfGq76TzqDYWrKzmXGiJDtMoJY4c85rbv9khLTuH"
       ]
     },
@@ -4631,7 +4273,6 @@
       "keccak256": "0x0999516efe3123ae5a8b2d1aa57519e6585165e3e6f7fc039d5c23cecd0f93ca",
       "sha256": "0x9460991ba898231396237105f795959b80dada5bbf632b95374000abfb86558e",
       "urls": [
-        "bzzr://3a444131bc9e1a0c8d3f590a3d7a4908c86cda220bb61a23a05c5d3894c040dd",
         "dweb:/ipfs/QmXcZfL7ekwefSo17JWnbmpKYXDxtpF6B9XyVTFYTh17JT"
       ]
     },
@@ -4643,7 +4284,6 @@
       "keccak256": "0x4e9f4990d124fa4194a7c06006185d262cd19c47aef9b8a153a688ece674f11b",
       "sha256": "0x6e81a09fdf1c630b51a3d7ede35a828f02be2e3ed53d97d361267bc915d774ff",
       "urls": [
-        "bzzr://fd5e4ed25921655527030d42c49ec1ff5e638ec1d151c81978f9291405920141",
         "dweb:/ipfs/QmPtex161AWSwStCw77rUkjcoCh9RZudG1rM65utzHjyai"
       ]
     },
@@ -4655,7 +4295,6 @@
       "keccak256": "0xcf2f44568e9cbb0e2b9d2a23abc949bf9db5c6cf3e9d45408eb0fb0df28cf316",
       "sha256": "0xe654be6ccdfa6e4a80a25dd1183f9a6c1e8828089f400459117f38831fede0fc",
       "urls": [
-        "bzzr://9ef5e813839ffe0eda504e58a02476735b8467fde4e9768ecd87efe8ea84eb9c",
         "dweb:/ipfs/QmPV73GNxrjLQbhhK8mjW38BEn288WhLe3JyE9JEsYazkV"
       ]
     },
@@ -4668,7 +4307,6 @@
       "keccak256": "0x6ccab19bfed36cc956fb78c5345bfdfb2f61e68c77c576fd4fd58fd0a51e7fe8",
       "sha256": "0x43836089bafe86343f6b6899eecbf0a46d10bda37916fb88c3714083c037341b",
       "urls": [
-        "bzzr://9a0e07d1117f5ea7f72e5aed8ad64427bc5291c7469af65dac7d4d2075337598",
         "dweb:/ipfs/QmW2e2LQWvsPojjLJiRTeLNmFsQko4Ah1khFftTg7n5HV1"
       ]
     },
@@ -4681,7 +4319,6 @@
       "keccak256": "0xbf78cf8b6f718cc2e1fe0654817b7585b0a549b21ce0029795a4709e2bd3df64",
       "sha256": "0x1840808055f08ada82dd73043c42ee8f6ff267c8c52d1076b4c9a72a38e45924",
       "urls": [
-        "bzzr://271b1b93e86155b184e8c934f2b7f061359c9e4890e39f5ede175e67467fbff9",
         "dweb:/ipfs/QmTS8qd6XtcUhidoevtBP5MaNEnufLJf3Jo9HiXiUqCC2n"
       ]
     },
@@ -4694,7 +4331,6 @@
       "keccak256": "0x13b5c84092e72e58e56f4f279565e109d2102a9186db56e9f2845b983c78f282",
       "sha256": "0x308954d8a741266404c85e56f89c153d089969efd38015b5796b5ce345a61bbe",
       "urls": [
-        "bzzr://47ca38fe5104f09bb85ab95faaac478f5fb30d69978f1abd9ab94b755dc19baa",
         "dweb:/ipfs/Qmdb8vLsbHAgU46DKAL86fm8tAC5duegCkxYxEB73kb6LZ"
       ]
     },
@@ -4707,7 +4343,6 @@
       "keccak256": "0xbf86a60250d6c27e024bda2373134ac972c3d9ac9d9857c6574e32c5febb0bda",
       "sha256": "0xac2bfb0345c25e2bb36eb68c67c79539e62ccf0ccda0a2e6125df0efad915cf0",
       "urls": [
-        "bzzr://2f45ed7fdb9a2b825be4f6179213515e7979cc617a60f946de780dc1172c6231",
         "dweb:/ipfs/QmQZ84VkxFsRBsW8aB4T417STpQtk8GtsvLPcEJWgwFZpF"
       ]
     },
@@ -4720,7 +4355,6 @@
       "keccak256": "0x9193a7fc34b90eee5bcc81e9b3f64b057a9c456d836364d1a462ef9016485cad",
       "sha256": "0xaf49982d37555a08d08472ccf26c3a5fe130a9f2b47bbff0aee4c4e19de0e6c8",
       "urls": [
-        "bzzr://07f07fba8cbc9b89d325e8d508b15c0dfb3d59e20170f6b4fa84e3fa7220e45f",
         "dweb:/ipfs/QmTNWexfzrbxGmr27fh6qn5YGQSjdutqKDjyjjWsRrgEdt"
       ]
     },
@@ -4733,7 +4367,6 @@
       "keccak256": "0x4a1fe6c87abbf964e0b864b72b61ed04d8e75c560660034a70f5fee41c9513e6",
       "sha256": "0x47ae7a46c65ecd1782dfc6b2d22051745e804353d7449554c50240313edafe12",
       "urls": [
-        "bzzr://2e05375e1414d0a1beba3474b5f884544ab3b2d5af3f7ba929f042159db98b06",
         "dweb:/ipfs/QmQymEPUpaWyYzdMNfiJBvqifzSf9mWfczYTG6a26cQbNa"
       ]
     },
@@ -4746,7 +4379,6 @@
       "keccak256": "0x8928a0df8034c75d1f96005c041755b5f53f01787f16f10031788daed02e8ade",
       "sha256": "0x6b156c549032c7f1360cb08b14ce8c1bc0684419a38289929a2187bd09700aa8",
       "urls": [
-        "bzzr://e1a6df9b8a9c4dc9eff319655e191aeb6759899bc59792f094055691377426b8",
         "dweb:/ipfs/QmVzKACB1BN6VXLy1osPBktGV5ScQ55U9jyNdrn3wuX4FT"
       ]
     },
@@ -4759,7 +4391,6 @@
       "keccak256": "0x7c8b229aedf2b6dfc4703b443b8d70303b6d7a8c7aa9e58b1b0935ffe17e79de",
       "sha256": "0xce51184a83757993e0d5af77846f7340a29b4548c146490f50aa2c8b814c37ff",
       "urls": [
-        "bzzr://a1f6d53e1f897d084310930520e6d99ceb45e56b453b108b9047c043992315f4",
         "dweb:/ipfs/QmUssgUpDbqv48mZjknUiWPPkni4rqvoBKfRqP8J232aVG"
       ]
     },
@@ -4772,7 +4403,6 @@
       "keccak256": "0x39ec6359ff78907e1bdadd13988482a9c17a48cd9393c7ba97972b7687e2fb66",
       "sha256": "0x3b4c0b91d992ed11974a9558e2a37663309e09aef3452acf3ffaf4fa29f759ef",
       "urls": [
-        "bzzr://469a82fcb6847d839765be8855ba330df9978ffc7c056e40980d95c2dccc5333",
         "dweb:/ipfs/QmQ5CEvsAKHAtW9miHtxifcbumWiWNVe7YE6yoVjyivzK3"
       ]
     },
@@ -4785,7 +4415,6 @@
       "keccak256": "0x073603ba717fc6a3b73b9243b663b56b63555a550af582b004f69b097adf359f",
       "sha256": "0x2184a1a27ec7b2b5b7988159989c0be0145a43c6a9fa3a229f89ee32f3ae2490",
       "urls": [
-        "bzzr://25254e42db18fb06b25ac38e630c4a9b55abe90a04b0bd95e8fb170e9852c5fa",
         "dweb:/ipfs/QmQSQV63xnAKY2dHqEb5EoPDSKRCV5SgwsPREzF4TXLoJ7"
       ]
     },
@@ -4797,7 +4426,6 @@
       "keccak256": "0xffecfa33abaaa5c998672c7557947149b25b1e6d8c952fdc3f34fb50620ec100",
       "sha256": "0x6ebd370d42785bf3a3523b798d85b53711a0f7766c82a465420f67bf403bdd38",
       "urls": [
-        "bzzr://f42d52773526513cdbae2eab0a8c6ba2f87e3208c4950d7125b39dfbfa12c474",
         "dweb:/ipfs/QmaaMCL2gEYQTDiL5jkFT1iQNTgS6AUuL28JKmng2jscr5"
       ]
     },
@@ -4810,7 +4438,6 @@
       "keccak256": "0x32646b9823beb407b835a4a5c86736fdbd1da5cf46e4fae3657dd5686e7202d2",
       "sha256": "0x5d0dd0e79263e2e9746c8360fb0916cfa94b9b4f4aba1f8b93a26ae5896c777e",
       "urls": [
-        "bzzr://d6a08efd666e53763baef4aa83ba8f33fcf065f4735cd2b8de04b8463e4aa494",
         "dweb:/ipfs/QmdDSLeqHSxq8XyBJDh4hY2PkykRiNKFdfRb5VMg3wqMkd"
       ]
     },
@@ -4823,7 +4450,6 @@
       "keccak256": "0xda4cf2ddd866b86a25588304f77d4781b28f32107f81c03e873a2770fb938e37",
       "sha256": "0x3df48f3e0079e5f293805a1b79f7f29dde2dd4daea74735779a7de55c0b4f25a",
       "urls": [
-        "bzzr://0ebc98817b217b4a61584eb536ee8c640aa2ddfe6843883c35adfc18c38608ca",
         "dweb:/ipfs/QmcmEUZBU66sBdhtrFZ3Sj6g9uEVB7CEw7Pu6fVDbMpNGk"
       ]
     },
@@ -4836,7 +4462,6 @@
       "keccak256": "0x1d2a10d66c848c2c88df2c398bf92a94d104e069242e3201d3c86249628f845f",
       "sha256": "0xe90d0509f6fb3188c64bf001549b356a095e563011fe49df2589577274b51b5d",
       "urls": [
-        "bzzr://089ad4dc3fb0047644956ce60519de1a5eccffb554b73545b56f0940d7aa0721",
         "dweb:/ipfs/QmVCSsyTFJ7FFZ4T8rozS61PP1ohrpq7YCHzNMVfQcaow2"
       ]
     },
@@ -4849,7 +4474,6 @@
       "keccak256": "0x087bee61ca2e779c815c5efc22d57f03e3773cd404c9f1f894726602dbefb8ed",
       "sha256": "0xf6544af791e7747e89698967791a0fbd7dee52107298503f92c8db960d291ad5",
       "urls": [
-        "bzzr://8d328ebf8d486ceb9838bc3ee9510263595b4f63580d844db29c4d11eaed808d",
         "dweb:/ipfs/Qmd9QWL63NFZLJejvLLqJhJEHi8f2JwEovWgUJfP4GVT5x"
       ]
     },
@@ -4862,7 +4486,6 @@
       "keccak256": "0x32771950d3a03ef94153af28f4906291623625a91b0ccf841ee9aa31c80cf2fb",
       "sha256": "0xca79be6bf3b1df06fbd0b02dba5f06a752034c2c1be374917e9768aa4622dc82",
       "urls": [
-        "bzzr://a6610c4c4826fb592f6d577c0946a0dc19cc873cff451d1226a435eeea64c6de",
         "dweb:/ipfs/QmNdSa8qGwLmfbgN9tosa5Cp1yzRbYd2V724jNtpAqAmkV"
       ]
     },
@@ -4875,7 +4498,6 @@
       "keccak256": "0xb2678ba42a82bfb7754372900b04c672418806c53993d5065367db26fbab195b",
       "sha256": "0x4e21f8e7201b3526c4d6de1105a414ce348aa5a294527ecc4383b8f9ee353e5f",
       "urls": [
-        "bzzr://1439e5e833fbdd6149a460af5d677f5d96d193247ab665573af4e0e2722fafbc",
         "dweb:/ipfs/QmV7bFxe23yiE6HPguMf46nAu91tWAEWAqow52ithfbPpA"
       ]
     },
@@ -4888,7 +4510,6 @@
       "keccak256": "0xf2d009e23901ef2fe47fec9c13bf43e8d254ce8137bc962bf1387ea4940650d3",
       "sha256": "0x89368d4e1e277b58071aac21d192219d66ea74769385d639e14fddc8ba58b09d",
       "urls": [
-        "bzzr://089af9f9dab8b53199e3b55b58b873e9e0d24a2a86f713191c69368a58b6f0f7",
         "dweb:/ipfs/QmQDA1VJhRyH5VdpRQq9LvmdzopRvhwhMpUGxgHosJPwfv"
       ]
     },
@@ -4901,7 +4522,6 @@
       "keccak256": "0x966be33fb6140be87347e6e7a58bc57b226e02048849fee4bfe0e4b48089e46a",
       "sha256": "0xefc16621c60594f33b5dbd9d01f2d5c4b70eafab5e634a1e4a9c6d4c3e147fa6",
       "urls": [
-        "bzzr://41d93f6c3e59b05252dadbd24e82ccf04c16b486b7cb2591b4261cb64ddccf83",
         "dweb:/ipfs/QmWrESbKMeJcxs83Z3PUAg1DTbqTiLzJrttoNvZbDcuuCv"
       ]
     },
@@ -4914,7 +4534,6 @@
       "keccak256": "0xd732466dfd42dc86ca3c03022b039fa4790bf67b6ec6c222c19be9adac0caf0a",
       "sha256": "0x48333e6e6addca89a6613c0bd45218f5d7efc89e54c0b951f20cd1df0e72c44a",
       "urls": [
-        "bzzr://704eb95325ed8ad8ec1e80738554d50bb90cc8bfbfeaf69227af62aef96c5ec1",
         "dweb:/ipfs/QmdbU3cGZ3K8zWdYo7ZDwRfe9HnhhCeHUeXsdUyDkBr8Jc"
       ]
     },
@@ -4927,7 +4546,6 @@
       "keccak256": "0x4f8e3f0e040bf4da8ee6491ed37447cf4737755a508599f8347392a3d6b2ee02",
       "sha256": "0x4a0ea70c12e228954d74f95781bef9e7748738c2b1de98aea4081446a5cb6ecf",
       "urls": [
-        "bzzr://6f9d35d9d537dd47baacc14e84391e01c64bb4260bbc3e620fddfadb234ea0bc",
         "dweb:/ipfs/Qmcf94zP926fDCLyhTzEZzNjRPXNc5aEhcX3yyD3feCcf6"
       ]
     },
@@ -4940,7 +4558,6 @@
       "keccak256": "0x5ec4cf12fb863997382482cfb546b93dd35d65a7bf2cf559d6956a4150f2f843",
       "sha256": "0x10cac42b259578f4945ee1a664cf649e8c31405d5cf2f55cafea931eda3a54dd",
       "urls": [
-        "bzzr://881b9042097ea90799eab7b5540eef4b12ae20929968be443c7ce3d91cfde0b5",
         "dweb:/ipfs/QmUQ9118kQHnjzdPFajdS2SXJ4AcZqABAquPRqCSybkzGo"
       ]
     },
@@ -4953,7 +4570,6 @@
       "keccak256": "0x6f3924a1532246595b64df68c1501c4fa00372d17cd56cc7ed2fcc64d32801e8",
       "sha256": "0xd4868cbcdf87de523a395127e8c092c6735f1210fb5825e841c7f9b8b85261fd",
       "urls": [
-        "bzzr://2dfa95b68c259328201f89cf6a1dfa04b9302ca39252ff5c56fda932f3272391",
         "dweb:/ipfs/QmUvbfPmm6bYY9AJfxtUVbP1RQgtfFMnvkQmU98MA3JNTd"
       ]
     },
@@ -4966,7 +4582,6 @@
       "keccak256": "0x0db2092e152864af8a0e34e0be54b263f4688134b5f30447b0c3da0384a7d99a",
       "sha256": "0xa9f3b3052ecba20f89589bae48a5d8df4d3a82b5b5025f6110e636574d2c5fef",
       "urls": [
-        "bzzr://ee901e0938fa2c9e4fccfaaaf193b5fff22395b9e1a24044ef3b5b5f2fd7d2c2",
         "dweb:/ipfs/Qmcw1xNyXb4dstP4xUqNAwGvnHwamTJkLx8ReF2zvzVrfG"
       ]
     },
@@ -4979,7 +4594,6 @@
       "keccak256": "0xf554bd5deeca50b9c9935fbc5bb3791325b0bfb5cf48eb9c891f68aac654ff27",
       "sha256": "0x5814c115230eca659ae2b5adb803f7a12ec4c628efde902d725c170d0777589a",
       "urls": [
-        "bzzr://e1ee94911a8eed12fa6c2cdb201845218d5ab536d464e05b08dedf651977d504",
         "dweb:/ipfs/QmaYT37od5o5HEuaAmTFFGC28MFotY9v1NWaD2XmhUhf7T"
       ]
     },
@@ -4992,7 +4606,6 @@
       "keccak256": "0xd600038e6fb8483f6079a9b24d474ac22a9532e2b620b3203018f47e409aa591",
       "sha256": "0x43c94542d48b8755c1c3120502f8ff0b5c5061ffed4875a9656a5ff2412c6415",
       "urls": [
-        "bzzr://1f9b460163beb8d4041b5148a9140ca4a9fb69fc814acb00c4d93960caad60ac",
         "dweb:/ipfs/QmSfjCbNBwMw4Zk8dYxjV3saAqGKLUrfsDzbcNJfFbtdJg"
       ]
     },
@@ -5005,7 +4618,6 @@
       "keccak256": "0xe810004111bfab15f7d83cfef00648a35c5b549e57eeadbcfd046dd077d06835",
       "sha256": "0xba0606bd758ba58099a4e955e71360dbdf96145cf23ac3f9c11cadc2399949e4",
       "urls": [
-        "bzzr://d58ef91b868db4d8c414a0dc4240b5b7f21778aae7fd1a887a65ad537a01e717",
         "dweb:/ipfs/QmVTmxvG6vMjVvdDGiyVsnK5V7xTCZQZb5enqLxBmtGvEW"
       ]
     },
@@ -5017,7 +4629,6 @@
       "keccak256": "0x53d76fdde235668fe06b519bc6378aa6c8eea249fefb9bf84232801bb8c5dcdc",
       "sha256": "0xa52d6dddca6c3df5a6364cc11f93a6dd1c58e38e8c740f27e39f98e43cdaafce",
       "urls": [
-        "bzzr://8f0a94235a4a86bdf162270a3165570cba46e7d6646b84f6ed6bf857f9d1883c",
         "dweb:/ipfs/QmcuAtXyeJPJtmg4sxQgDw9BkMKFNK8YfRBFfHAX2ZrmX1"
       ]
     },
@@ -5030,7 +4641,6 @@
       "keccak256": "0x22695892d6698150c63ade14cd66d2f13aa02c75aef29424b693fb8d95100880",
       "sha256": "0x72f4464a3c2df6a8fcc8d7e4bab44b39ff87d9161d5f4e812e64c099cb5fff81",
       "urls": [
-        "bzzr://157eb9b64dc3d2a7d9b3cbc8a823e6b7080ce77dec2e22a1059295eb36be2e61",
         "dweb:/ipfs/QmSaJFLxcBiS2nYRBCHk86YNGwhCpYkbwz428tHv6sTtW2"
       ]
     },
@@ -5043,7 +4653,6 @@
       "keccak256": "0xb25c92c73236a1436ba7257ff011bf3ee9940eeda37061925344a51cbd2a8dca",
       "sha256": "0xaa47e2afc839a5d29ba75d7b3dc49788f6d131d58097dae487a37718a2a43ee3",
       "urls": [
-        "bzzr://d1dd18a662b2ec8f9537df3c0d826ff7c0d8a5fd9ba1dbb748c03f697e1e4d35",
         "dweb:/ipfs/QmQFT4vENSLmhEYqUybPuGXeSdf1JgJd8j72CrNEkGiqLh"
       ]
     },
@@ -5056,7 +4665,6 @@
       "keccak256": "0x791cb3900d34cf0feb1e61fb090a514b27d1524ba7f3f4ee96782c401faafcda",
       "sha256": "0x791b2310629203c721b92fa70b8673f379b1ab610e0d618f9bf4c1c7516daed9",
       "urls": [
-        "bzzr://d349309f3ee5c6bd648ec054b581749a0bafd92d9b574f2bbd5125ce653cadd2",
         "dweb:/ipfs/QmZ2UcBQPRNZuK2CwmNAKoJX7c6LMsg5tNzjwvpGzccXdi"
       ]
     },
@@ -5069,7 +4677,6 @@
       "keccak256": "0x3b99ad3c47b242b26f78b149ec2a39a81c846a41af00710267db9bb008ab697d",
       "sha256": "0x92c783f82e295082998f4418fa76fdd8233c7f052ff08e911a62fc0076651d1a",
       "urls": [
-        "bzzr://acc059a1d6c1c298d229a478996af2bf8383c3e0826569f5c22b41dee06b58fe",
         "dweb:/ipfs/QmPXz3sPRhJoCFtkkNpMyjDPXMZ9wA74RzNqhv4B8cSygd"
       ]
     },
@@ -5082,7 +4689,6 @@
       "keccak256": "0xd22c748020ecbe982f43ace2da6c40bd117fead7fc45f1785a9c67980709ec69",
       "sha256": "0xa1aab0b30879a9d743155b7d4be82a1db06482b8115001a55bd0ab9ae89e56fe",
       "urls": [
-        "bzzr://87e6312d421d45b4fb408bd349d43d955fc57b6beda8de1bb12cc3e65bc1acec",
         "dweb:/ipfs/QmT2j521VqAvrQqBbjHp39vpNPqeHdKWWc9D9sDW1jWd8K"
       ]
     },
@@ -5095,7 +4701,6 @@
       "keccak256": "0xbb465c729f6b28f661333aaf69ff2b090eb6d1cb4340babeb8f7fae616e55c33",
       "sha256": "0xe329ac76fc7710fc969a74c55159c40f41ebfb5351e1e373308b4bf073318b35",
       "urls": [
-        "bzzr://676459d6d4abec5ad993ff1c762c8ed627c2326c3c9ef8d8c9140fcbd5e8c964",
         "dweb:/ipfs/QmUGjdxq5umH1jXUGVP4zMbMe3th5ci3jioEuEYS8Zkg3F"
       ]
     },
@@ -5108,7 +4713,6 @@
       "keccak256": "0x3af650fc8a6185953f1e309133cc48f2f7001f8adcfc41d8316a5df342d324b7",
       "sha256": "0x5f005afc5bbadfa7b6bdcc85a2fee9f9fb4e6922122f9ceaf8b19a75896a2dbc",
       "urls": [
-        "bzzr://2d725abb42a0ff69fc8ca829a079192472e3c9ad7d3225885fc9338fa052219c",
         "dweb:/ipfs/QmSQoQ6iQjaoKUCa5Ro2BxYsVLX2n31u5rjAw2CWFt5j3r"
       ]
     },
@@ -5121,7 +4725,6 @@
       "keccak256": "0x51ba6c39681cb35d4802a82ec6cb55fe12bbc9df3a4b449008e335fb8cb97bc7",
       "sha256": "0x12c8a344b99448d455a06e20f76f15e9a7d6aadb0a3b533adf222bbc03452214",
       "urls": [
-        "bzzr://58d49cbf77635145489a573bf929f343f16ef03c7bcf0bff7517174643625d15",
         "dweb:/ipfs/QmNohfbVKtdnepEHwE4XJCqzeuuaMkCTMbfXFzx4fy4ECh"
       ]
     },
@@ -5134,7 +4737,6 @@
       "keccak256": "0x18cfdde57390bbf06053bcbb5af71f71bc555b2651e7cdeb7c2748afd2fe58a0",
       "sha256": "0xb8abd3bcd90989fcf440af5be2c1c4bb19cc6f232e732aa22eb15690da0290c0",
       "urls": [
-        "bzzr://81c090bd4b34720c52379ae5c7c5961da714dc9859183b8059e07d28893282dd",
         "dweb:/ipfs/QmTg8ePiYKpJjjzzMSAqn6p7zf6mUwyW2E2XsQR6QctoC6"
       ]
     },
@@ -5147,7 +4749,6 @@
       "keccak256": "0xfc44bbc1e08f4f302a73ee1b7f4f4a9d1d3deb2505a3f79263a09808796aa23a",
       "sha256": "0x25aeeaa8b807bef89f29f0c19f2b424f4606da7103fe4b8319a0e10c1dbf6bc3",
       "urls": [
-        "bzzr://293c31d326ee48258d4b80e9514975cc09b0e071d116524658780485ea64dd6f",
         "dweb:/ipfs/Qmc52r93CmSm1ASonShfPsM8qsPX7gRmKr3q4nP7nxtPyh"
       ]
     },
@@ -5160,7 +4761,6 @@
       "keccak256": "0x67b8ed5d098180f0900d9346c143cba27ca5f5f1a81259640ed47219a60cadd9",
       "sha256": "0xf38c59afe6de7a779b65533c947c1aa28b444ac3642c9d6987dd37a9671489d5",
       "urls": [
-        "bzzr://37b1357d0167f0cec09a827d7eb305651dade9bf4ab5a5310d6bc57126a14153",
         "dweb:/ipfs/QmNuQzUQXTbkQJCuTBDSgzQCtuEWhGp2VLek8iVg9Y5NKu"
       ]
     },
@@ -5173,7 +4773,6 @@
       "keccak256": "0x484de3067afecf01739135bf820efdc03e6c56a2dadcf8b5f1ed576b3a6b3384",
       "sha256": "0x013983d32e9cc9135835e1ea65ca9349ac74a19f8a31f0faf17c8ba508516dde",
       "urls": [
-        "bzzr://9e9556ef31118c4b515b47dd442d64e0160b2115bc731c713b0056af80dde8fc",
         "dweb:/ipfs/QmPMyYts3w86VJmTMZbMHzSs9wyHcVHGXaP4Yz1vxk3sdJ"
       ]
     },
@@ -5186,7 +4785,6 @@
       "keccak256": "0x0430395328e4bd3cc5b8f91f5a82f80bbbf340e6101277f071008296ce53a6b8",
       "sha256": "0x305ec4db2bf4ece357612b6628f9d972cdc59c9965b51364f91ee47545da5f5e",
       "urls": [
-        "bzzr://8df9ea914024f60f209a7fdd9741652696a35f2c07198c791df8e69f5e5e38ca",
         "dweb:/ipfs/QmRuPaDArtfkp3DbA3icjKmCUgR9RSKueZ5r3pA8CNRxMj"
       ]
     },
@@ -5199,7 +4797,6 @@
       "keccak256": "0x6dab883cb28eb37de2ca334515c79276a1e8ce196240a3dac8995212d9863009",
       "sha256": "0x2128e70d7ec85c2f99a5b9fd181de3b5800a82febcc61b9595cd94693e5755ad",
       "urls": [
-        "bzzr://492e649fead485d214bae5add602ba6811daa3e58e52bba03c7b4bab568be918",
         "dweb:/ipfs/QmQhYbiV9JWDA3y8cBKQBWGMqidpXJzv3a7j1ayRerZNbn"
       ]
     },
@@ -5212,7 +4809,6 @@
       "keccak256": "0xbc72773e3e7923807144fdb5e2f4f520cd729bccda710424d06b62008e237107",
       "sha256": "0x0d3859ad1e083d127c69686d32207a761bdf7354fc456e8e6540a3bc111f438e",
       "urls": [
-        "bzzr://c5951bc139ec0006596f892d0de95ec7f09e850b66769390056e9bf7a95708a0",
         "dweb:/ipfs/Qmeui7rZDUWEx2eQ6tJt8BAdZXGg7XQrJPp4R5ZsPRys72"
       ]
     },
@@ -5225,7 +4821,6 @@
       "keccak256": "0x6d85e74cb2ad3546422c9b6fc1900c794c3180ae2bf42a4c411f2e4e7f88859e",
       "sha256": "0xb8ea17dcd9d8c09aa5fcdadd8b2546ee49315a783c5b7b62fcb5b219a2873bf5",
       "urls": [
-        "bzzr://b32392dad43a479fd4ea15728aa9b27fef0e2aa9c7f20c5ea04e8b030fd9aec9",
         "dweb:/ipfs/QmRTrX29dHKfSNUr4Dd3LrGBEme9f35w1PF77ngjGkc6G7"
       ]
     },
@@ -5238,7 +4833,6 @@
       "keccak256": "0x96a4aae4a4fe1b0b0b7a0e6f6ec2475945b4964a660e464d10549dcbf8f50f69",
       "sha256": "0x329176d6951ee844a989b842496fce06e5d6d1cc8733fd25fef9db02f2600f75",
       "urls": [
-        "bzzr://c7bfa001848efe95a733c926b5aa512fb53bfa9c7ae188799a4d12d7eadbe6b5",
         "dweb:/ipfs/QmSWoiyy4QXsLRUxEwsnckFALLr2xFjEDmq72j5uMrztrr"
       ]
     },
@@ -5250,7 +4844,6 @@
       "keccak256": "0x0478b43de978b1af1d6d6d8c09e84cdb2cc8ed76218d38f17b841b6e539742f0",
       "sha256": "0x905e3d253406973f545666d79cd64c5c85985992f68fa35935f60249e311d74f",
       "urls": [
-        "bzzr://bacf94b83b539b0a704236daf9fd9083766905760e39d1372fdefad9a53ea26f",
         "dweb:/ipfs/QmbM3mus64QrXn7qdk7nyqedSwurLfKmS9L8a6rRop85NG"
       ]
     },
@@ -5263,7 +4856,6 @@
       "keccak256": "0x3bec52d85663767e9107ae2bc01f0cdefdacaaf66b13f1fd51b590d8564f2bc5",
       "sha256": "0xd48a1ba624096f5553448e54cfb19df205bce8484ba132d73b345910f6bb49f8",
       "urls": [
-        "bzzr://55188e5c9c4cca21df17b12a31812c913913f87dcd970e53265a6a589772c9aa",
         "dweb:/ipfs/QmPc3uFo9HqRFLm6uzTcs19rRzU8omFbF1NfxRrnkziKAg"
       ]
     },
@@ -5276,7 +4868,6 @@
       "keccak256": "0x8c102b7102df499c2eceee5b9d6a270f0c2b301cc892443e6fdc930ab941619c",
       "sha256": "0x21102667907928da81d246ab661f58e32320b30aa3090366bb09aeaefde3c2df",
       "urls": [
-        "bzzr://eb3daec21fd9d4693ceec909f71ee052a950a8b67d91e25ba9adecef48572c75",
         "dweb:/ipfs/QmUTb2NVWNBnSP435VGrWeGmPD7mT2JLBdHJC8Xjq88Bc1"
       ]
     },
@@ -5289,7 +4880,6 @@
       "keccak256": "0x336bcf9c87c4c9666dff0a2e51a75ee6446e28223420420a1f567bbe94a8724c",
       "sha256": "0x1411ccd6fc93fcfda607eb32a52e9099de9cc897e281981ede3f5af8e4f91747",
       "urls": [
-        "bzzr://5b75741798a25bb38e4b27d25a13e7b60c9113aa9c90866730f8900a9df1f3ab",
         "dweb:/ipfs/QmdCK1vDJ5qENoQZQPodho3jscvDiZcURMuWbAfDMWzCXf"
       ]
     },
@@ -5302,7 +4892,6 @@
       "keccak256": "0x8c4e7dc36b495c45e02e6aa42fe1ea63d23dd58135327a01f641d102e65c5729",
       "sha256": "0xc6405b1c1b3825a7beeb00200a6cdaa3268d776fd497997a88e59156e48d1579",
       "urls": [
-        "bzzr://6bed1cd7d82973b35fec0ee0c6f98a60cc5b660a9da732cdeb3374e560a49d1e",
         "dweb:/ipfs/QmUi4NFRD1wj648YAtNP6dJPW7xqLtdetb2Fe32WjpQCqv"
       ]
     },
@@ -5315,7 +4904,6 @@
       "keccak256": "0x37f142fb18a99748e3ae5f83fed7b82bb40b245deb2f1a7fc9c4666df005954e",
       "sha256": "0x00fcb6c35bb795672f9783b27b6ad181ad7ac1b30290efb4f9183dd4bf273b5a",
       "urls": [
-        "bzzr://25bc201ee1ec6fcbdf9dbc66d7b9b41bb7402a72e411acf7cb2d0d2cf9f4852f",
         "dweb:/ipfs/QmeYXSAFBdW9K4CkYE1oeL1isWGnadVp5nf5TfUjEBjicN"
       ]
     },
@@ -5328,7 +4916,6 @@
       "keccak256": "0xd65d81d8c911febfb1e5ad58e5cc74d972996593e9e4580bf49b14312578310b",
       "sha256": "0x2a9e898ea494ef038276f00e77bc8c527c8af17399d043bfb1d7f8dcc15ca1ac",
       "urls": [
-        "bzzr://b4f35b32ceb8e4cc6d65a9f078ea91c36021353946c17dcd81396b53e0abe131",
         "dweb:/ipfs/QmbeZkzHjexfPzWPNjcazcpf1xkzEYYoefXAbgUKXSHmST"
       ]
     },
@@ -5341,7 +4928,6 @@
       "keccak256": "0x3962de9bb630566af812e389b25190f4b71b23f1e214f144a8d09ce535064371",
       "sha256": "0xd547991a9165a4cb9a911a5dcec9da98f761253b39e0670a6cb318da3ff9f80f",
       "urls": [
-        "bzzr://10f44d5a3929ce878c5d59e7ee87c5e5e99086858a55443f01c0a5d84fca13bf",
         "dweb:/ipfs/QmeAZ1Ny73j2aGfZrsa2zkZr1CPWJ62JWsxmD1Sm4mCGpX"
       ]
     },
@@ -5354,7 +4940,6 @@
       "keccak256": "0x75727d3561e9dca2e12a8c7c0f9b3b307544bbb495639afd4a64a36493ffc4ff",
       "sha256": "0x04181934f4754fb6612568db01dc86976fcaeba0f2fca4d479b3972a7c55ce92",
       "urls": [
-        "bzzr://c50e68937d028019915dda43ff80e38c9ca42cd3eca7a43dbbdb5bafdd3f0e9c",
         "dweb:/ipfs/QmRvXrJ7RGv8KmBgaKKGmeg3Va96KFzeYxy23BZwxvJmKY"
       ]
     },
@@ -5367,7 +4952,6 @@
       "keccak256": "0xf960e5d09cca990d6423cde9f4dcf617e2043d432bdc3fe720704fd09b722404",
       "sha256": "0x189ba96df68d6c395b633feefd43a082f0ac86c01e2a4b1916c5a287cd9a8e99",
       "urls": [
-        "bzzr://6d34609929b1a70be6b1529a38da0e35f106f62fefc8569f04c239aa568a529d",
         "dweb:/ipfs/Qmbf1Y4tmEWDFnFy3k7KdzSyMEgnq4fQDRhF6TGJN1cbtE"
       ]
     },
@@ -5380,7 +4964,6 @@
       "keccak256": "0xc08c8407395edd767796ee02c9408782bda1774a7e4e07f05a1a990755e17863",
       "sha256": "0xb561171563905dbbf892516dfdaea28da6a8db28237fa6935931f67c4c223e4f",
       "urls": [
-        "bzzr://85337ef8a6cb02d3b3a7499dbd29c4c66ed76fc9e1eca3244ef508f8b57aabbc",
         "dweb:/ipfs/QmUcGawmDJx2svDUb5g8Gy6DNoFrdfotsram4XoXNWuM38"
       ]
     },
@@ -5393,7 +4976,6 @@
       "keccak256": "0x5702d0cc383e5c121f1deeb141f74508474a5dfbb6dd572bfba9b2d53938774f",
       "sha256": "0x2688846d14d6b2b3f30b78f0fda18ae8db51e07cd1da11cacd68ced1a047f0ef",
       "urls": [
-        "bzzr://7b48ed7ff3cc24b4fca970d785d88b95a3b8287a14f56cf1b3af925c19bcbc04",
         "dweb:/ipfs/QmYRsZHZQpNvVgaHDsXd3arUgXii3n8WZjaxepA1eVVCA2"
       ]
     },
@@ -5406,7 +4988,6 @@
       "keccak256": "0x831d55423d63d5fa69916a5eb0a1bf30cf3f4e782f9739d3f29d115b2b5cd58e",
       "sha256": "0xedeb15d5381a1fa616ad3a44c04ec1b17d570f4a9e889327722b9cc9cf6941de",
       "urls": [
-        "bzzr://65ff7ec4896383a5d7b18eb94129094e341e188e85bc17f9b5094769a34fdc22",
         "dweb:/ipfs/QmeNZRye1tcwW5PqY4ZXYhjfbdkaYbisMvHLNvhVw2MhCj"
       ]
     },
@@ -5419,7 +5000,6 @@
       "keccak256": "0x06256845062c4f8c47acd0e23437e4a264e9419ae833ee5b0fca622dccbf7535",
       "sha256": "0xaa8ebf41bfe73c45f172280c3245914e22200fe27ce04606f33550e049749719",
       "urls": [
-        "bzzr://4be62feddafe4200e058e9affb3dba7afec864cd8ce8d134fcd7b42abc04effb",
         "dweb:/ipfs/QmabDFA8BjeoUmWnJa6GhzWHwb3vWBXZ3kunAu4QyTRk6R"
       ]
     },
@@ -5432,7 +5012,6 @@
       "keccak256": "0x1707ec11e0d9e9cea65fb4b4995f470ce6929f8c1924ff628a1bea253756ff0c",
       "sha256": "0xb8f821ce76a967e7bac9f51e6d28e1f00c1e97f70afc502f64e3327df39bf0ca",
       "urls": [
-        "bzzr://91e7ef9afd0df85e3938d5747db58bdab1e82190046ed2f62387f8a9b6dea6b0",
         "dweb:/ipfs/QmZewTa6LiiThBWf8DT424Wno5wyt9e6MAX8rZqAy4oRbe"
       ]
     },
@@ -5445,7 +5024,6 @@
       "keccak256": "0x8aedc2f68b504bf9a15c42fdd20affd26d85cd2891ab3b77698a0bd64af80f77",
       "sha256": "0x9eb539e5169152ca76b45bddca918ed3644c8f8999589eb26edc9d64837e34dc",
       "urls": [
-        "bzzr://df538d814ebd4fee7b17e7911db42212acec4c774528e66a5b158118cd6634d6",
         "dweb:/ipfs/QmTZ4aMvtof8KrXpHi4wXA6q3r4woo2NgWPRB3nz3vsUsF"
       ]
     },
@@ -5458,7 +5036,6 @@
       "keccak256": "0xa0a10727124825451e8b5bab35d399f5251188f52dab275898abb6078c18b23e",
       "sha256": "0x92a5ecf12030d77d41c12b7d4a32d84221984da49c1d57f81ad4f7259b7676ab",
       "urls": [
-        "bzzr://965fa1c9a5d8afe6cbaa80c2b5d6e49764944dacd8e214b77819ac26bd1c535a",
         "dweb:/ipfs/QmWgBjnzRbxrff6hm15e8v6NJeZ896LZCyHMfN6iuuFBif"
       ]
     },
@@ -5471,7 +5048,6 @@
       "keccak256": "0x87503f9997b695249b68c93f5e6898366867892d86724e6471c5a8bb7117c31e",
       "sha256": "0x4cee7df8d5e1efbf30f44b489a99a3691ecc21576edc0615146ce6b317fd28f4",
       "urls": [
-        "bzzr://7d764109331fb91f62177fc530c436dd024a2995f4d19bad2d90dce2e74daa8c",
         "dweb:/ipfs/QmaAQrKCUACjHZG1UKqWnPwReRs35wEX1mvm8B1LtGudnw"
       ]
     },
@@ -5484,7 +5060,6 @@
       "keccak256": "0x0438e5a8ae5c55888ab8d468caa255d541bae0cc3921853c803b93793cf958dd",
       "sha256": "0x25b982acd295acb4d18fe2f5499bd517fc01ff44d24b3a319e7db0398db14606",
       "urls": [
-        "bzzr://3977fcaf1aaccb60dd45f7c155bb63e8b04ba81dd6c1faae16b3b7deabb8f567",
         "dweb:/ipfs/Qmcfr3NdK1p2irymHiHNd5BVqV5YvV1GLyi1gH4AsnDeQq"
       ]
     },
@@ -5497,7 +5072,6 @@
       "keccak256": "0x69b41820450d7b4a9570e3075ed18543b211c6b28e3c2044083f002c4d99ac7b",
       "sha256": "0x83667987815012ed72a4fc9d6f7153e33c777b4899e18e6e8c46385f8b00bd50",
       "urls": [
-        "bzzr://ef587b23ccb9405d34320066b2b4f9c0a773ff9756db43838b7317e1b2a2af92",
         "dweb:/ipfs/QmSs7ij6wEWatUZZeTRgLK9JqdMwUoxZPgCYBjJeZ916fz"
       ]
     },
@@ -5509,7 +5083,6 @@
       "keccak256": "0x96b6118bea8d3d97739b621e6b0838e3dff6aa407d6a90fa65e06997414f61f0",
       "sha256": "0x61071ed96228ac7b88ccb9c6eeae9a152daf6c06f19bb15b45b7ed22226a27e8",
       "urls": [
-        "bzzr://5431154a2587e9fcb5922a2490d755e0efa650e9347d084b5107fd5891e2fd57",
         "dweb:/ipfs/Qmf9oR491y62mr1s1KX2T5gTMFVtQL1Kiroa8Aga29iQXc"
       ]
     },
@@ -5522,7 +5095,6 @@
       "keccak256": "0x72fa6b890f45efdb5646c23aa8e3570033e0056f2750ddd58d47f597836bf880",
       "sha256": "0x01af09cd15a62a9bc0ca5c177e5627530fbe98be6214fdad58d77bb42d0bd84c",
       "urls": [
-        "bzzr://653071a44d598caffe21a6762532f585db5a54bf017b4503a2f18f14caa8a5fc",
         "dweb:/ipfs/QmXsUmJ7JjE5FZC486hEbgXRmEkA43xZ8zz1vDZNi5kaSU"
       ]
     },
@@ -5535,7 +5107,6 @@
       "keccak256": "0x564f83c1dce12e68f10f895f579b4670db5424e9c517bf3a8216c58c2e15da53",
       "sha256": "0x01b7d366d14cbbc6eb7a73ea6a8d9e38c081e575f3d264ceb060e43ffea25b31",
       "urls": [
-        "bzzr://cd087575312bf978e3f333e406d8dd83dca12ab3d994d055a2125d13ca25f962",
         "dweb:/ipfs/QmaN6482fd8AuxfYnKSC2tjobLTyY1eLAPV86CDdwvYTig"
       ]
     },
@@ -5548,7 +5119,6 @@
       "keccak256": "0x7d64f3c24546e161f847ba421e82d69885f3c7786fdd1a9bc17214688c10635d",
       "sha256": "0xfef244a2bc2fadcec90209b070daaa300e335fd3776ccb2c761b87637697b910",
       "urls": [
-        "bzzr://a86d290c7a4ba07d4c6b5a9fd4a403adb4cecfb364658b9a17f9ac5e4b75b3a5",
         "dweb:/ipfs/QmTk6Z4VFfjrWuzBPZG5NxwN1YE9VmWx9L25Twakrt76sy"
       ]
     },
@@ -5561,7 +5131,6 @@
       "keccak256": "0xf33b0646bd6e37278f4913d2ef6a0489d5d8d1232d220c19975235f110993236",
       "sha256": "0x142b0694bb8b7b20242f18bb18c17068dcdad4d45989524f7f68cfbd749e8d2f",
       "urls": [
-        "bzzr://41b05c78df9f5cd7f745f6242aab1ade8b87fb73583468e5cbab07b794caa339",
         "dweb:/ipfs/QmRRE2CDJZp91Y77pLTMJTnEVr4aYC95fRLaDBkbnnsE4M"
       ]
     },
@@ -5574,7 +5143,6 @@
       "keccak256": "0x13ada915c97acf29a43b345f51a3d417c7c825391cc66691458532dd57714c00",
       "sha256": "0x6491f056b07fd161c49dc985561eb844f2a3bd86ea6a61f0e6375e1a9f9804d0",
       "urls": [
-        "bzzr://2b1cef842e0038ef47940f3194c88bbb9fdb2e79813dcba2da92d04f785c6894",
         "dweb:/ipfs/Qmcf8jB1fD4iKaMbteMrN7MHY37Hv21oPhXSU9h7sJU2dP"
       ]
     },
@@ -5587,7 +5155,6 @@
       "keccak256": "0x589de5b03df6cb8b68294b8b7aa101a5bd729aa9dae105c87297a0bc14d00587",
       "sha256": "0x959e46ae4700cb9e7b58902f70595d3dfcf1fb13f07376f48d9a6c768a7fddba",
       "urls": [
-        "bzzr://0b1f839d7c0ec7c87df61c75a454139847e991136e41b3d09ace1e628f37287d",
         "dweb:/ipfs/QmeuFazCjQcRX1LHBhR3CGNaj8eAn9NLWAmFrmyhEGq1Ci"
       ]
     },
@@ -5600,7 +5167,6 @@
       "keccak256": "0xa7c7bebed1a7a4592fd17af555b532f5655c1254ada00b9f48f7b01d0dfe84da",
       "sha256": "0xa11b021e2ac8bc02844332133ba3cb66f2db5a54a255599806ac134a8b5f59a0",
       "urls": [
-        "bzzr://46aec9ac8a2b881e0c6d4892bee1152b7434ef45423b047f3667decc5995472f",
         "dweb:/ipfs/QmSLJ84RT2Ja6cozY5yoJq9TGgE1jZtrNYoAncWunnNUaZ"
       ]
     },
@@ -5613,7 +5179,6 @@
       "keccak256": "0xfb0366a873ef20a5b314fb8cc956d6e26ff3940f6ff70ad4dc13356587116008",
       "sha256": "0xd5c9d157e90dbfbef190a3ea13036bab777dc922d6070646fba93cfdf79143d9",
       "urls": [
-        "bzzr://af67da6982a7de585bc04854b2853e113a653b1ef8b213d95b9f5db85bc74577",
         "dweb:/ipfs/Qmb1L8MniG4pxY6ozhWPgs1g5RP6bYQFozG7g2j67a3sYJ"
       ]
     },
@@ -5626,7 +5191,6 @@
       "keccak256": "0x5101882e0546f1533703ae7df23d6270fa2a62e5ef9e3ac117138a99a8ac930a",
       "sha256": "0x226d4bb93dba8714463336c0bfd372cc4eadf694d256215c7edd5a7688d9f24d",
       "urls": [
-        "bzzr://854bfbe94a0b422fe0792c4062452d09f48c4a275d284558063c614c3f058715",
         "dweb:/ipfs/QmYdB3AVRBdU5E7HAPKi1tSDpeWi6snpGJDySaX7RJfoVf"
       ]
     },
@@ -5639,7 +5203,6 @@
       "keccak256": "0x236fb765e547f2a91f31393312658d68461b89675b3d5a73db128388420d6076",
       "sha256": "0x47db90330a94bc17b94d5bc3d280e65ed733c95ddc080ddc238570747adb3725",
       "urls": [
-        "bzzr://cf12d391adaf15ddf1acc91b956b2c09bba0736af6daf62c1f2b74106993de38",
         "dweb:/ipfs/QmbNedPjhtEseGfpHGu3YbidoxjHAVXXpQQ9YR5hMH8HPZ"
       ]
     },
@@ -5652,7 +5215,6 @@
       "keccak256": "0xa702c4f7a804af805707d4c430b23af1df0bda447c6911ef4985ccac98b98927",
       "sha256": "0x6d45e3178a08cbca278bbdae282a7387219b4cf2d12da5f9764c1feab2214359",
       "urls": [
-        "bzzr://7859b19ac846855e2b7d13198cae4076f429b0cb178226ecedc041a3ef80db3e",
         "dweb:/ipfs/QmTJDsr9KPVC1sLBmUAA5Wz7sBk5iaMsbquKctBgcM2zat"
       ]
     },
@@ -5665,7 +5227,6 @@
       "keccak256": "0x512e438bad37751848d4b554f0a50703adb7caaad28e9e00c2686740bf26fde3",
       "sha256": "0x447e5bfb25eefce6af40e94d85f44fa35a59aceeb4249c5052148ee587996ffe",
       "urls": [
-        "bzzr://4144ee051b41c09563c20410a9ab9902d1f6ac0135a7adbfc47881c0be8e1242",
         "dweb:/ipfs/QmfT2MPEKoZCjWGGvRoUn2YyhdDrNKnv2bxN8SySsyU95G"
       ]
     },
@@ -5678,7 +5239,6 @@
       "keccak256": "0xfe4e9faafb7972fc2909a32bbd0ff45b32637faa1a31a7a47197eab1cb592549",
       "sha256": "0xd3923c14c59c6cdca8cbdc37989e268c964a415c383794ca1399fc779c00d2a9",
       "urls": [
-        "bzzr://efcf95ca3805faf85bcd6729f41f3ad1a560f843eecd32bc6aeb364a13aef9d3",
         "dweb:/ipfs/QmeTwpTv9Fy3CeRHFa5hGeYXQ914v88v4F7LsHFMQSzrTE"
       ]
     },
@@ -5691,7 +5251,6 @@
       "keccak256": "0xd14d3d240b75cdd330ee838ffa27c2c68268ee1f355b78783b3f07ee68fad3af",
       "sha256": "0x12d331413094130c3d0b01911012b4df0889d34afa9c6dd73d24ec09282c7a1d",
       "urls": [
-        "bzzr://5b8727a2990706f28b3d4cf157add49320d7164af26974a3c16704a4361d840c",
         "dweb:/ipfs/QmbBjkjch29vaK592VXPuKaYGyEL8RLqY6z47ATo6TrLc3"
       ]
     },
@@ -5704,7 +5263,6 @@
       "keccak256": "0x5226cf597b93edd5a17f48d225e0ef1f6aee60a536f6064351fef61b303fc170",
       "sha256": "0x200b3317f87f6b655edd285907348de7958d112f260792342c5f242ac7ac45b2",
       "urls": [
-        "bzzr://b35a1295ef8f7ed8cc802bdf4160d903da960153e6531dc84a6903b572d350e7",
         "dweb:/ipfs/QmdHRCeGGFiwJjmgWrtbahVYmDSRJncjNxeQFyV4Xai4Bc"
       ]
     },
@@ -5717,7 +5275,6 @@
       "keccak256": "0xac4418c0b5799bddfcd78cd355b16e5c5f1f599742cb3fe1e6f32c87fe935cc4",
       "sha256": "0x6eb8fd5850a8db146462704b52177b7e5abd2b73f69622d572abd7b388334342",
       "urls": [
-        "bzzr://44a558d10031cd4fc13582b8e10a2cfd4ec653485a8ba94da3f30dea24a07ea7",
         "dweb:/ipfs/QmUkLRa6MMyiEeFCkmGktbUPW44WmED7xeyaknBZfhEpyG"
       ]
     },
@@ -5730,7 +5287,6 @@
       "keccak256": "0x458c9136301b4fd6951f1ede9731b6a2f8b8b289179865a231449419b3d3c0ec",
       "sha256": "0x58dbe7043eff36fd086098601b96165c9b060a56729724170597ae5bdf3eb0c9",
       "urls": [
-        "bzzr://d45d8337ac659d43f409ad21a0da162bc0d1ca3ff771a326934e538350da148b",
         "dweb:/ipfs/QmXF5ncXuThMXSsVrYRTAJuJenyP9hA7sXEaSBWzS3iEdx"
       ]
     },
@@ -5743,7 +5299,6 @@
       "keccak256": "0x6107351ccc22ca65557dee311527ae0ca66e2f68cacec5924803592792ab5344",
       "sha256": "0xa59dc57c9e6c677dcf41758fc3296cdd490bfda3dd2a59ceba4afcc3a8d64e9b",
       "urls": [
-        "bzzr://28be1f82df0d1e405bdc1b4a16c99aef785aaf91f0dba24f567e0706230ba200",
         "dweb:/ipfs/QmTGauwMdAXgor9ce2qmzSoLJfKGxXPSmdbU6P3FkzZB3n"
       ]
     },
@@ -5756,7 +5311,6 @@
       "keccak256": "0x400b7161fb03b5158df60813b6d25eb0efc7a05928560352f71d01a204759fea",
       "sha256": "0xfe756017c3d464b5812e251183f71fbc54826abc7d66beecc0dfafae990492ee",
       "urls": [
-        "bzzr://48e7eaaed53cbbdf2629ebed16aa4b3994633d2dc3e712fb82e17c8ecffb978a",
         "dweb:/ipfs/QmaAoutDiQpPL7cfLkUAsJyexMWuC4NBb2jAYd18PfjgR2"
       ]
     },
@@ -5769,7 +5323,6 @@
       "keccak256": "0x09be7ee37ef342637bb4e9c2cf1e8ccafdde88f7265e52a09bd04632c10627c4",
       "sha256": "0x4da5c414489f4eb8832c8cb3152292b4b7b09836b4d3f80f7e8671a1093b3de8",
       "urls": [
-        "bzzr://90d9c722c9bc478d0c3c8a35925d83e7be454ec8b5e6e9e79ec3f334270bacfe",
         "dweb:/ipfs/QmezRLcQYfrZXT1MkNc6dFcHgT53oA8ykPnLf5Ekm2LdwW"
       ]
     },
@@ -5782,7 +5335,6 @@
       "keccak256": "0xe3f86e366fad4d74902654b500dc6df5f3e122ea6ec2b76a85bf4c720f47b1ed",
       "sha256": "0x56c937b30233bcb2e5090e4f886b0be17657d0d5db7f7d55843842cf3ef19020",
       "urls": [
-        "bzzr://1b4c7936bc7e4ad9a4b5c93f17de6c03303ef94693eb0766ad6dca05caffcecd",
         "dweb:/ipfs/QmNvgYGKA5DGGb4ZFqVrRhPzF6SWKAyrVLiyhaJZzoCxhH"
       ]
     },
@@ -5795,7 +5347,6 @@
       "keccak256": "0x8b4ab1fb31b415585869089f830f61a4982282c731a1873d47a6610126603a62",
       "sha256": "0x386bd4815c753e9258328c2a40c6caa62cc8c84e1a7204098343dfdd4742476e",
       "urls": [
-        "bzzr://50c2e324fd10fbe7a2ffb1dd454148f53a3d15b7b1ae5c8c54c8b3366d0da506",
         "dweb:/ipfs/QmWBZqe1XRu8nxwUe65oYmKtGsbFzUsJs6yEfb7hc7Phbc"
       ]
     },
@@ -5808,7 +5359,6 @@
       "keccak256": "0x1b4a45db77b79052eb4cc04dbe981a60991ab51735c8c1f66fccd7bf8eab3875",
       "sha256": "0x9901cfda8643fbe095e746582b5033e0f6be957ce214ba3424a92799f14fae36",
       "urls": [
-        "bzzr://26cd13683cfb44b881d44c96cd2833f6dc678a8d3b48c8a30328c4100fbc37be",
         "dweb:/ipfs/QmShsiKBCHVL896o9HQUPGLzzXTCGkWdr7kGZeLt7j2Bi8"
       ]
     },
@@ -5821,7 +5371,6 @@
       "keccak256": "0x8e2d4bbd6294e6073f938dced44f383372d943ddd847f1635746015ea169b600",
       "sha256": "0x1d0609607d0b6b6c5607d0d71f601100e0b602c368c7f6e0a6e83a42edced231",
       "urls": [
-        "bzzr://10a2ed5fcede9ddae1c1e3d1b0f322a6b4943c75c9106f16df71d27a50c83b1b",
         "dweb:/ipfs/Qma7SrKbdA76AMoWvgn6Ny6XSuN3typbsenrJ496WHDyNr"
       ]
     },
@@ -5834,7 +5383,6 @@
       "keccak256": "0x0754a09e115324818bfede345ee6398ce04698b6d1ac8aa3fa97ab8fe2a97d61",
       "sha256": "0x79b12c7deb440e0c1fc32bf5f84003140b9eb568bb325d33602a906481a06a14",
       "urls": [
-        "bzzr://264fc72a259070ba7d18b89731bdfe80001a68aa68f855a0c4de8cc6f7c8959a",
         "dweb:/ipfs/Qmd5P2EDjSp2m1sAtoEvvDrqsUiHNN5KsoBnAJfpcPQXVm"
       ]
     },
@@ -5847,7 +5395,6 @@
       "keccak256": "0x1a9be339d7144634148daa07b2d9fa76965656c77b1e84369f62fee0b6d8e488",
       "sha256": "0xdb910441cc9852400c2f5b07a36f5dc18694fb450c050750fdaa769ce4116697",
       "urls": [
-        "bzzr://8ae74219f0ff969f09e37c41a62d1de01818ade8c79d2d54a6bff878d17fe39e",
         "dweb:/ipfs/QmfEkjL1qmrvqWNgiAVRe999vkvwFUNEugRiwU62tMStj2"
       ]
     },
@@ -5860,7 +5407,6 @@
       "keccak256": "0x505b1fc02f8d242e88fc301469ba9734540e7a12f7bf96d1dbc2e318a9036e2d",
       "sha256": "0x29507b37c0571be5ddfe65e494e9089d3965c44295761835b81689e38abe26fe",
       "urls": [
-        "bzzr://b40f645b3c411dd0b64a57585345045ad9cc2f91a14b4d95ca5ecc835fa7dd7a",
         "dweb:/ipfs/QmQMDVtxD7Uku78k3aHd31DSkvmLVj6cTXeioej28q1JwU"
       ]
     },
@@ -5873,7 +5419,6 @@
       "keccak256": "0x34a439b85ca68891d1d3caa5586764cd1c52204be73a5aae3af73b70cf2f1582",
       "sha256": "0x1223ff8a7a8515ddb84def268146483e9998da3bbef35c7bf3d2bb1d8b5ee136",
       "urls": [
-        "bzzr://542f2e9f7e2f174ebab25c75deabe321e46ff03f31315cbb04ef8dbe1545e710",
         "dweb:/ipfs/Qmc5cJozpDvu6gdUNQYmBeAmKfCvaEenNiFvu7qWUCJ526"
       ]
     },
@@ -5886,7 +5431,6 @@
       "keccak256": "0xc7336b7c81862829933d2a84f21793861c5d2ae77702fd2537890a2a62e0daa3",
       "sha256": "0xa3efc7db1f01ec591a0abbf598f46c75bc8fee1718d57d4d21a4fe0bbc8f4d7d",
       "urls": [
-        "bzzr://066ce9dce8c78e2141b32e074c16dc8bc61254f3c6e815e87c2296856a0bf69e",
         "dweb:/ipfs/QmZNykgxUFvBkFWNdZvdWo2NB53h4jjzTdooZh5VqDKWfX"
       ]
     },
@@ -5899,7 +5443,6 @@
       "keccak256": "0xb6e882e594150b886e120a0a6d3a91444d7dc1fe75bcb397f171914afc7b6607",
       "sha256": "0xc8ae386e328c582c1994e78b125094421a1e5c1e4d3de88da753de4881237d38",
       "urls": [
-        "bzzr://6356ee57cd560834a5747981293838c723e30bb0d3fca31f4b87c276915d47b9",
         "dweb:/ipfs/QmUS3qY8wp8esjLEBUgunQFzANFC9ktcPpgpVJwUZeSZyM"
       ]
     },
@@ -5911,7 +5454,6 @@
       "keccak256": "0xa4d676d718f45f3b81140bd4c3b2e8781b8fdd38203f61a344577ab95bcd89f6",
       "sha256": "0x2dbd26d82bae11c5469c5a4cc6c04d96e8fa0d6c3e1a98052133840794ed28f6",
       "urls": [
-        "bzzr://58b337aa6762473f084d0065040044a29f072e8d6ac47066cdeffc6d04d5473e",
         "dweb:/ipfs/QmTkdw7j3gsegBPSb2HeN5vykkHRwEQqSjQoAWyy3bR4bb"
       ]
     },
@@ -5924,7 +5466,6 @@
       "keccak256": "0x8115861d77a2452bdd782cae35d1944b7a5e8919e74eb7c1ce7d59b8fb43ddea",
       "sha256": "0x4695e31411926da9baaecc890d5c9aac414bb91f6532eb1bace3aecb48d304d0",
       "urls": [
-        "bzzr://47917aa7d979355c95799cd9368f1bc2810808b7584c3dace95339ab28a957a8",
         "dweb:/ipfs/QmZ5RKFPkGgB5JFK2ZTYZk7NENN2JJQgZdk1wCKj4KFqps"
       ]
     },
@@ -5937,7 +5478,6 @@
       "keccak256": "0x12d0d2261be29ce7d8c398b17f9b115ce370f3e1c864913239ee31ce10dfdf97",
       "sha256": "0x4831762d8feedd70cf6d74309c775cf1769dec6efb431db6dcbff82d333ab11e",
       "urls": [
-        "bzzr://9bac688fd880d77d6d9205501b688486a1d33120690a9131aa85244b1bd65cdf",
         "dweb:/ipfs/QmULWzkaAKx7FeKBRx3sNKSM4JFgWKMwWT5stjADYD75c8"
       ]
     },
@@ -5950,7 +5490,6 @@
       "keccak256": "0x51e400364f99c5645e631e3896ebf4f9dfe953cecd54820034e8a6379045d49f",
       "sha256": "0x5212f5a53a3e78eedd680fd9480b2d1a23f6d0ef81932d296535597b511d6617",
       "urls": [
-        "bzzr://790d6efc37cccd042271fec6b3b190fb3233514a4f909b087af5c1f768cb7475",
         "dweb:/ipfs/QmddZvCJ26uzmeiXW1p7iCDxK2LsKtCd4ZGRi8KKpXXDuZ"
       ]
     },
@@ -5963,7 +5502,6 @@
       "keccak256": "0x19a4daeaea6e18ab2302a2c4f29dea87139995370fc7b07b634549794d23f2c5",
       "sha256": "0x01d169302c793339808e06a1b1475c84f5adc22eedde5e28ffc4e1d039aa8abb",
       "urls": [
-        "bzzr://cee0acac6345d58ac55e8bb86e8917b28dd3417d9b6cca8494b3337cb2e9f262",
         "dweb:/ipfs/QmaCywfCkaZsQ4CfpB3VsEuLVioCETqe9DPMhQX7vQsTrv"
       ]
     },
@@ -5976,7 +5514,6 @@
       "keccak256": "0xd069746e4ee386e75f9710b4ad45394d903b763a3bb78baf0a2b094f299903be",
       "sha256": "0x87920ff2cdadc1e9844066425062c0c17300a5c41115ad68fd2254ca891cb16f",
       "urls": [
-        "bzzr://93fe7bbf49fd1161d1fa340fc2bf74a633c3199b3181fb7e22d2ba7a63c33b5e",
         "dweb:/ipfs/QmReJzPtVy5ei81V8823u3fN45ge4EJddJGB78L3RttSof"
       ]
     },
@@ -5989,7 +5526,6 @@
       "keccak256": "0x3b0999c1bfc2c4239107134da7e952e206af34be964419a3ed1a573cb3df4405",
       "sha256": "0x35f206a38f79a939e7db953e0a05b126428bb19e77389d21257651b4ec63f317",
       "urls": [
-        "bzzr://e6733d2d3c5c0f34abc3bd00d37402c0b2078c6ed6b347f7d5b2ac156930dba4",
         "dweb:/ipfs/QmVxriZ5ycGPBhvMMpGZ3VSUtrxpagrmd4h8ZcwhNzPxMg"
       ]
     },
@@ -6002,7 +5538,6 @@
       "keccak256": "0x570947b969f67d83aee69bb22b89ade6214907b784ab25ed75fc80e6f7dbe6ca",
       "sha256": "0x06b68017f30744ecd17e2fb427205538847229efa8b27705db4433c308fddbf9",
       "urls": [
-        "bzzr://ebd0c3279e4630f2017632a00bdcd8dd523dedf6a60d6bc5f64aa1d1b9b3da25",
         "dweb:/ipfs/QmYZbPpBbpGzPJsYuw3hiG8YT1co4SwNgBUBzoViv8vfRT"
       ]
     },
@@ -6015,7 +5550,6 @@
       "keccak256": "0x4d73bf4f2e64ac931321cbb0ab63a262278b7125333ba6c474f9ef92133bebdc",
       "sha256": "0x94db4ed24a5ff3120374acda161630187d95d931ae8d98270645cb1b7cfd58a7",
       "urls": [
-        "bzzr://d1812ea940a0f918b87f5bbef6f2ed54007679fc8cca4203eee143dc20bed76d",
         "dweb:/ipfs/QmTPfqMTccCECtc79TGLRfWTk8HnaUpoP5tvrFmpxdasSs"
       ]
     },
@@ -6028,7 +5562,6 @@
       "keccak256": "0x178002bf29983242916b73eae89c37a00294a1608dafd073a525cf6e94978447",
       "sha256": "0xf7a24d0b12f9bd2545f6a8e54ad56ac4f3a2c614da0d40c9eead3f803b061234",
       "urls": [
-        "bzzr://0ad95eab48fa45ab8f5dae8abdc1168fa6c500af96dd58956ea88a8edb1422ee",
         "dweb:/ipfs/QmUqQJC3aArXjpsvH6cchcghsmdVrgLjDRh8fWCJ4JyhJY"
       ]
     },
@@ -6041,7 +5574,6 @@
       "keccak256": "0x4bc350add0fdb101a8cee12dadfb2336eea26a4527b43d0ad808bcff940254d8",
       "sha256": "0x28bd8245d87959cd74d889980055791565ace0fdab2ca1f4627bc42ea90e4c84",
       "urls": [
-        "bzzr://ad3d91a6d6458763c9afb6e46f1b7b38c0f26cb930dc52205f6ab12b4062e78d",
         "dweb:/ipfs/QmRMAUjdLJufxPCbwZJKjFfssPb6WTTRTdvLhRUAKcH3i6"
       ]
     },
@@ -6054,7 +5586,6 @@
       "keccak256": "0x37b0955799e58b115357630480a67623de7e9745cb06e4ba018b6d98f076d09f",
       "sha256": "0xb7abc2b7f62be2f61dfe612708432e7a9fcd5ff55b892bc1d875af4e69e3fde8",
       "urls": [
-        "bzzr://13c29516ba5e2afd172041e5640292b3a25d35883a11c4e053d195961983e91a",
         "dweb:/ipfs/QmfDhwGYkJsapJ7KSk7WGQBPMaA6WKioJE6gT9A7RBRDkJ"
       ]
     },
@@ -6067,7 +5598,6 @@
       "keccak256": "0xe023567a19ea835608655477df4f19301fe043991ac8299aa15d2d0065836768",
       "sha256": "0x8ffe3622660c0bfb1ee6d660e7d119ac702b4cece9107a4265a8c27a8baeb642",
       "urls": [
-        "bzzr://16715e83cfd91c1b3fd4ca699a55c1d92fa5f9411fb10628a36f6955cbec3e82",
         "dweb:/ipfs/QmUGGNf1SAX2mybQJ9ZeX5FLQJRJrEcf3Gz9bQR2MNyoKq"
       ]
     },
@@ -6080,7 +5610,6 @@
       "keccak256": "0x4f8c7ef4f266bc8cbd83d85e9fef8aed32ab643e435a66f72d5b5dec6f725b0e",
       "sha256": "0x52d30d418cfed12af199589c2b6a07f8c2bff030449c490a7018c2a80f7a033a",
       "urls": [
-        "bzzr://2ab18957a5d580396da76f9ed08e0173301a165a9277c4fc2529e1eadbde9446",
         "dweb:/ipfs/QmWMhy2w7aDm75X9ha9oNgZgBTrCuge6DzeR77YxqRCsrk"
       ]
     },
@@ -6093,7 +5622,6 @@
       "keccak256": "0x07242c4463dba168ba5c94d5f69a010eef0bbcc7429952603b6304411b5f56e1",
       "sha256": "0xc38c09222a31cdc7beaff63b23f537b25309ad923b774eff95273f427e5b9b8e",
       "urls": [
-        "bzzr://4f91bb5f2b64b348c825897cc5ed1c194d72104cb98ceef46870ff731a19a61a",
         "dweb:/ipfs/QmXc7cGaGGDEkstw9DUoxv6s6mC68B3vEcMqfQBbPL4MhZ"
       ]
     },
@@ -6106,7 +5634,6 @@
       "keccak256": "0x0b47d5f52269fc0c2c4911fb09f614ab57848cdce255974574659b81d923bfb4",
       "sha256": "0x8a171f6344b698a08dbf065eefc42b487c89c6b1685ccfdec57cbb5838e844cd",
       "urls": [
-        "bzzr://ff2b007152215bc9f138c792084c4f60933be3f4ed77a3fedab59638dac43ff4",
         "dweb:/ipfs/QmTEudf1kKFEk8hDf8pUg4NJhXYGLU2wctE5bVN3isjkJV"
       ]
     },
@@ -6118,7 +5645,6 @@
       "keccak256": "0x0d044f67281d5901da07f83548e017f9843870c7a75adc81b8c3b3204a34cd0c",
       "sha256": "0xc58b63408782a254767d1513bd20febfcda3e611a76932279d0ed507900cdc67",
       "urls": [
-        "bzzr://254e82a618047b9c6796caf7538907eb38dfcb8f1c43b0f6b219b9b4c87c8cec",
         "dweb:/ipfs/Qmb8HU6YHA26wxAWXSyMLFgDC5AZsNFpFrjphftsqGc9cb"
       ]
     },
@@ -6131,7 +5657,6 @@
       "keccak256": "0xbd1f64e62bcb97317d94a4451f468aa6403bb0e02afcc0c1096233588977a219",
       "sha256": "0x0115bc2f605764d9cf12cc12751bd1bd87eea0c1c22b4825599446e2b2e99ed3",
       "urls": [
-        "bzzr://23baec38d8a75682f2be7fd5b4b7febc69ba0e686923bd6862fe4e56780e3442",
         "dweb:/ipfs/QmWswg8TsLqEMiWJLk1iLcj8SYmZRMWxzAgzXBVV2bhbi1"
       ]
     },
@@ -6144,7 +5669,6 @@
       "keccak256": "0xe5ed1c927d67c3b168102d979c62b16faf32cff9886c340ffffe154214eeec05",
       "sha256": "0x603cd6e462bdc4139f3681f64a5dfb842168209b5b65d06961a9e5faa5bd919a",
       "urls": [
-        "bzzr://b9532c2306066545bfb136a8b18d9062b1b216cc1ad6de38a21913ea06eeae20",
         "dweb:/ipfs/QmV9cfoRm1wobpu4FE9WQHhiYTbvoFdgEUS8i16n13Q7Ww"
       ]
     },
@@ -6157,7 +5681,6 @@
       "keccak256": "0x56092d977f54bdc788bbf18fc60c45466ec36c95a6e888b15d46a8e58a3a0183",
       "sha256": "0xed5166b3d6310e30dd13231d84026b79da250734f73854f3d0055ba3ae526d26",
       "urls": [
-        "bzzr://52f602ba4508758b030e13de8782cd199961f96289c609157cd15dc39d401f08",
         "dweb:/ipfs/QmR7ry3EmKBWkz6moeP8imz7JrLgDYNNMaoX2Amw5hEQWU"
       ]
     },
@@ -6170,7 +5693,6 @@
       "keccak256": "0x9fafcef4437ea3837952a86e039ac5ad14499eab956708079a82664d757ac82d",
       "sha256": "0x184debb28d193a59b318b4e526ed81539c41f8db287337bb561e45da53cbb683",
       "urls": [
-        "bzzr://59138c10076c218493170052aa9209273a77d9023dffac87cf1ea2ed26504ec7",
         "dweb:/ipfs/QmfT9vArbVx97KgxfsTbkXy57y7LG81oXdp9TnzZbNsxXi"
       ]
     },
@@ -6183,7 +5705,6 @@
       "keccak256": "0xe1f87ed62225a48f014fcffce23dcf7579c38ab30b829c7559cc3448b1831609",
       "sha256": "0xb3d39d859924e3efaaa941cc753820a9a5a394d4f5947e25577395d7b04b4e08",
       "urls": [
-        "bzzr://1b897f2df9dac09096c83a0e2cbcfd989e0d8afe53713a1f12f84a8fd8bf4486",
         "dweb:/ipfs/QmQeq3a9pVu7sFcz9vhxZnEDdbCsGkfmEbUXVNEHFdhEKo"
       ]
     },
@@ -6196,7 +5717,6 @@
       "keccak256": "0x1c1e3e162389885603114ac6e25bff043ae6b5ad62b26d115c69bdd32e418322",
       "sha256": "0x1ff485fe74966022dc1cb61bf69e67a209634f22bcdc04921705671fb3da23ac",
       "urls": [
-        "bzzr://310cb806e5fc4836643f82770a75498ba181ff3412208c4047045ab304f98dbb",
         "dweb:/ipfs/QmQZZuUe9GTrCvcXB937CQrimBVJzFLhcKaNM2gJsSdAcs"
       ]
     },
@@ -6209,7 +5729,6 @@
       "keccak256": "0xbfedb3d586cb8f01b600a537a3f8ea01f9decfc16733387240d4650fa9048a9a",
       "sha256": "0x30593c0cef677cb81d4d380bad7c33b7d507584e8d0b941957f886ad66849fd4",
       "urls": [
-        "bzzr://d8944b44db749b5c25d402e6faa941dc564916441f951fe301a9280550f74e59",
         "dweb:/ipfs/QmfJZb7bDDKKD3LQGboRkbT5uKjLVDmpoqkuy6JDKLKpc1"
       ]
     },
@@ -6222,7 +5741,6 @@
       "keccak256": "0x7d3c11f46be9ac7fcd5e4ee1b9f5e327629c6a148fe9dc6406152e2f7106119b",
       "sha256": "0xe5158582eb811b7331dd3121a18f547dcab72e5014738c60ac5a18adc0cdd2f3",
       "urls": [
-        "bzzr://4605432cda4936fe5d646a33c7add57f219e57040ccb8be027cfda87afc1117b",
         "dweb:/ipfs/Qmd9o14PQDF36sbYV9D5Ag4wk19ZXSNTP5nT9jhK6P1ZgG"
       ]
     },
@@ -6235,7 +5753,6 @@
       "keccak256": "0x61c2e916f021ce53b1c924cf1957780840542d7656354a66d4176504161362cb",
       "sha256": "0x1c9237b63fc377c5c7c206f915aee5479c65c11d25c98c439341cda9592d48d8",
       "urls": [
-        "bzzr://db91d21dd69c41f40d6c1b6b313a3a10c18c2657d624c272f81c2dda1d7337ca",
         "dweb:/ipfs/QmRHWFo174bzbDPVXYJGhZmaiVYbpP9XhXB29GRzrZVFEJ"
       ]
     },
@@ -6248,7 +5765,6 @@
       "keccak256": "0xb89ba76ef63f8989bbf86f5a7d1a56e6e86d6a6ce061b78404cebe46873dc0ca",
       "sha256": "0xb6d75c8bd4158008b480e12fabb22b277f58d5c36cf93bdc32f1aabdf1d09945",
       "urls": [
-        "bzzr://0fa464f7e26196e6a044eb1851a2cadf852b305e089039cd75d80f328c3f3f76",
         "dweb:/ipfs/QmWRwuS6vvVPJg8kpdsa6Z59MUGrc6sejqds14iB29dFCS"
       ]
     },
@@ -6261,7 +5777,6 @@
       "keccak256": "0xa50873fa3032acae4067b3d284478e73e23829df0dd6949c32ec4d0627b0e4bf",
       "sha256": "0x4417220d8fe6e1b9ed8a26caa239f3b0686ea7d0bf5ade77e1cc0c06f8ea66d4",
       "urls": [
-        "bzzr://b0b2b2071156963ae7340979b385a9eaa928565ac67422271be52a4e28d3f496",
         "dweb:/ipfs/QmZzZBNowPixYFDHsV39G5MaZzNXMGcUdRWub3UAV7oK1V"
       ]
     },
@@ -6274,7 +5789,6 @@
       "keccak256": "0x716e09ab66f498542acb18d6bf7456c7532ab6072334848f25153979fd479def",
       "sha256": "0xf1198d367f62ffd72458dbdb42830b108e67fed2db54017c4f817cb363190ab2",
       "urls": [
-        "bzzr://0b7aac6fd70945f072260b126a87bedfd6e79721230e546fcc5e92f9ec342f65",
         "dweb:/ipfs/QmW9gPzvPhLMVb9FC86vr5ysJiRCe7PD8xgmyiufBAuS8r"
       ]
     },
@@ -6287,7 +5801,6 @@
       "keccak256": "0xd7f6f9ba66b22dec8417ca5c019341e3e04794af788bd375a9cfdda1f70a4112",
       "sha256": "0x2ac0b1a2e2d4917d226874e11fbf92699a771f977d32e7ab606eb1f75071f26d",
       "urls": [
-        "bzzr://0478fc31ff86ae1542442f3975db47859d2434ee8fc874e91565feaf844f8fb8",
         "dweb:/ipfs/QmaPiGqnvwzrBhBnsMkU79wr47jJ6G6i7xRejDmfjSuAHe"
       ]
     },
@@ -6300,7 +5813,6 @@
       "keccak256": "0x605f61238c330acc8ecedd97823e83096694edb0dda88f26f6dde794f1900f6a",
       "sha256": "0x87f500a5271dca11c800d4b1c267fd9a32e3d6a22fd71ef6219052cf65284649",
       "urls": [
-        "bzzr://6d4496f7a41ae683ccdd12ebd6003dd3b89d594bded88f840d96174838ea3450",
         "dweb:/ipfs/QmUzC4fBoUWekr8Q5ocFDerhshNG8M6tvD2z3oVnzTqmGR"
       ]
     },
@@ -6313,7 +5825,6 @@
       "keccak256": "0x61fa0fa5b4a77eb68e0aec0d7bbed157a5d197c6ea1674dcdca733fa9e1085b3",
       "sha256": "0xbb1bd25fe325b6f8f728ecbe8917fb34985c0239599296508048c0cced83fca0",
       "urls": [
-        "bzzr://9ac61ba17d2b69c5160a195856867576396da326e711464854d8654513d296a5",
         "dweb:/ipfs/QmcHeoiToCYUb32VV8nBEAzQA4Y1y5YiDK8XxvkLDb5hzV"
       ]
     },
@@ -6326,7 +5837,6 @@
       "keccak256": "0x808b75ac826756413675067d32e41494c88dee54ca1c941d5ffca83ae3364bbc",
       "sha256": "0xb34c1778decef146a6032a3ba9d72a8b2fd60104484b425546f6dcca69a1e05d",
       "urls": [
-        "bzzr://cef081c9f45a2e4f05fefbe6b72a34aaf0aeb0e06e0fbe79de91a4b62cfe13df",
         "dweb:/ipfs/QmNYQX4yVYYG1yq8YKwQCQg4r7QhoHWU23Gz7Xr5VWvhWb"
       ]
     },
@@ -6339,7 +5849,6 @@
       "keccak256": "0x3db2eba7109208720f91eb09604f4743c88ee05eeb9fe8a7c95cb052c649b175",
       "sha256": "0x23663b7f01af6be79e9b8d5a90de722abde964e9eb53de21cc4c909b0a3b3829",
       "urls": [
-        "bzzr://fa5fa4127c5088137f18f2365035dc0305b968d7e6680fb72fff5a04538d34af",
         "dweb:/ipfs/QmNy2RvuPJT7fNzx6B2nFiSwmgAWTpiNJaLz7j4wnDrByx"
       ]
     },
@@ -6352,7 +5861,6 @@
       "keccak256": "0x94b161d482455098eb0dcc42283713f0f1a2d7186dbe16608b09d6924f555b75",
       "sha256": "0x7ec61567f9f23a6ab361c4056158c93da707d335d9307cbacd844f6a5ddefb76",
       "urls": [
-        "bzzr://3825ac2923aabe9f1d91886629021da43d65e24dc7df3774333c046155956c47",
         "dweb:/ipfs/QmccriYjYNbvdciYuFwUwKqFnREb9Y5wwyPSaf2iyTELp6"
       ]
     },
@@ -6365,7 +5873,6 @@
       "keccak256": "0x529e7ea5b62bfebf255bda85920b78dac376d5441573fc589dbcb531b99bcac7",
       "sha256": "0xb1ad3b468e8bb669dedbe7cad58df4b498d1c5d571b2533f0029b8a0d8b2ed65",
       "urls": [
-        "bzzr://1c7be1268c704f8eddb30b44877732a7f67fb04bbf70753b9e42ef4be85ebcac",
         "dweb:/ipfs/QmRQ9Kv4JwuT1PCUzbsVZZ6gFYzrtBS8eoyGnsAmmEYM8N"
       ]
     },
@@ -6378,7 +5885,6 @@
       "keccak256": "0x642aac29eabbf8f9d4d0515520485c47216e239511b9512ba27201f668a7b88f",
       "sha256": "0xdde8c7192e5ef3bce42402da74041db73162468140cb3029e87e92590918a68e",
       "urls": [
-        "bzzr://cece313b80e7b7ebeb74e4c1596b940f21e5afb15e9554a15d8ab12d4abe2098",
         "dweb:/ipfs/QmcTR7SaYEUxSXNZqk52ZxascUW8gG8GscvCGHHNZfD2GG"
       ]
     },
@@ -6391,7 +5897,6 @@
       "keccak256": "0xb7a0eb8107fa176469d789aabed965df7965ea6a18f6f05447ad5b61869bee7e",
       "sha256": "0xa3893eace367e5db1f0b188f66b0aec161198aa69cec5c299cae19cd7741af71",
       "urls": [
-        "bzzr://c8661c6c1bd7e0548984275abcff8f123174f1eb78187cf73f477d4a38d28b6e",
         "dweb:/ipfs/Qmb2GoRycBU4nN7GYpJy9dXVpeQu2b5xfCvyz8mYB46b2M"
       ]
     },
@@ -6403,7 +5908,6 @@
       "keccak256": "0x0a069b2d28a777626d192b69e0e9d3b4e571714783f6f5bf67990294b3c9ffda",
       "sha256": "0x770884d5d6ac8daf6a04585436d246fddc26be3e6914c30f6cacd8d7f93e376c",
       "urls": [
-        "bzzr://8ad92815a49691ee4befe959b45e5a9afdea64e7ffd930a12a1c08a7745eb074",
         "dweb:/ipfs/QmTVHMTsEtWUVZtC5LUrz86pcSuyaJnvndeef5PQeFM8VA"
       ]
     },
@@ -6416,7 +5920,6 @@
       "keccak256": "0x18900bbb3c03947f293e8a8c07cadb4a119dcf79b1c1e7d14345a8ead5b4b7ec",
       "sha256": "0x6d25a9ef9cbc86bf9d9f19c182245db21ba2e5ccb7245b58691e14b56e249cfe",
       "urls": [
-        "bzzr://983fc8e27ecbd41f4f4f0e5d373e47ce108a26d2680783dd77e4b4cfeaacd128",
         "dweb:/ipfs/Qmeq7nK93FqgLxL7o6NkdiyfQ8D9F28LE51qohaaxSMHkb"
       ]
     },
@@ -6429,7 +5932,6 @@
       "keccak256": "0x214db7d71ee3fc92da82ca0361851fff92ba13ea798b60a19f52e1f9e02c6e59",
       "sha256": "0xce7749d157bdfd2cf8d57b1de7b101e414cb216edcc5c7364640469db5868092",
       "urls": [
-        "bzzr://55c6c25dc93172a6436e5413fca28e798d08f898707f2de6e9c09753208d9a4f",
         "dweb:/ipfs/QmVuPZnAzbQUKSLa5knujUUtLUf4yN9BWN7LwZGY5SWHDE"
       ]
     },
@@ -6442,7 +5944,6 @@
       "keccak256": "0xc3941032cd41e0fcf7c6060e3f1bd8a3c7cb9fedee6e63ba8ab95768a11e177b",
       "sha256": "0x22cb494ea3e25438d19803dd522d115a4b39ebffa6a483ffb27b6d6ac60fc8b7",
       "urls": [
-        "bzzr://043b5dbee6a3ac83ab2b29e207600b88cebc1beb149eccf59ffcea083a23de82",
         "dweb:/ipfs/QmW85H3GwU1PcpjoE8CpzN2yk2RfAuYZnPmrf7mNebwnrJ"
       ]
     },
@@ -6454,7 +5955,6 @@
       "keccak256": "0xf928dd3a232c2ea5f6e56b3292966c7c4dbeaa1f0e1f7ce1554bbdbf70d55993",
       "sha256": "0x7c7011c0fa6838cfe0368b30ed4a61d2b4f77f4ba9cdeff8e8f08c44286bd7dd",
       "urls": [
-        "bzzr://ea78db655cca333e39c0775a6b4c6042bac2aa8c7d4ec1ca8146165f2b38b408",
         "dweb:/ipfs/QmeRkE1X9oBVXuzScRd5PFemXZ32e16TPCbXiAkQhQ4e1c"
       ]
     },
@@ -6467,7 +5967,6 @@
       "keccak256": "0x7f5a228e4f005874b0a1cd6c0e4c5cf35c1a4b008d47f2bf05a753c3635e4456",
       "sha256": "0xe84fecb315efe7d84f8b8d1ed234941c34b21c176618d267a1d965e52bfa3a1b",
       "urls": [
-        "bzzr://af24fa29289c09de656f699c93063b36798d70a0419d3ca0f5630216428a9918",
         "dweb:/ipfs/QmTJmvm9oaaRRGzG8TSoNLCLbyqTSJwa3c3JmoGA9ndpa7"
       ]
     },
@@ -6480,7 +5979,6 @@
       "keccak256": "0xab9a1de84c0aa9486d666c71b40f2c07fb3ad1c35a54f06eebc52d6fedf217b5",
       "sha256": "0xfdce8c9fe80d0eada29712141e375e9e499cb1a2cb649b97da11dcdf614653fe",
       "urls": [
-        "bzzr://701744946682ceddaf85e2886bec3c8a5d855f8c51af5f2b04467690155f6e71",
         "dweb:/ipfs/QmSTVV4KqFnrY6MSTBtsfY2dfoKoBF2sQ1steRK8QrmdZS"
       ]
     },
@@ -6493,7 +5991,6 @@
       "keccak256": "0xda493312f9bbfc0aeca2d36174309c06d51efd72b0bc8542f2ed5f8de24f0c58",
       "sha256": "0x4e1fa27be892c7aa7a9d24b755fbed73d78f9e1c7064b24a214e1fbc58c28fb7",
       "urls": [
-        "bzzr://a705ad39e94ef0851bcc3350f00a060357fb33cbd7bbbd7bae40ab47aa842099",
         "dweb:/ipfs/QmWM7Wx7jBm9H3TRMQ4NqC1dxRFKaj5TJ9A6n7thJE9prF"
       ]
     },
@@ -6506,7 +6003,6 @@
       "keccak256": "0xf21a1c556d3f826514dbd96f53eb3a9a2c8dc52a4f2110811e4bc7440ce33045",
       "sha256": "0x3215ead8d37f5a38ce30286e43b9d0b82f12056ac881e89cadfac287d7b83c4c",
       "urls": [
-        "bzzr://3212cec1782d1702f3693fdb0aa664d070d011bf6cd5d6bd07972650c6cff125",
         "dweb:/ipfs/QmSh3URcZYtiSriRezqcKRwxgWuMGcokrwAaH6iSi7PsKC"
       ]
     },
@@ -6519,7 +6015,6 @@
       "keccak256": "0xda5ec4162c1652d5fa485f77fd2ca2a370a454e25be61d54420f54f8040b2d43",
       "sha256": "0xa51a5a64ee627e3e530e08f84e2b0c7531fc91b8fe17ca31fd77621af74a563a",
       "urls": [
-        "bzzr://ccf17dcfad047791385aadeb485d082bf764f8fe7c2cc33c4c5266806e8e3843",
         "dweb:/ipfs/QmRHSNXnNxnsSz2XnWcfqTuXVoqAEGedZphi7HioZQitfp"
       ]
     },
@@ -6532,7 +6027,6 @@
       "keccak256": "0x3a8af63b2e2eee0535d30d304823d4fa11e8d25e128dc2ba1acd239950de2ddb",
       "sha256": "0x15c144468d63510f203c88e94d294c9ea0f3c13068969a44348d7e06346d2b92",
       "urls": [
-        "bzzr://826fae240a013e6c9d3229401044f8021f30c422f7643b8906b43945fcf864df",
         "dweb:/ipfs/QmVibhinEH5MWf8bVo86rGyPYwibcHEXSKYVWpUtCkWY6Q"
       ]
     },
@@ -6545,7 +6039,6 @@
       "keccak256": "0x115a5e6b52a928fcb6bff1ddc0dd6d7d6be47cac01da65769dd34701c0bd0d4e",
       "sha256": "0x68d528b348f3410c0aac48de1d6b40bbb1d10311395466f746af4be16a78be7e",
       "urls": [
-        "bzzr://613e1dcb36f9fcc172151366139e026bf27a57444c52c65325d2d4eb0d30b02b",
         "dweb:/ipfs/QmSEFoEPU6nFrtzVLHi8j1koRrmDdLR3JansNbMDKNfNTZ"
       ]
     },
@@ -6558,7 +6051,6 @@
       "keccak256": "0x33605909d2e70cedc29e653156b87b1213988fa18d08044c859183c387256e44",
       "sha256": "0x6f2ad78c157c9dc06f8808960afc36bb51cf01de8ab8f173f176e6ae78523309",
       "urls": [
-        "bzzr://76944eaad4ba13ac9b33f21bd4093090b026784ccb5f3a54a77c5d302ae27293",
         "dweb:/ipfs/Qma1efXC8GJZXJ92SiVbhqHSuQC8Szovv2zASjcToG5hv9"
       ]
     },
@@ -6571,7 +6063,6 @@
       "keccak256": "0x8dc20ded4a8e0e2a2ca24e17ce88bbf3268f3001787c89e18dbabf394f50c2ab",
       "sha256": "0xcdf8d539231df99c4d11d0f6f8b4daa63cbe8c86623923f46acc526e3537059e",
       "urls": [
-        "bzzr://bbb17b2c991d534efd19e7682eb58b9158e511f453b186f03895cbc14beacf07",
         "dweb:/ipfs/QmPQt2RxeeQzMFj1Xp2Qijyzujb9kYYAzTwdCDEk5o3LDa"
       ]
     },
@@ -6584,7 +6075,6 @@
       "keccak256": "0x5b78d624965a25701b88ea5232d4d2dbc178c7fe3b48c7fd08ff9d9dedc56795",
       "sha256": "0x78b115168ca3514b0d838c03af87881fd3e8a9ac8755ce1b0d9a862421c2ce16",
       "urls": [
-        "bzzr://d7fa7380104d07030455517e10b72ba90df9d9141f9d4c16ffd0f39bc951e556",
         "dweb:/ipfs/Qma8V6F4VXHvVhVLWgZv7Sy7PoGRpH97xjFCVKxLD4UiBa"
       ]
     },
@@ -6597,7 +6087,6 @@
       "keccak256": "0x50c55ba21c9b8be6866e09e416d62a668920fc649c4638f1ffca94dd9e37ebbc",
       "sha256": "0x0830b5963c7681a598d464951da19078fe56d4e824392088fb2a58f7af9ef888",
       "urls": [
-        "bzzr://f1d43a91c5f8dd583945eb43a70f734d429ad962da268d1a9104c6f02c6f9d9e",
         "dweb:/ipfs/QmSKUnwiUdiYFm2ff9G4RbGvvkux5LFjm81zT4hebNFzUu"
       ]
     },
@@ -6610,7 +6099,6 @@
       "keccak256": "0x58f64bcd753a5ce190c88121f88afa7baaf54dc82bc035fa28f4e26c787783b1",
       "sha256": "0xb865b418f46cb479a3e455bf88f5e61e01fa7b3ab8cb3ab460e0fe2db90770cf",
       "urls": [
-        "bzzr://6e0840a9902cead34fdd509fe486ee3809535db3a89272a0c5a6120b12d9b605",
         "dweb:/ipfs/QmVypVpcJAhgTHkMgw8PEFdiU7U6e3xF8ZTxRxPNFRPBpB"
       ]
     },
@@ -6623,7 +6111,6 @@
       "keccak256": "0xcf780094598d010c5ac8e0c560f53f60574d4351f261bb813d0ccceee5a53fd9",
       "sha256": "0x6b504a43a3a1fffeb49836733ed026d88245e7fb861490db730e25cb3e01ebc0",
       "urls": [
-        "bzzr://08af274d394da323d3e0f4695312f205d15f17a3f4ca571f974f7f7137060bf9",
         "dweb:/ipfs/QmS4GT8arJALASAWpWxENhSzDybzgVQW55hHhh5LueE4Yi"
       ]
     },
@@ -6636,7 +6123,6 @@
       "keccak256": "0x480f57741c7a62b8e809a86382908bff781a22954e9095ec4b589540e55c570f",
       "sha256": "0x6758686a9796b0aa3df1b3efab75b9765bcf5f7ab95338859e0465c364cfc31a",
       "urls": [
-        "bzzr://37bd29fe8a79aaf9e825f6af006beb432b1a77db795b7036ec987ef265ddd4fc",
         "dweb:/ipfs/QmaewAc19F1SZPaJoqnaXdBUmYDPynPLaxzrsryhj89tUB"
       ]
     },
@@ -6649,7 +6135,6 @@
       "keccak256": "0x4b47524445228c38ad8e554c9c4a80eaa3a0aefcb8424059379f3d181e9bc523",
       "sha256": "0x7b31a5727f05a8436c653921fcf6d12dab724926f4aab3374229674bae8712b8",
       "urls": [
-        "bzzr://c363eefc745f6f0108b4bff7ec04e2aa2cfe53e7732f1483ecbf49ff5a8c2dae",
         "dweb:/ipfs/QmU2G5z1LmdhDi7oKdP9huB5NRz2VRm2PpERfGnQ8vyxbj"
       ]
     },
@@ -6662,7 +6147,6 @@
       "keccak256": "0xbc3cc89fe2a4c3fd1b4de2ad09c4ec94371f6c1b3fe27cc8fa506ae0cb2ca20c",
       "sha256": "0x6138d94beac4c64e1ede1e76535323508e9838a946f276208e7546f82f5080b8",
       "urls": [
-        "bzzr://fb6dd252cb458d61275f3a13d12aa67dedda4bac50552eeed463cbd97f626055",
         "dweb:/ipfs/QmaUrsPok6FhUmNu45tVgweoTsFJhEgSwSFYrYnxtgVMQs"
       ]
     },
@@ -6675,7 +6159,6 @@
       "keccak256": "0x402b1f47bf7d0f6cbd4c19d7d3e6452083dafa0246015dbfe11e6cab79eda184",
       "sha256": "0xfc9c5fd2b9405237915cc83f664bc3e9219670fc1a0efbf13274a160eeb8f2f7",
       "urls": [
-        "bzzr://965ce40ed5e4037a3b3916873b113052129082efec45f9aba767658515264bc5",
         "dweb:/ipfs/QmS6swd31BavGb7vecDRRh8ohy6gDz3cXuRqQx9oXfyg6E"
       ]
     },
@@ -6688,7 +6171,6 @@
       "keccak256": "0xd6877c4e6919906f0c2ec5eebc8b54bd8abecf36619f1b9de53118d66890c4c2",
       "sha256": "0x93c5645c66182439e649ffb46265242e88a33908ff503e04d11cdfe6ff739e1b",
       "urls": [
-        "bzzr://83393f31311c2cd49f4c8564a9fbc6962be548a73c79a5967eb7423ee5cf59d7",
         "dweb:/ipfs/QmW9UxWLHUrAZx7831JyuFsTCPrjphUK7PrDfbuBdE5oE7"
       ]
     },
@@ -6701,7 +6183,6 @@
       "keccak256": "0xeea56c1218e694e86024a3e18b04f5f428e182e39cfa94d0f4e21e5b2b3675cc",
       "sha256": "0x84cb868f6eb453aa19f266dbfb47bf7da5af9019337ecdb280bd42c7baa4aa9e",
       "urls": [
-        "bzzr://dbaaa698d20207fb480f5571ee110d2f5f9fc4825ec5fb7c1d0a66c235541d1e",
         "dweb:/ipfs/QmZq9dAkbs3C1HnJn2w6T5YosyQzw3zqF2jsyYFdMoRgtq"
       ]
     },
@@ -6714,7 +6195,6 @@
       "keccak256": "0x7e34ded082f4403f672626691c86bac90cf3127047bdadd92218fcad9c5cc05e",
       "sha256": "0x9a4e6523c2523a1c474172d45a4a1d5935361c0ace7de2604f8f2840558184ce",
       "urls": [
-        "bzzr://cfa47b4d8d75df10651343eb3ef3609d6b1176a35a0c97faee45abeb7b033cf3",
         "dweb:/ipfs/QmNuM8UF3cqnS2jaJXtdrGqufBTcHBEpvRNEh9gwN2phLS"
       ]
     },
@@ -6726,7 +6206,6 @@
       "keccak256": "0xee322e8f3117fcd7c196e88407d938846c096a3c62a51debd8a646f3aa228fcb",
       "sha256": "0x9d9ec631865882a435fc577126fe068ccdf9c3962aa439acb2cdd0794907fccc",
       "urls": [
-        "bzzr://bbcf75b3549aaa4b68bdd805e5c5b8a0b0be6a964e068b7ef36c48431f44e8e1",
         "dweb:/ipfs/QmWyGqzpXbJjvMrqySeSMB3mzVP2gcz5FcXhpajvnbtYmn"
       ]
     },
@@ -6739,7 +6218,6 @@
       "keccak256": "0x542d4ee7433cc87b0af481c0576c0eaa1e039564920cabaf05c470129028adab",
       "sha256": "0xd3c149b925c77a7574b55a2f385385773018c99df5a468f830adb5320af97a0a",
       "urls": [
-        "bzzr://59a32bef8105739bcfd4c510bfd79af4c8ed8c6a7044cc35226dcf728730c66e",
         "dweb:/ipfs/QmSWr8Z2hVAFDafirbTNUPoUKCcZATxGtwCzwRamzQaUdu"
       ]
     },
@@ -6752,7 +6230,6 @@
       "keccak256": "0xdb0c3ad580eece0e4be735bc393511d5c6da3a43e4d9bdae4bb301759db9a48b",
       "sha256": "0xac547423f6c07920d394ff0e30d1846f376922fe257c1013debf2e5f315336c1",
       "urls": [
-        "bzzr://d7518a74bdf87800dab785598f1194800cf74729b31bb2f2cf56884285bd3d7b",
         "dweb:/ipfs/QmeSJSVUYqKLjkc7N84yuMHNuAu38134rsqtGhLRo2nTRy"
       ]
     },
@@ -6765,7 +6242,6 @@
       "keccak256": "0xdf46b3a863c003d7e5e4e5629dc95c120c34c2fc2379dfe686a91b0b513a0cf6",
       "sha256": "0x2de886430e3d6c46d85f0b61ae336d62e7d4b7cee84d222d8dacd220c855642d",
       "urls": [
-        "bzzr://a40273ce36779aa9fa27bcda851a6bf9c7919830ebb27fd73e10e539a502a4dc",
         "dweb:/ipfs/QmRxuiFmryHRViKbKbi6VzJbmmzaH1sXarA3YzrsPCMcRB"
       ]
     },
@@ -6778,7 +6254,6 @@
       "keccak256": "0xb5b57bc72c77a76e277e7eac82d041dfaa251288f727c13d1b22bbfbda039e32",
       "sha256": "0x660c5c65c6fc2a054ac597a5a2bd42e126d32890a896918caf5cce9c80a82aba",
       "urls": [
-        "bzzr://058835dd41e4819be08eede51f46b0c75311f95b1e1079891d6d888d94074da6",
         "dweb:/ipfs/QmT2CJKAX5EKnMqoUsKwQfCffn4iBy4yM21vZ36NfHn9aA"
       ]
     },
@@ -6791,7 +6266,6 @@
       "keccak256": "0x2770bcff9311f4cc1b11b31e8e186ce205a7376353979c9a3b122a00f11ba06d",
       "sha256": "0x390b34192810e4cc019fe798457d1dfaebf19a96356332f3e1acf1dbea61f003",
       "urls": [
-        "bzzr://9a7d1a775538ae6f416cef602b01edb0af53c3f740c2a321b8a7077af9c0f55e",
         "dweb:/ipfs/QmTYTXGQ9Dpzv58HUciHeZhjsSAs8KCJimjURdyiPE9EwE"
       ]
     },
@@ -6804,7 +6278,6 @@
       "keccak256": "0x8b21b478706c069b19746b7d088396ad1a7323acca051f7e3c9065ad172fff19",
       "sha256": "0x891e22bcfc37332705821b0e2a2145c0dd77296b3765ad9506cdf1f8060390e9",
       "urls": [
-        "bzzr://254ef850416cf8862bf2a9495f202099f56e6d39fc03fd177d2aefe5a0d9643c",
         "dweb:/ipfs/QmaJZDUTDN78dgDAdwQEa7sowySzk7zh4vamHBX5KwuaNJ"
       ]
     },
@@ -6817,7 +6290,6 @@
       "keccak256": "0x7b2fd7abeb5ee053f462ecb6e075b5435c5903ffc337956af5d5174d787c958e",
       "sha256": "0x2a8f1bfe84a26ec59e5a8a284ca7978b1db07556578c272d453ddebe012503ac",
       "urls": [
-        "bzzr://001ab758e76c6a7368d943543d382557210c5edf37ffbdcaaa627f60319f8bc5",
         "dweb:/ipfs/QmRM36eguzKczdkbR6KLMBcxBGq57SZem8PhBt4oUvXWXu"
       ]
     },
@@ -6830,7 +6302,6 @@
       "keccak256": "0xb8717d5ddd7cb2f8516b7e7bf0cae3802cd89659d3c2b408f5c9f4ce67545e9f",
       "sha256": "0xc8ef83ab135f5e280ef34631bd7ea2a2a7aea4e4d73308eb0cd5207b36d031e0",
       "urls": [
-        "bzzr://966adc290ef6f10203304c0866ad7c4bd233a93c7e74639b53647263fd02c71b",
         "dweb:/ipfs/QmQkaboZBQpC7kiV49ouUz8FUkzDQCBbT2zWW4oiaNCXKv"
       ]
     },
@@ -6843,7 +6314,6 @@
       "keccak256": "0x6e5eb8454f1e6f6248f609d839e2d459842326db86536f138341555b2985b58d",
       "sha256": "0xa1656cb2c004c3ad08767e8b351d7b1092cd731c343d4dfc8f2f06e8a40dd293",
       "urls": [
-        "bzzr://31d1b91ba0efa44ea689a2df2637de69fc09dc1a998a81df9fd1aad7514b9e65",
         "dweb:/ipfs/QmP6EUMjcHii8AzkKWTruAyVJNdG5gA7fiVj1MPvBNbgZQ"
       ]
     },
@@ -6856,7 +6326,6 @@
       "keccak256": "0x257b4782376e9f044df5126869745811fa2a00bce2d9fca3e0665d81244dead4",
       "sha256": "0xdd3fc35ec3f1666e8cc48175098c80003991eb737f421f0294f3392388ad4395",
       "urls": [
-        "bzzr://9a46af1a168690a684139ca2d2d4550932f3c11ab7a3d9493491be45319e0e9b",
         "dweb:/ipfs/QmQMXCtEJb7KAcweLxCamr6DAV4eoe8brH8facUyYa6Pem"
       ]
     },
@@ -6869,7 +6338,6 @@
       "keccak256": "0x36271bbc780a45b1b5ed82f6e8e09a02caf78557a9548962e6162032f1a4014a",
       "sha256": "0x4b56dd741f12062c6fae57451712d5357b5b50406367e3b79d956d7846e18f57",
       "urls": [
-        "bzzr://dc36676cf21c961dfd52651b82c85219f1843f578489195dcd6b6f48947d60b9",
         "dweb:/ipfs/QmQWVY2WdS1AqHuzKnY1rXuCcqXYgom7ZySEQzwdGNru6o"
       ]
     },
@@ -6882,7 +6350,6 @@
       "keccak256": "0xcaa82fac0cbcf2e35782e45745cf830f97eee0bf27bba85d24de967d3e863e71",
       "sha256": "0x4f5202766040f996a938d77362dc499ecd959b35a3f97c2ef3c018154b6249cf",
       "urls": [
-        "bzzr://f631082277241bdbe1fcd92783f4864d60c7dd16bb96ff78a84e73cfbd7acce8",
         "dweb:/ipfs/QmRyNrVMvAh8xCJXL7ed9eKLauZyqHBq7EeZYky63383sP"
       ]
     },
@@ -6895,7 +6362,6 @@
       "keccak256": "0x164b5cbbab21103155cce12b2e6e819d7f6e748cdcf2ece5194ab4e9e2129ca3",
       "sha256": "0x138f87f2e9af7dcb96abf1cc8546386634b15dd7d356d3567b0ca22b26afce98",
       "urls": [
-        "bzzr://3f305063ff8f7c7fb04fb7071120b3adae90a741e7ccbacc07d3535724f973f5",
         "dweb:/ipfs/QmQmEQv4is17neTKKBmkg9YHvazRoWJLFXHM6dCnYLNqph"
       ]
     },
@@ -6908,7 +6374,6 @@
       "keccak256": "0x6d319de59f80795dc65ff9c71cbc88d5433664c2e208f6bc1ca3bcca011dd69e",
       "sha256": "0x5ee56d0c8597d6fe6b18736817ae250b15e9a4134f50e3900cf5aa2c364aef61",
       "urls": [
-        "bzzr://ba5f458fc3a05465d52fe2e4502a5b2517cdde3ddaa1da3c6229494d2ee3f841",
         "dweb:/ipfs/QmV17RjMyNY4H2QAAkScvNsfnPpWajKJDfDhoxJzH3nP4K"
       ]
     },
@@ -6921,7 +6386,6 @@
       "keccak256": "0xc61567f505486fd9a7907b05e10ca297fe5d0f7f021c070449ac541795d781b3",
       "sha256": "0xc7e99fe0ee3c1c2c8956b495a5a4c5b11055dc3cd70d6ff0fbd5a02ed57df113",
       "urls": [
-        "bzzr://990aad9205b4293bf6923f7d6abac9416928dccde529b7df52c379e1432e3dcc",
         "dweb:/ipfs/QmRNgxUeoG3kTYe6pMjxZcf1anLF5oJrYFNFJtVZE2UwyM"
       ]
     },
@@ -6934,7 +6398,6 @@
       "keccak256": "0xdab0a9f25c5f5fb9f7a824eb01225ebf0f73d744b33049587b642179485fe059",
       "sha256": "0x9f6b8657cf05ad1448137422f53b9d90d63a1f4352d4bb6fb4c7bc97a7c20a9d",
       "urls": [
-        "bzzr://5596d6d153d32f43557d738d9de4343e880fed7030d0b1c93792fa57c69dc8e5",
         "dweb:/ipfs/QmbiHVU5G57Tyhg6E75Khr6TY3iWzDzVJpbRMuZjJyYfzU"
       ]
     },
@@ -6947,7 +6410,6 @@
       "keccak256": "0x5332a1fa2f9e24d39a5013b117552c2adf7e130d6d5ea96d86db8f99b2126cbb",
       "sha256": "0xeb15b75eb27fbb8808ff4dd780b949c127c578da79876e5ba4263ff4dcfe60c6",
       "urls": [
-        "bzzr://0b5c9b9ab9d15edf63fd9a14ec32d684c8a980f49f80d274d96edf0112ba30b9",
         "dweb:/ipfs/QmRjhqya2PmV9A5ESB8tj2mAEGdLThSdSTCAcRgPwa4gDW"
       ]
     },
@@ -6960,7 +6422,6 @@
       "keccak256": "0x3a1ea681afc4be4ec049258d7c6d262e251e46bbb571b13e78b3ed11875dc040",
       "sha256": "0xd21605789b47cb756f94440b36160b658531f484eae9e0237e18b501e13cf785",
       "urls": [
-        "bzzr://9b80ae9f183780cea4f6e11c47a6dd2d845399da0537518fc834cbd8abba1d3a",
         "dweb:/ipfs/QmdQrRCH2v83G71uViYdVeVwbv7wAqwuKcjdXA9PHjh78M"
       ]
     },
@@ -6973,7 +6434,6 @@
       "keccak256": "0xf4f2d9990c605f24f4f8217f6c1249150b0709e76ed0f785af4a163f96d231ab",
       "sha256": "0xd4d924d6a3d64144a8ad97adccfa7faec57646aafa7f423d4a0cf29761743a4a",
       "urls": [
-        "bzzr://a73ad38f658292182d399010fbfbb6ac1069fa4b2e59b192bb1e04987aa074ca",
         "dweb:/ipfs/QmNqvKZSN41awwK3y9wwvikYMrf9dGMEw1jBoHsZEziEBo"
       ]
     },
@@ -6986,7 +6446,6 @@
       "keccak256": "0xea2f1c0ab2bb9b8fe910d611f3a49e5fd37a3eb6d9adf9f5f8f58f9b488cffa5",
       "sha256": "0xf938b0c3fcd0c384635d7f71d3c80c7c3a65f99e8e78058877f98b7db01ad11d",
       "urls": [
-        "bzzr://fb554bd8f06cdb7d84e68a9900dca8c0a1cfcbd9a1a60912f95f8b6005539f51",
         "dweb:/ipfs/QmRaV1fSdg8GYBThnpYpS8kzgVHZXp3idYpBZE5muPiZvk"
       ]
     },
@@ -6999,7 +6458,6 @@
       "keccak256": "0x2a0509619ae9d8e48c995729031dcebcf9eec3f331db383f183e311e548e95c3",
       "sha256": "0xcd1549a54b0a02a462ec23309297ad013e2325737b8d1550f0c378cfb08fa74c",
       "urls": [
-        "bzzr://086d626be661d624f875e9a06c8308ca29cd0a1e5e96c098518fd6f458266a04",
         "dweb:/ipfs/QmNxwPtfxuKjnB4ndDkSCWnCaY7NHpN2BQ5hoyprCcQSE9"
       ]
     },
@@ -7012,7 +6470,6 @@
       "keccak256": "0x4d54a840997e7357d832ef48fcf254aa73d3cbd98ba2a2db3f4a334343382da7",
       "sha256": "0xdc2c9cfe2fd4af7fbdd1aed881e441f53fa60285b578c0d47ca833a59fbf62c2",
       "urls": [
-        "bzzr://1fe442eebadd93850fb579baa2772038a8c9b16c86cbfa41337cccacb1f58f9f",
         "dweb:/ipfs/QmYCL9mWvfopwRxGnCQ1DCBPweRY9HUTta1fndHDTB1Hxy"
       ]
     },
@@ -7025,7 +6482,6 @@
       "keccak256": "0x02d92eda9e226921dbc2daa5614718af522b398365698daf38acdac20c49f81a",
       "sha256": "0xa5ba17460d921d3b2537f36eee8a6df2b17c89a93e2777b73d056673e00a0afb",
       "urls": [
-        "bzzr://0005e5682dd04228df8307d747263acf0c441fcadccceeb48c8174e92783aed2",
         "dweb:/ipfs/QmSy4kif3czsb9LBPjLvPe12cMWiakb9KSoeeuekBSMKDz"
       ]
     },
@@ -7038,7 +6494,6 @@
       "keccak256": "0xd15d991e87f04bebd172121d28f52a322d25e987eb777c672808761600fee06c",
       "sha256": "0x809578c73e300a36a180e2db5e1ab4bc2dce985e099174255caab98a1ee0a1ff",
       "urls": [
-        "bzzr://06df461b1657373167dae4f6c8301c0c3b44b7260731e9d7729afb756dcaa186",
         "dweb:/ipfs/QmeBmfgGJ4ALskAqskoCeKhLjSNFvyhKyZezMpwHWKiU8F"
       ]
     },
@@ -7051,7 +6506,6 @@
       "keccak256": "0x1f79c6d21b4aa1cbf2c304d976e7c1625b4984c4aa9ef511ac3b17ad890cd8de",
       "sha256": "0x7d810ca90c0e11a7838e86aca44f5d6f18b971bad94514118f7f5e1fb8519fe1",
       "urls": [
-        "bzzr://e1249083d559743bcd71565c064991ab6e935402771755e55d87419b46617d15",
         "dweb:/ipfs/QmVoz2zCRnad9PTXU3M4DEQDrvW3bspWZNWGWZVP45MiCp"
       ]
     },
@@ -7064,7 +6518,6 @@
       "keccak256": "0x0359b3c9000a2a029e30f84562ff8e1136308ae1c34d2e6cadd9aff004cddc50",
       "sha256": "0x162b157857c352d200990b7d28dbdc30dd73d04db458172cdd4584d01d8dd88d",
       "urls": [
-        "bzzr://2136c6bcf4968c5f1ea89e43d0ff438a10612ed1d1a0f6ff41c497657d146a02",
         "dweb:/ipfs/QmRsbThg4dk42d6N231HcVxWtAarsTbswmhUmJJ5rJPBsC"
       ]
     },
@@ -7077,7 +6530,6 @@
       "keccak256": "0x625d1167d51abc243f58be59ffe642f9b99ab01da1c65047315f30536fb6bfbd",
       "sha256": "0xfab200ef2e8c20760cad8a1d5c1abbe06c25ed81c6053b6cbdd556bcd12e02a7",
       "urls": [
-        "bzzr://fc8350deb4474f627a2bf7f4917f3e3601c50935969f4d03b11a0be96dd68f7d",
         "dweb:/ipfs/QmTyPhDExkYDWRGPekY1S5fTF5diMjPk5VF5ZSWU9SZgYF"
       ]
     },
@@ -7090,7 +6542,6 @@
       "keccak256": "0x72a6efbb086828f9038707c5dfdf94210667aa2af2fcbb2c074a4659216cb44c",
       "sha256": "0xcbc3123e5f68ba8ea3cf67e2c3fa5f9c744215fb1ab76135cfabf449b8f4b546",
       "urls": [
-        "bzzr://6201b547c6d6dac3651417820a25194d1874302ec99da50d5a3f9e520d7e8f79",
         "dweb:/ipfs/QmSyzmYfXdH5FnrdTohgJGPYjVA38Cykb8cDEF8sdCZazq"
       ]
     },
@@ -7103,7 +6554,6 @@
       "keccak256": "0x8166a79ac8c84d6e0f5e505b5d298470132b8e3eafb4303d75fa4d34ad4dd05e",
       "sha256": "0xb27947c9af4e106968b864476699f182370eba6ae2c9521ab991685e2dae5199",
       "urls": [
-        "bzzr://4b3747b801c4bd899c4257b5af53c31aeafbf3b7eb004055bbb3488ab8bdfe2f",
         "dweb:/ipfs/QmUvWfSREPR9J7emQBuV6qwA2LzEPkBdsL2RkkLpAZQJZ1"
       ]
     },
@@ -7116,7 +6566,6 @@
       "keccak256": "0xe9700367a831cbec2776dab305212207f3086d7bf09e0e843e0797752382a76a",
       "sha256": "0x655890f59043af9d396f7a250ae5298d14938233540f0ccf9a93dce0ed855cff",
       "urls": [
-        "bzzr://ddb2d819c5f69597f2e4d296193ff210e294b77a9ea7716e8db64fd13752267c",
         "dweb:/ipfs/QmaY94ckTEzuQcjHWuWtFWb8ACk4LZSj2BkaqjJR1XStqw"
       ]
     },
@@ -7129,7 +6578,6 @@
       "keccak256": "0xe53674fff496f1e25a19c1202e90ed1f840098bb41b2022158dad6cc5c786980",
       "sha256": "0x95d071c58f5e3b273d36f8b168d2a2926995e48cca764624a05fb7d4701f4710",
       "urls": [
-        "bzzr://45fb4092600067d2381234c3acbb5a44754152586bd2e68a52f76d1909005195",
         "dweb:/ipfs/QmYhNC3b8ZXs7JFkusyeLkA8JRztqQZF1uT63p6QZ6JsKe"
       ]
     },
@@ -7142,7 +6590,6 @@
       "keccak256": "0xeff0f32f605065a8efc04c426f1a43d73407528af7714aa6b621eb55fb3fc97d",
       "sha256": "0xb7a00eca74924522c89aca4b8bb63d879c6502f942cbe7481ccd7e4959edc272",
       "urls": [
-        "bzzr://55789d96dd81a82612e0a24a71982cca39cb8339d5f3d91d8f427d530a52ae5a",
         "dweb:/ipfs/QmTKSD1GboJTpfaEbMGNkahkC1nZfHtpKaRH5UiMBzCjQU"
       ]
     },
@@ -7155,7 +6602,6 @@
       "keccak256": "0x96372145993577c7445499d5828ea4300435ec0fc158864af594bb3c2596b031",
       "sha256": "0x5b0242b18988563ce4b39dc51d42295407aabfa715ca2184dbf5205d2570ea53",
       "urls": [
-        "bzzr://075a61b4e27d27d469b95625c03099743985390e43648c914426dec99a26d28a",
         "dweb:/ipfs/QmTTqsGYtCLRUFZtub1aV64zng7LsLApYBbCqdepphpDTd"
       ]
     },
@@ -7168,7 +6614,6 @@
       "keccak256": "0x4910427d9fe180552acd3cffb240cc7af9f8e338458663a80da5203b905458a1",
       "sha256": "0xec39f05ada9ffc1b90a1f5a45f3d7b246683b342f95e01a6761da6d58c63b95d",
       "urls": [
-        "bzzr://e238a8c050673d40c254457d7248c7cefe715226f60b9c2999f41fc38841561f",
         "dweb:/ipfs/QmPqpzThLV7t68jnET2eALmTErujwiCvnurHixaVVc8qdV"
       ]
     },
@@ -7181,7 +6626,6 @@
       "keccak256": "0x6ff4af9cee81994d49da327b20732805d5738b3a26a5b7e3c039c0557006c8bd",
       "sha256": "0x644e01e9d03dca81c99421ddbc91e299110c3afaa877889fa1efae4e1fa7e083",
       "urls": [
-        "bzzr://69e560a28deda58da0eb536f5c39e201a95fa5c339884185ad3ee8a4b4090bc2",
         "dweb:/ipfs/QmeEDH4mGBvNXoeLwMcnLjfqyQukgfn7xxmD8XHq2gu3Ar"
       ]
     },
@@ -7194,7 +6638,6 @@
       "keccak256": "0xdd0f12649aca201ed4fd8d7087014206426d3ef20ffb09657c70cc539c4947ca",
       "sha256": "0xb08edd193647670dff6ec6bb54f95e6045eae28946746810e5f05324004fd5ea",
       "urls": [
-        "bzzr://75085bff8a906a506ac4c6fe197a11c488ae2f355915cc1ec4ae8d07de313797",
         "dweb:/ipfs/QmUpxiknuRAQZAZKPdo8GZvBaKELBr5nAeeXRFkJham3HW"
       ]
     },
@@ -7207,7 +6650,6 @@
       "keccak256": "0xc16b68ef2e24c958f893555a76cb6517055aa4ad9fdb2e25baa817778e41af3a",
       "sha256": "0x82947ccab21a6a11c005b9f428ffd6ab10516edaa87800da89c1cb93c650635f",
       "urls": [
-        "bzzr://5f3e02ba1f9f173c28457ed477f0d569e9c9193b13721431ce9f88e01a4f0813",
         "dweb:/ipfs/QmSikcs5G46oovQxoD6JCuZaULZQH9aAdrQUDYcUKMho8A"
       ]
     },
@@ -7220,7 +6662,6 @@
       "keccak256": "0x493ff9ec4533dc2dfb93b992cb177f46409d006dbb7f58311de36f283a8a8f83",
       "sha256": "0x5230d769bdcdd8f08b9218f72f3a1d2224f7045f67859ac8bbe20527c5989b0b",
       "urls": [
-        "bzzr://96e8d25a70806a25ed362637e3318c33fb1eb48970f02e183430aab936d3c4fc",
         "dweb:/ipfs/QmNcu4STdRpGzxdmGTGKmdEqJoo4w4wpYcSSuGGsgun7Z5"
       ]
     },
@@ -7233,7 +6674,6 @@
       "keccak256": "0xeef1a5cb3a54c9a28d2167f9f2086237971f99316eefed28b98f30db0a25eb56",
       "sha256": "0x6f546e93b6257e833d4a1eba3495b004ce654c74f09f359d7057cdeb5e227371",
       "urls": [
-        "bzzr://13c0111000aa72d8ab45a155ddd78c037e239e2269a6b1706508a1a3e1925d30",
         "dweb:/ipfs/QmUBtUYYcYpUa7MMcNRWyjjwdj4zjSv6wnYe3HNYgdqdnD"
       ]
     },
@@ -7246,7 +6686,6 @@
       "keccak256": "0xa17ce1e11918c9bf88c7cf922d645f61613e152d93348ce9c5bb9b26a5046617",
       "sha256": "0xeb12770c888bcf43bbf514f9f18afb59a552e6749e4b74e9964b2f2d29c83b04",
       "urls": [
-        "bzzr://7bf0b6fa3602c9080872a3dee5130d254e71d2dfd8def39361c332eae62c8f5f",
         "dweb:/ipfs/QmWVbQztTaWBGumMf7BRkmVur13c4Ukwxr8eYWQcKBr5qH"
       ]
     },
@@ -7259,7 +6698,6 @@
       "keccak256": "0x0dee8537df4d4fdd5a943f6fcf877f2e9fe4e6878e19475bc4a4a73e8364c710",
       "sha256": "0x32a50a392a2a05a4219759b41cfd7716bd9cb6f3fab9e3ca40f3e13b9f55a170",
       "urls": [
-        "bzzr://550b114e577ee918c479544db1347f13d5575d1b59bcc844df0c242e3b314525",
         "dweb:/ipfs/QmSjigsWGHK2wV2a7yzRNxpwmkNdEBaC9rtsmRBS4fyA7z"
       ]
     },
@@ -7272,7 +6710,6 @@
       "keccak256": "0x0d424aba2f4676eeababa6e5834dbcf3ac79992e9d1ea6a2d4a6c58a8ae9e78e",
       "sha256": "0x2df74e0e93cab3e07346629db5fb0d341ada5c7ccce96b766c6291752017ba62",
       "urls": [
-        "bzzr://ec30d7e33f3a0fe3e9d612b35df4bee005d9bc0979955afbc692d0ffab492ffa",
         "dweb:/ipfs/QmST4uuA2CNv5kFwkBaSJjx7ZWtByXY8Z9XRXadSYgbZDo"
       ]
     },
@@ -7285,7 +6722,6 @@
       "keccak256": "0x7bf29c24ab24394a54275950801fed58415f562103ef1593b2539fe85fd81ab6",
       "sha256": "0xa9ab9b21052f03f8210c6f0a396256ebe8874841412024be4693bbc33e061108",
       "urls": [
-        "bzzr://bb22d9dd0e9f393aa1135990e6386aff16825fd84f87d6fa70eb81d7e9ec570b",
         "dweb:/ipfs/QmQX2aBRNr6Uv7diPTXVtkzWWzMjEpWzMv4QW5S7FjzDtS"
       ]
     },
@@ -7298,7 +6734,6 @@
       "keccak256": "0x5c064ff5c12f3e61acb73085875c00131292a97ebd94f3d4683b97ac8dc5546a",
       "sha256": "0xf1ba167c3046d6d6b83299383be68cd7caddf39a48bafcca12b736228dcbdd0b",
       "urls": [
-        "bzzr://82973a45085231d027f29b9a3fefb1bcb9b64edfec2ffe4f401fb0b97f618be9",
         "dweb:/ipfs/QmTP2dkN7HyRx9AzFuzkSgjr3GTeD71fmGLTnBFi1K8jCh"
       ]
     },
@@ -7311,7 +6746,6 @@
       "keccak256": "0x216c916ef271f5b39dcf246b9609c59afe4ccf4ac12864ce6947b96a60c2f617",
       "sha256": "0x0f343c95c4886f1b3eb52f350dea7917ef9529a4c9abb253032e97197d2cc66a",
       "urls": [
-        "bzzr://3229e06e8621e7ada6be11e87645f4ffc0743cd45ce762453b52fe92d2c781e0",
         "dweb:/ipfs/QmTk83vXRfr2BKBcMVqai7XgZG5vR3H3AZ98QVEfrjWPSa"
       ]
     },
@@ -7324,7 +6758,6 @@
       "keccak256": "0xd9c2442d36580f41cfbbbb42a2069c3b4b48538e2fdd858847767bf684a1b894",
       "sha256": "0xbf7c801d9c4f31a804558b5cbdefd2d24c057690f89a514c2b7da07b2672dd46",
       "urls": [
-        "bzzr://57168aad3e1712ff03d7030ebc9ab1f7aefca38cbe33f54ea91c0ee8a60b7ee8",
         "dweb:/ipfs/QmZjwaqALxyJoRLLvSdbTQAVfzEfiHtHyo69MPn9E2j2Lx"
       ]
     },
@@ -7337,7 +6770,6 @@
       "keccak256": "0x474a0c24a9cc5be3cbf69261086c8dbe69d7dc5c21a45eb6240886bfb2358603",
       "sha256": "0x17f9b081f5d5da5b7fd7d5e9d695eb47b35abfd3fd7ae6a3c1a6eda334d546c2",
       "urls": [
-        "bzzr://2f4887ce3eb4135cfba2269cae6950f548bf5a923fb7c03bdd9774fd7b2bb840",
         "dweb:/ipfs/QmV2xv1XMhksWRvTNcnc3DFqvQSH2dRQGAD84qnbCMdVK1"
       ]
     },
@@ -7350,7 +6782,6 @@
       "keccak256": "0x2de9d0c1b1f9207f184489430140ce30e6d4d271b549a6818fb2935447662be0",
       "sha256": "0xb97d328fbdfe1db2d850fa5cbbeb23233aff3826cd5e9cc192abfa14dfbd7776",
       "urls": [
-        "bzzr://f55dac604295329b17363fd4b3126d3545a6746aa9772e006c50a75eba69c6b1",
         "dweb:/ipfs/QmXYHZvNHNhxyLRsXvkhL1M42zWh67hoeSNmR43GE3sokj"
       ]
     },
@@ -7363,7 +6794,6 @@
       "keccak256": "0xdc79e44d30667620c2c61e8f90104842f3b060a8b6a9f92088d0eb3d50bedc57",
       "sha256": "0xa402aece5b691adf595614d7652bd33f199d89dc85e29e894190a8a7cac335af",
       "urls": [
-        "bzzr://89b30317900a1b87f3ade08fe3262a0bea6a3e48694ecabb0731435c1e547b7e",
         "dweb:/ipfs/QmTPep4DfaYV2vwTCvLq9ouFucH9j6GL9AFAiZpZCXZjpw"
       ]
     },
@@ -7376,7 +6806,6 @@
       "keccak256": "0x4471a568a1c75df69018b3b064022208d19aaa6eb84efc4856ebbfc762d0f586",
       "sha256": "0xbf3e1e8cf53b06905f94cb8a15facf8f0b10357d745aa03b0a5646c592ec26e0",
       "urls": [
-        "bzzr://377b8afb7ee89b059b7aa1bc4e1201e2906323f1621cb1560dba7f690c9d59dc",
         "dweb:/ipfs/QmbQsNTAZZe2PEaivDMPMgp1Lt26F895vi53k1M8ZnParM"
       ]
     },
@@ -7389,7 +6818,6 @@
       "keccak256": "0x014e646f532cb56750932be4d3cd29d470c208bf030005ad77bbf146e8d59cfb",
       "sha256": "0x03ac9236dfbce5f74fbb5ac2e238c6bab85a9d8fbd0dc003823996a1c22a9a12",
       "urls": [
-        "bzzr://4689ae8bd1e270d5b171e6a8f890d24339d3502734d108e12010cf1d7200dbe1",
         "dweb:/ipfs/QmYUmekUoBM4NpDMxPviiavTrWHpvpSvdvKzqzVms7yP69"
       ]
     },
@@ -7402,7 +6830,6 @@
       "keccak256": "0x1558d623b0ec26cc9b952bc74bb0df31938c1b23585d447bb434d6915e413708",
       "sha256": "0xf2f9863518181687d4330f5ce305d2985d7789af16f11aee9f9331ed1d7c2f18",
       "urls": [
-        "bzzr://8fb0e9c36f9b8a3dcc45296da89e641e9dbc1eaed420f0fc79940abe6576c78f",
         "dweb:/ipfs/QmedbATTJHssYjoWSddrXHCZyspfRSNLK3eAsmjYDuY7Z2"
       ]
     },
@@ -7415,7 +6842,6 @@
       "keccak256": "0xe4ac2d0679b8760c8723f87e727e2f659de5a63c3ef11db0a5e1f50402c8330c",
       "sha256": "0xcda71c93d76f305f8350f693a11f10cd1d6f1df933e28ab2e1ead748cbdeb1fa",
       "urls": [
-        "bzzr://32aa6458a0146b8e9acbdf0a41f173dd068ecab32619c7f97b4e6127e7aa4bcf",
         "dweb:/ipfs/Qmf6fv9WogAk4j73Wk8L92kUT7BUrKtTKToXUEWSLUCYb2"
       ]
     },
@@ -7428,7 +6854,6 @@
       "keccak256": "0x41d4e739536bb6eaea5d9b5103eca0a3528b8c3f9f3f557cd2aee1ffaf4ba041",
       "sha256": "0x9b9da80b19d7400486b67b4dda8d788f76f43d3cdb41396a5acb3cd961340187",
       "urls": [
-        "bzzr://b46987c91709b3d32edd5bea1056201033b969b217b9901c97e7afcd0e73df75",
         "dweb:/ipfs/QmfXPgVeTnj1TjuZGHgoi7XJSLdC2HrwgK8x4ULHZCaG64"
       ]
     },
@@ -7441,7 +6866,6 @@
       "keccak256": "0x5fb1d43783be7fe77996d4c8f2e493ea0a25125b264b3f4ff7a08f71be072d7d",
       "sha256": "0x987e8b40458d1a45068769457e06368ab127ff7c98427e8326a38bc41bc724cd",
       "urls": [
-        "bzzr://50852c6f4f0412af96c3984320ec74d2d41e6711bb798f3bc9c80111b98ab343",
         "dweb:/ipfs/QmSm2k8txG5BbU9oK9gJJtNaFHJUMKPZxAmCXAPtyvMuLW"
       ]
     },
@@ -7454,7 +6878,6 @@
       "keccak256": "0x773e0ed8132bdf709f8250e9a99f8b9bce06193525f31b27bdb06ab4786920a7",
       "sha256": "0xbdff40149dc0d9b75135b7148cf43479f44ebd02999dc51ea8866a8ab834c12e",
       "urls": [
-        "bzzr://db19d0e13e6b2a6d13b2c7567f137376b5b67a429c175adc8c196ac5e8185d83",
         "dweb:/ipfs/QmRreKAv5UBto6y6zUHyA6br11fRz4NFoNjUBdQkh1oouR"
       ]
     },
@@ -7467,7 +6890,6 @@
       "keccak256": "0xc285ade1cb194f535292be481f2acb06a577ab039e42b40e9c10815b4b5dd90c",
       "sha256": "0x6ad43efee5ff34e5e756abaf841d2b4dc4bd7326e010b7bbb8ee1329e67c2cc2",
       "urls": [
-        "bzzr://d22b0b679f63d8b171a8e2556662174d5d4a0091c47c1fcfe5e39cd626961c6a",
         "dweb:/ipfs/Qmf5rotARPhajc5b97maJtqa6E6JQGJ48wJqFS6Dj9Vbu7"
       ]
     },
@@ -7480,7 +6902,6 @@
       "keccak256": "0x83c97715841a0abd5de2c01740d941e193898721acb895472d96019fcda54195",
       "sha256": "0x47c5a21a7d07e981ace79548de9c8ccd00189d475d517171ff65263ec7bb720e",
       "urls": [
-        "bzzr://38e410f473c5c65a7bfd987a70d30e5b2973a59538b49e23469c1323bc65575c",
         "dweb:/ipfs/QmZNpdxynRR9XMXiehjL3KpydEbVt1LNn8Y3jmAojppaey"
       ]
     },
@@ -7493,7 +6914,6 @@
       "keccak256": "0xfceb48f32999b1d0e61c6627dca9d1306e41b304c2ad2d99d769189b2e1e9e1f",
       "sha256": "0xce017aba04a4e7ffae7bf5a4420b5560340bac0285fb0d5679423d3e3d5e2bd1",
       "urls": [
-        "bzzr://5a19d20245d4226bbd3f66f2042fc0bfc4436fe2dadb43b00e71ff8a1c9a8383",
         "dweb:/ipfs/QmXVgTwKC5ZRnzdXL4H3u3D1Z5inenvB2sGhkTTeNkTyur"
       ]
     },
@@ -7506,7 +6926,6 @@
       "keccak256": "0x69b7ac52eb6f7ae8362fd2bd7f4e54b3074353a5e7f449503d9ca676744c70ce",
       "sha256": "0xddafa75eecfa1ade5d2ff83c680bdd9872447cd07a8f6153077133170122a103",
       "urls": [
-        "bzzr://45abb27efec11d5400ea6c6f2f7214742a2bbc9ecbe6e6579d367f6fd81f7aec",
         "dweb:/ipfs/QmVGYC9BuupyHs77i3dcshFn8rmbarnz99Gca7NQ6D4a9f"
       ]
     },
@@ -7519,7 +6938,6 @@
       "keccak256": "0x5a8e9772b8239ff2b9bdb4c6244874e11d24bd3b78fdddd6fc11ed7acb27283c",
       "sha256": "0x769f8f04d53daeedf0d6ec32c7bde2744856b16c55be0dd9dc4b9a0a168930f0",
       "urls": [
-        "bzzr://bf0fc3f06de455ee8e62a785d9c64df80c08b98f50a46ddc5d3f2ef39e5cfdd2",
         "dweb:/ipfs/QmTMx4wFe5Rx6WG8hAbM727iu26zocASK4TK1H3do8D7oW"
       ]
     },
@@ -7532,7 +6950,6 @@
       "keccak256": "0xdee39be4221a23f47a1eefbd15f095573b2dec385ac8c80257869c7acddca4ee",
       "sha256": "0x97684a75d2f764b8942404b3f8267c295d90a74cb5297943212562392f1cafbd",
       "urls": [
-        "bzzr://5c21d6c3fb830c51ab520e5830f69bb24d6575597d6c4162c94ff8d417830844",
         "dweb:/ipfs/QmfB4d8wxW7bWQcrYUFeUNArm4JUFi6gvpWv7FDTjBhfnk"
       ]
     },
@@ -7545,7 +6962,6 @@
       "keccak256": "0x0be00feb352a616ee2965a9d52c9dee050a0f2ec7cd88a66b8eb925bb576a3b3",
       "sha256": "0x6579303c98b7aedadb869f80f497cf9bc06b1164a6c66310c554cd207c221008",
       "urls": [
-        "bzzr://559687514e9e4bdca9c8f6de2ead06aa2a5dd908f5cfef4956fcc147a030281a",
         "dweb:/ipfs/QmPdSfQuzL2TGKpz1uvL3DdS7MNo2ot82LcBSuLkZo1vCF"
       ]
     },
@@ -7558,7 +6974,6 @@
       "keccak256": "0x17b46419c667c91e996f4d18daadf8314cea4a7427ea8908a359870aaa69e1bd",
       "sha256": "0x1e553f8893c777a5eae28f81f0de80f2367fd768f6c4f63e34454c4b26cbc30d",
       "urls": [
-        "bzzr://92e3ce0b6d12a2a15cf2b018eafb02611e2f8f5c16f3653c08375edc54d3fe58",
         "dweb:/ipfs/QmY3giRD7PYyPicPcrHikZCmrLV9tzVDFHDEbGmR6WdLH5"
       ]
     },
@@ -7571,7 +6986,6 @@
       "keccak256": "0x1edb69cd506a2f9a8031bb2c15c1a6c9b30daf6322dbf2a744fe73231d9f0eda",
       "sha256": "0xe51de9f166d14a99639867e9b3172187c7c976d0fed5576b69c13525710d2851",
       "urls": [
-        "bzzr://0cb2c9225ce21408c947abe1ea615f3595800465dae309809b2726e74e15a2b2",
         "dweb:/ipfs/QmfCD3Ue8vs4jkMF1GtqbbAX2iVbmAH9U1deJqXfAqUHxk"
       ]
     },
@@ -7584,7 +6998,6 @@
       "keccak256": "0xf61aa7d2526b738016bab428467e6fc6111bb9856e84f4c8a7ac571aeff0c0f5",
       "sha256": "0x0a86f69036d1ab98d57c5aed139ceb249386bf1c03c12ce89f8b925d17416370",
       "urls": [
-        "bzzr://45eb2886024f81cdd35dd245a6c0ea635567622f68efeea75a9a873edc21406f",
         "dweb:/ipfs/QmbkSAd9tTEKnxyocvXebXWLKMUvdPVV4LbGwWw59dyhtD"
       ]
     },
@@ -7597,7 +7010,6 @@
       "keccak256": "0x2e87c7b3e6f239b5c0b975c7c9aed08123aab4dde0968eda3d66e813cf66759a",
       "sha256": "0x5511a967ef029833ddb89f7475e3ac527277f90a25655a359b8c516d5cd6a9f1",
       "urls": [
-        "bzzr://9740c14f251ac9f12e8234598fade7787b183fbebfe0a78608797f99cf31ee85",
         "dweb:/ipfs/QmSMjAhR7y9k6M8rP2F8nH9d5DNVLW65HRwSaGAE1r7A8r"
       ]
     },
@@ -7609,7 +7021,6 @@
       "keccak256": "0x6bf3bf312e572e6c25c06412307b971af3f75730a63cfa9e3ea50bc96feef7f7",
       "sha256": "0x6d666d08307afe4a40aa57140794f835a338d2ac4436154ad1a0f043851ac2cd",
       "urls": [
-        "bzzr://71756135f36a4d7647c0c1449c7b483f006ee346f151205519058def72c4a916",
         "dweb:/ipfs/QmeLfwmfJD7rdSJZzCkLyrxx1Qnvtcp1wU8nPVphVwxe82"
       ]
     },
@@ -7622,7 +7033,6 @@
       "keccak256": "0xe369d00f84e3a5fc35f947127360f502c51d6a8443616b4a11573f905e477661",
       "sha256": "0x1743de8257855d96f8144082c897164e767373ba547e5e265799cb6ca8baa688",
       "urls": [
-        "bzzr://2e42882f9d1e1eaad6b9a83f37411dff4b53e6d767669ba33d44164dfa99fa6c",
         "dweb:/ipfs/QmR4cYRSMEPVFX2UhKhgFtpPUYqzKSHqu5YZYN3smQHK8Q"
       ]
     },
@@ -7635,7 +7045,6 @@
       "keccak256": "0xfca41a2850d07fad7089c6570b6ac5f4a7b06e2d8a7fb42d3938abc38026f455",
       "sha256": "0x35f5dd18a05d34e9c82e012fb6fb76ebbf015921da135d7b4ee35ec0ebb48960",
       "urls": [
-        "bzzr://7b0173760a449c9151b4d0868eabb35be0ad7a64056e98e69e3d73543dd2e666",
         "dweb:/ipfs/QmU7H8ZEpuMoTigMumxFYhyiHL7RUdDYzBrnW42S5ehnUM"
       ]
     },
@@ -7648,7 +7057,6 @@
       "keccak256": "0x0d62718e3aafbda17600dfbab049f88bc291b05b0ddde45fe5fb27c8d7670ad5",
       "sha256": "0x002bc894230b31e66eb2629be37851768ce0f75b9d60c8cae177b999dee1b3d6",
       "urls": [
-        "bzzr://4980b02eb4f761a6cc43392c03632aa37e169cbafc16bb21bb40046dbae3b765",
         "dweb:/ipfs/QmXoJpo1b9wX7xZ2chvgYaRgJMGo58N6w2a3JXMhmr8g9m"
       ]
     },
@@ -7661,7 +7069,6 @@
       "keccak256": "0x661af24be152dbebe49cfb830ff0031bf411c02bc014275d057caf9f3e8449fd",
       "sha256": "0xcff512f7a9d219771e2ee7f02127848bc8f29e7b45fdf691432d1da1da484161",
       "urls": [
-        "bzzr://7d0f6cce2dcc26c37674f6bfc58a161bb04463bb5e4dd2c27c0e932409a92156",
         "dweb:/ipfs/QmSRUkpz13L4rUuL4YB3YFNDjfLYjA2yneQND4Ey3qtBGF"
       ]
     },
@@ -7674,7 +7081,6 @@
       "keccak256": "0x6169c602db78f98b75b051ff11991e0ff6a8006516f8061def1bf8083aa9f27f",
       "sha256": "0x026c5b3fdf2c7ffb7168037f2cad41ca9e2c5f7468c40bd29661778a4ca9aada",
       "urls": [
-        "bzzr://8ae41bde178e4b6f0b88cc0118a601deb3927c5f4f640922673ae0cb077b320f",
         "dweb:/ipfs/Qmah2oEAo7MuFzymQWcdxny97bm6Nof73C2udM3Gz1Z1pK"
       ]
     },
@@ -7687,7 +7093,6 @@
       "keccak256": "0x2b26e9b56c21e3b10e6cd9df8f6a979002e09d37ee1d0691d4ff80c59c39c067",
       "sha256": "0x84a7a0780999eac94ccfeacb3b1e49fcf1c497fa15c4f543cdfa8601db319dd1",
       "urls": [
-        "bzzr://32adb0b6f65a8936413454e8d1f9e58162e36882ef62acfbc7b28bc32882cfd6",
         "dweb:/ipfs/QmaDkuUScZjzpzBHGScmdGGEB5tP4Sc7idQ1PWYgbodLd1"
       ]
     },
@@ -7700,7 +7105,6 @@
       "keccak256": "0x9cbd1e3e2d92a876817309768fe2d46a3b93471b727255bac65d2802d9cf227d",
       "sha256": "0xa6ed98f8408452602ad65a7970e9dc70d2d9caa82efcef0e0be0a1b9a304a11c",
       "urls": [
-        "bzzr://b0a03343cc301681f02e84d9d5568f5c4817490fd7f86ffc5818d7657343d5c6",
         "dweb:/ipfs/QmToBDe78ANkyGJVrt4iR9Mv8cvqKygjPZcUfoq98CN8YU"
       ]
     },
@@ -7713,7 +7117,6 @@
       "keccak256": "0x4d55b6d3d39fecb88973eb74494f37553c376dcc970a096f68a359b9cec1be29",
       "sha256": "0x4f330e492065c94ec59906309cc763023347e163069a3b7911e97bd4b683ead9",
       "urls": [
-        "bzzr://74e3843d97f01418fe20804a915a4b09b2ce906e867dbd575d21aa711a7d8cb3",
         "dweb:/ipfs/QmUYdTTZX6PHLaCT26fuXtYAsaLADmh2TbBNubyirC7rc2"
       ]
     },
@@ -7725,7 +7128,6 @@
       "keccak256": "0x4d774dfa046fca4d838357949a50e052278a90ad2f417f0c5debfe7498028752",
       "sha256": "0x357adb49bb74c9eabaa034db28f96b4105def2b052c7795db8e30ad9a34cc551",
       "urls": [
-        "bzzr://3a1c2595504f14bd0bb1a93b4bcec2d95560abd0d23b29c00739225ef8956d2a",
         "dweb:/ipfs/QmP4J71T2maAavhQazHQrhjoGHyWQH3YZQzZhEL19rcLLe"
       ]
     },
@@ -7738,7 +7140,6 @@
       "keccak256": "0x9dcf0a106abf9bc00e6623a66cf31f1d74f11d6128df57936741e2572525b756",
       "sha256": "0xc394dffaa9b7c68daa68242ca630c9440f8a7585732f63580c1be72c6af2a59d",
       "urls": [
-        "bzzr://deca587f0a0d01daf5dfb10ef7403ef74a6f837e266c4aaa918c72f5d9ccfc7f",
         "dweb:/ipfs/QmX7wLkghMiN7BpaMQnggmokhSgSsAsRkKomZ2nsLPXxFo"
       ]
     },
@@ -7751,7 +7152,6 @@
       "keccak256": "0xd079159dce915823d95ee297c652f1f7546530fb166664246b3f28acd25d80e7",
       "sha256": "0x6867d72aae7a441d38cd4659d52f4d46d63cc716110de0c24e587eabff688a70",
       "urls": [
-        "bzzr://f447a123bb86234618437d3dcba019e2f2301ad97d89894f1a56b80552de3027",
         "dweb:/ipfs/Qmb8GeF7YmnC9YUhT7VMhpa17qnCAoR6h9QvR8TdD1Qvkb"
       ]
     },
@@ -7764,7 +7164,6 @@
       "keccak256": "0xe0db5d35e451f99cd7f99c6cf92c8e3ae10e297df8fe84320d03623881e30832",
       "sha256": "0xa541d2640e4e63db8641c98f7c1d2ead3c410ce6a76b21d722eb2a69afe68210",
       "urls": [
-        "bzzr://9d7bf27833ba5adc953a8390c080c0d9cca016ae2d7337c3e8cab03ecc279991",
         "dweb:/ipfs/QmZBi9yuJu2rk7u41V5T5xqLWjhm9FCWFrxpskhb778pkY"
       ]
     },
@@ -7777,7 +7176,6 @@
       "keccak256": "0x6a4fe8bf8536ca3567fff147ca368329c4da5bdf50eb91246503e1c31d916aa8",
       "sha256": "0xa81bbfe4612c48659a6de011317f7d81393d669306c05ec3740c7b7b50958bf8",
       "urls": [
-        "bzzr://c3a98ab24e17a4133c610edc0ebcc983e275b73280e3c349b65f9f3fc9454842",
         "dweb:/ipfs/QmdCoY5zEKgCnxS89QzUeXyCjpFPx4g567CYirPeNqQjKQ"
       ]
     },
@@ -7790,7 +7188,6 @@
       "keccak256": "0xac7aabfe520833df7e1f2238849afb8313e6126e268bbb10d0ab53046ab6132b",
       "sha256": "0xb7bc6a77ff6a1c371ce1d7e40e8d7254e68f19bc465fc22ff245f850a76baeb5",
       "urls": [
-        "bzzr://20703aee36012f9e4e54c7daa39fc9068d1568869836a858bc58499d6fe8b366",
         "dweb:/ipfs/QmX65FBUhoj5V1k9UtcanEjLFcvPwEDnqESX8ZB2ykCmMv"
       ]
     },
@@ -7803,7 +7200,6 @@
       "keccak256": "0x4543f78afa2a5698c6c78da53555d995c9c58259f8fd73bdad39426e0b04d976",
       "sha256": "0x207da73e85054417972fdaf1e1cf50766a3f802e1b4df4b0eae5c303dc90c009",
       "urls": [
-        "bzzr://7833406414f75c0d2b5abdf47a5157e9cf60091b62abda2d468c6ac5f1aecc35",
         "dweb:/ipfs/QmfLWMHtt3K6FXj33wZNTUccki77Dr5QdE4PbDZGvBLuWT"
       ]
     },
@@ -7816,7 +7212,6 @@
       "keccak256": "0x6a782d905aa62d3914f58c2db906c2ddd798b2170ceafacfb36961a0f5c42413",
       "sha256": "0x1d58d86dc2cd2dd2ebe2f7d6f6d4d8fcd14511f49bb6ad991defcdf4428182aa",
       "urls": [
-        "bzzr://94b53a03c61ec4ed714b00f1e513b722c33e474f75f3eaa0f716cd59d09b8187",
         "dweb:/ipfs/QmZVVQWQTTtZj3B6jnk2dzsmRafUW2pCAGpD35CBJQRYax"
       ]
     },
@@ -7829,7 +7224,6 @@
       "keccak256": "0x01a38914414f9f95527021af8c2b892b6ce46ccd322a0c4fa21cde1a0f683b09",
       "sha256": "0x63fd9e6acc0dcfb4200dbbee1b8d3b8dfb43a857e17cffd8d7a28d69399e5bdd",
       "urls": [
-        "bzzr://92fcde954781cfc9eb7f11c3bf8c467cf64f02b3b0c374a72df326db2c1af4bd",
         "dweb:/ipfs/QmNbXYDY1oTR7dwNGscPoUZ3WpeZekxNyXkCYwa4jXfFwh"
       ]
     },
@@ -7842,7 +7236,6 @@
       "keccak256": "0x5d92bca46571f6e6fefdcf4fff5d740b2eeaa6d98b8358d74cbb1ba1542f3e79",
       "sha256": "0x91d4d828eb2eab1e0e8a845e92598338c863d155218fc9a30b04b7d136d2c969",
       "urls": [
-        "bzzr://030a9e60bbe3ba456bb7abb8b7d587873fe7808d170d840d3eaa2f4d420ffe2e",
         "dweb:/ipfs/QmSprdumYexdpwhLN1BeQRv7cdmi1QYzucdmTYbXh9p4uP"
       ]
     },
@@ -7855,7 +7248,6 @@
       "keccak256": "0xd671c9392773cc38e251b8a72fae0092fcb1c710c4b2b24ba27fd21919743e99",
       "sha256": "0xb0aad963055e1ac07aeff60088845aa836f2882bfc92ce296820660a9215a164",
       "urls": [
-        "bzzr://e6e6c3184117469e2f98dbe5ce0047ed20906583738e11c0eede655597b47450",
         "dweb:/ipfs/Qmd1e2eT16RUpppnhdHHQh2fh6xwmNRS4xXCfNQwneir4n"
       ]
     },
@@ -7868,7 +7260,6 @@
       "keccak256": "0x5bb8c1b248c763ac2467b9159f9aba238c2da108280cc600800dc1914455d641",
       "sha256": "0xb69a51977b9a2babad7c79eeb1a1521a8cfe2745ca48d7e004cb9053e7f99993",
       "urls": [
-        "bzzr://c0a0d3cbe9f4be81bb486c8ce4e2c85cf3769616bd092e4cab1c9fb1315db43e",
         "dweb:/ipfs/QmfU9vCgZyDPsdLWh6pXP2uQdMUs1RazCKDzffsmwNYktf"
       ]
     },
@@ -7881,7 +7272,6 @@
       "keccak256": "0x1e80c189d0f4afa503e8e0cba2922192d11f89133519882b9b956fc816934747",
       "sha256": "0xc13095228bf582dae0b8e20050700f851c70fa4c0763a68513067f1271b26fc1",
       "urls": [
-        "bzzr://128f6471ad9facac5bd1740cbbf0a60fa870d4234dc387f3b018e21d9f398b6f",
         "dweb:/ipfs/QmdtRphgRBfT5CzjaXjL5E8Mk9fBPkkhBudsNFRmx1xh56"
       ]
     },
@@ -7894,7 +7284,6 @@
       "keccak256": "0xe7a26aa2041bcb417870a42b73b7db42b5ca300036b5d9109100e4a9ecb48f02",
       "sha256": "0x7da21d58e86a62278e5d6f46805b9319a62da5a52f33071d11f7adff0e92493b",
       "urls": [
-        "bzzr://066c6f0cf3b5edbc065d8a76a91be98b1c9b460bb033f3ca7fb2498f72e9bbe8",
         "dweb:/ipfs/QmZAxpTb8rY8W9bzd1Fd5g6xpFoJNJzczBKDoWuxuLFY9P"
       ]
     },
@@ -7907,7 +7296,6 @@
       "keccak256": "0xf0538f923829602620dbfe54a39f154ae6b572a85ef3b7cb2a6541b9924fc32a",
       "sha256": "0xb895821b766da91134297883e9fc84118b0326c8bd9500a3fd4ac98ec8962df8",
       "urls": [
-        "bzzr://f7273c0793c584073e29c2930480e2d35367e4778c81139b2586dd96822accd7",
         "dweb:/ipfs/QmPqBUsJx1aaL4Y14Q9Z7KjzNs781hXJd7sse2jzPtDVvH"
       ]
     },
@@ -7920,7 +7308,6 @@
       "keccak256": "0xcc992b7ecbcd8aa398fea1f853521db303c0137b2cbc42c84803cdafe0920ba2",
       "sha256": "0x3b8e600335ad76907674ae729f8b31993b81200259f71a0f9a19e3375b27781d",
       "urls": [
-        "bzzr://2e8b138a66c723d49de7b88a0e7696a9599bade142eb0290fa08ea0ef63b43ff",
         "dweb:/ipfs/QmQw2daUgJSZnCRS92CWwPebWuSPYr7FiLNMH8RamDNqSC"
       ]
     },
@@ -7933,7 +7320,6 @@
       "keccak256": "0x06f39286bd6d809c4dc5569d7a13ef413a93051a324aa75fc71354fa0a76dd60",
       "sha256": "0xa646faf420851511af7604f06e6bfccf928424c33c5b5f1a9acf1f163dc66480",
       "urls": [
-        "bzzr://f3e812cc3ed8e89150e6cc6f8001261786796380e3ac2f45b7fc356aff04818d",
         "dweb:/ipfs/QmXDMRjo5driJ5BAs7vD2p2JQik4sKiwjhjLYWccKT5sVA"
       ]
     },
@@ -7946,7 +7332,6 @@
       "keccak256": "0x019e0a0c02117ca30e6646d7bba24bce38cb73578aac0a102f218905e3624690",
       "sha256": "0x4c2d06207f024a7d592244487a1490c57aeb0443ccdd2f2085a948962f97f9a1",
       "urls": [
-        "bzzr://c0641708570b988d7a5289588ca74e3c0e351544d9a0c599525c68869e869f4f",
         "dweb:/ipfs/QmeBJbbx7Xe8DZeB2y2WMoM2Ht6HN8w1i1a1GPNub2B6f8"
       ]
     },
@@ -7959,7 +7344,6 @@
       "keccak256": "0x677b4b240a43c942fb46ed80377b80d8cadfbf92b880aa9df1d312c34e4f5d8f",
       "sha256": "0x36600a213f9e233a3779fd9c9e12092f9021f501af38b7bd6114c466880791d2",
       "urls": [
-        "bzzr://0fdad5a9127bf464728af748d5a4aca4c4b65ac34d6429728f6e653a289dd8c2",
         "dweb:/ipfs/QmTKSpyKqQLjopnbBbfCYCiszRLcmfZgvxs17qP7jyRyvT"
       ]
     },
@@ -7972,7 +7356,6 @@
       "keccak256": "0xe6f440c786c26a27310dd0b126c9ca119cbb2e8de2288b17a47566897bc77f0e",
       "sha256": "0x52fa83aed737c65ed0defbe64ab691eefa6bd290703ab450250169f07221affb",
       "urls": [
-        "bzzr://86b23ff6f3b6dc2347c25547653e7273053b6586f5e2b01adb9e86f7fe208a28",
         "dweb:/ipfs/QmUZdcvQZB9giDhAi3zFBA2ruN6VHPeM8gpeaehCe4hS6p"
       ]
     },
@@ -7985,7 +7368,6 @@
       "keccak256": "0x33eba53b4d17a3f9a0ab560a019a65cc16b11babc2a7088e084931c567e57aa4",
       "sha256": "0x7a0c4a269151ef83f4d304c57eb3bbb35428192ffe667906a2b5155a6f8ae7e0",
       "urls": [
-        "bzzr://f34e6e888caa52c357a9ebcf49500cf580edb8768f48f13a77da0cbd40cc657f",
         "dweb:/ipfs/QmPuA67xc191Bfjo9oBBakAyMLZxoHXivHG7Apw42STdzo"
       ]
     },
@@ -7998,7 +7380,6 @@
       "keccak256": "0x674175651b60e2aa4bee31f70ba46e84abbb7a5e75b45ce9811b11fc4449553d",
       "sha256": "0xe84b7a0ad7074cd5ab52f66edd0d09ee2684ac0f92143c21abeba535ebd47bdb",
       "urls": [
-        "bzzr://c263198dda2bda257842f6977257a9a95f39c6a98c9c8ed0eeb0c75c81288983",
         "dweb:/ipfs/Qmb4QoaGA6KHRYQcdzicuidvgyh2LmhvaKnmcT8aXwgiZe"
       ]
     },
@@ -8011,7 +7392,6 @@
       "keccak256": "0xf38e13f6581d8fecf03b0aefdc37483cf1d92b96f1e221314bae1cc7931fb6cf",
       "sha256": "0x348d6fb6d2067e6e4e583672bb475323ac8044abf30ee6456be8dced89edf7fb",
       "urls": [
-        "bzzr://a4b84d7d3ee374b6b043ce42e545c1d0d99f34ff62ba4113f366675a74e9e341",
         "dweb:/ipfs/QmNsFBvUPoVQ5BHBf7vRJKKXFGoSW9xSsJMe5mthQ3wKdw"
       ]
     },
@@ -8024,7 +7404,6 @@
       "keccak256": "0xaa4a6a50e5d433d1f1f71940a23b9d403dfdc287dcf13deb16abc7a3e528f202",
       "sha256": "0x82b5bdfa4c15dce14973c02c4da039083daffaae9bac9a8f39fbdb3eb427d460",
       "urls": [
-        "bzzr://f0ac6e7db29d58408a6dcfdee05781401ec16bc19907c3a33ccc955c34af2fcc",
         "dweb:/ipfs/QmV3JE4idvxPcfoe9Jcv3toEjXzPYca3cSFyLpVwReThbg"
       ]
     },
@@ -8037,7 +7416,6 @@
       "keccak256": "0x91ba6ae3a79f0a292bf986407f37ccbbf792e06e7dc705015a1ac1e7454ee973",
       "sha256": "0xa23a6f8c49e70b663e433b9a35ce8164e3c7ae8ea293fb00db335c4d6ac6c9ba",
       "urls": [
-        "bzzr://0d434c365ea4aec763fb8e0f067a1aa3e57b5f3dc829ed931d4d2aecc90c7406",
         "dweb:/ipfs/QmXQYbQQei8v2P1cfwgPGtWcBHNKBLDQde81uYCrFHuwLy"
       ]
     },
@@ -8050,7 +7428,6 @@
       "keccak256": "0xf9b7a206252a7a525ee873bc4749a0119766caee26528b7ea6a6e3a06fe29678",
       "sha256": "0xc75f1a4797970bb8c46b9b53323e0620051c7220a3a0010010d0246069341735",
       "urls": [
-        "bzzr://8069f1af91606baf87a0aace134465ef78fef6b5859c25e5783cca4b6c7e0740",
         "dweb:/ipfs/QmTtLnDjX4VTMwjJ7SvaTi3kj9WSsndj1GG5arScUxxtQh"
       ]
     },
@@ -8063,7 +7440,6 @@
       "keccak256": "0x7fa04c99f1e0f0ba91bc5e8ce8399e512661ea80cf5b4488b767cd48a8ada486",
       "sha256": "0xaa84385d48fe08b8b88a58248363bf4d9b8f3ab3dbcc70d07da292c83fcdb97f",
       "urls": [
-        "bzzr://d3dacbbca917fdd2db404879de7ab84a402c4072b5add4322756f9c3e7c3e71d",
         "dweb:/ipfs/QmcmmujXATBygJujwXyHbUpDwznrpEhssC9LiABVwKkiUe"
       ]
     },
@@ -8076,7 +7452,6 @@
       "keccak256": "0xf50e82dba5042b5b25a728aac0139beebc441f9be003a6330871bce158fce613",
       "sha256": "0x93f161115d4fa7eceebc5213c184670b20503de08aaf31683009e26cf0654894",
       "urls": [
-        "bzzr://0d674fdd8e3b0c060e1e2e6a73e6808b94b08b8ca30335c15f74d436d2714084",
         "dweb:/ipfs/QmbdtZsDjv8jWvyNsANuydi5k611revhen82uZgUiU7aiU"
       ]
     },
@@ -8089,7 +7464,6 @@
       "keccak256": "0x686df05b236934fac2d474651690200506d5b732adcdeb5f050d4a02edcd63b0",
       "sha256": "0x36cff69c6fdd1c0d45fdf9d3ad637957447944b1689c437ba467a3cc922b1d58",
       "urls": [
-        "bzzr://a2ae97ecba3aae3545d9ae04e38c4803e96fb347f95c294dfd3a102754485bbb",
         "dweb:/ipfs/QmcqctwFBvioxhNDHoLFNe3CLxo8Rkc9uFLBEymV1PMNLz"
       ]
     },
@@ -8102,7 +7476,6 @@
       "keccak256": "0x96117f54dc7d50d2bff0ef3c78c154bca50759060670a14c637b9dfb4f172a28",
       "sha256": "0x3d52af8137e91d6a429cbd3cc228d28d53b3915d5c4e9e0351502a7f759ab767",
       "urls": [
-        "bzzr://954ae765042d120d1c438103f06cf11aaeb5072fad5ff5fc7e3b7f2669cf9a88",
         "dweb:/ipfs/QmYToNsHcoiZt9mZWAyysCKFb8wX55AoRUGXSVQemerybR"
       ]
     },
@@ -8115,7 +7488,6 @@
       "keccak256": "0xcaf95066df573eaea7e6e813211e2a29e17cd2fc6982c36e676fd16d83d9d3fd",
       "sha256": "0xcb75a1e7bada8377d7613f6b14a56198c2fd58b6b67a960840c59382120bbbd5",
       "urls": [
-        "bzzr://d28ee93489dc1f3f3583aef0e2476974f6997db4b9281989e16e10c3ffc0c01a",
         "dweb:/ipfs/QmTitEF1W4Xma1BmkHZrS1d2QZBTvHdoTHP62dwyhSeQeK"
       ]
     },
@@ -8128,7 +7500,6 @@
       "keccak256": "0xaf13034e79afe8e2e5c9d11dd2c7283da4310ff3dd17d9d82fc7a299e836698c",
       "sha256": "0x3c20881f100b83696e37bce72bb2e20009fd01a6dddcac2b31614e6cb48542c0",
       "urls": [
-        "bzzr://abc86ca39e17ff31e10e73b564983ff47eb6af4d7d5e00a1c9a806f8733adf92",
         "dweb:/ipfs/QmZqRhVeMHiu6tzhkXfxj5nAieycZPScSqEdygk9e9DZKt"
       ]
     },
@@ -8141,7 +7512,6 @@
       "keccak256": "0xa5df87af38cdc7037ca94c420cea8015a0149b1c88794fbe72426ca648ab0dcc",
       "sha256": "0x7a1874787f2b5fe4bc3015c159928c1e4e1be1b1c34fd01afe02fd43a2e547ef",
       "urls": [
-        "bzzr://8b23fb5fd0a207121ff1472ba1b81d11cf71cf039f7f62b1803010976c948b16",
         "dweb:/ipfs/QmPKVyz7B98umXQ7tF94VSgNV6adnaDPvBijyBKfgpDFCC"
       ]
     },
@@ -8154,7 +7524,6 @@
       "keccak256": "0x917cc9f0ca067ba30a4f107079ea890eae3354e94c4404798732e245387fcc19",
       "sha256": "0x266de5676041a7803a5dbbb6703b846436ec6fd0b3cb6cc24937bb87461f596c",
       "urls": [
-        "bzzr://0d84b299fb96b3e55b640d501cb1d727c0372ef7bcd2b789c95c2f57aa02fdee",
         "dweb:/ipfs/QmbmaoYwdSm1UymwdLNVDSoJ9hKmfs5SjBm1iCXLBWFfvJ"
       ]
     },
@@ -8167,7 +7536,6 @@
       "keccak256": "0x37ecc5746ae64b7422c9a43249d9856b496bc19840e3917e74a4c30f420a514c",
       "sha256": "0x34ed30064d2dac305b7ef522b3f77bfe346dbf2c66f1f550d3b2b7c57fd9928e",
       "urls": [
-        "bzzr://64e27a5b654ba7ca58a6d5b228e332b6075a1e30c338a76d36d33e5f6a7df4f0",
         "dweb:/ipfs/QmbR7BBsGHpLBJpCHrajgeGbA1Q5AKim88Sv6WizBqVs2x"
       ]
     },
@@ -8180,7 +7548,6 @@
       "keccak256": "0x9b2daf828b70e8974d8e0076ba1d688428f58bd9733f04463b67537c06843bab",
       "sha256": "0x5f21d787078679048732450a67ebf70a237af876bdc2154a5df2b515bc873b9d",
       "urls": [
-        "bzzr://2b4b93ade7ae9884690c51f1a5fbdf54e549be6acb181c8f0e32c766fc9cc455",
         "dweb:/ipfs/QmY3qq8MZuz5fsmsWqS3mbaF3FXLQUDynoTynUDBimurmu"
       ]
     },
@@ -8193,7 +7560,6 @@
       "keccak256": "0x24192cb4482a2d3b05df301c63dbfe689fd977566235fb09fd18f55f5fc27fa1",
       "sha256": "0x8399b7b591239843183555f2461a4bf779cef94ca693a8553c8f95eeaddb8597",
       "urls": [
-        "bzzr://1be9f2a71aff8b5fc8526333d1d5045d306d626934de166c9e97a0166d39352e",
         "dweb:/ipfs/QmeTdgVgW8JgT7J5davbxJZRAz7LhQD3jKgkZP3uNxcBub"
       ]
     },
@@ -8205,7 +7571,6 @@
       "keccak256": "0x58f38d5282278f80ce27c57cf00d8e7521fd7061d5b164ee5119e88b906590dc",
       "sha256": "0x0a6b1175a618d0341da604a672f4735a96de862b4611b79fb02b6424336df3d9",
       "urls": [
-        "bzzr://38f84b39ff79bd9a11e4a541737dea28aec4dbe3e403186b79a69c5c4d5d4328",
         "dweb:/ipfs/Qmbxpo24W4pZzjWSBNsbW5HucPYb5eeprF5tvFe9brvyD6"
       ]
     },
@@ -8218,7 +7583,6 @@
       "keccak256": "0x422babeba3aa8f396b7e20d39fbac8964f04896dcbb3d7b9e965f99339c38de8",
       "sha256": "0xefc0e48b8def93c3c07083237b0e6b04f9c40f274e35a78a05f83a7840cf8638",
       "urls": [
-        "bzzr://49f8690f39b7bff446e5165a2cd08d86ad71edaac8d1a7a6b47fceae92a66575",
         "dweb:/ipfs/QmUFMpkFH98LFf9nv6ih84oKkrtXyPSzHAS4ZMSq17rPe6"
       ]
     },
@@ -8231,7 +7595,6 @@
       "keccak256": "0xf626876c61164c9e90774db926fae1b7de4a91fc8729c30eaac76e353655538f",
       "sha256": "0x48b5e94c2dfd43e4f7c6d25f74b9aef2ed5f2e40daf2f64a93958ea0510e2d16",
       "urls": [
-        "bzzr://100d3cb98773db090da8bce8a6ee9fd24322bde77ac0cb0485660346c72fcb01",
         "dweb:/ipfs/QmZDoEKJ3JiEZymhV6jUnVwSonUxevXzuJuextpiomfJqK"
       ]
     },
@@ -8244,7 +7607,6 @@
       "keccak256": "0x1b3437768a034a1d6b72e780ad20d2c1b7b6fe002d5f73ec5286592b8ae6bd59",
       "sha256": "0x2a4e0346f104ab5a632acad8402058ce1d266a1f866ed75dce42c73e9b1ccd11",
       "urls": [
-        "bzzr://460321ec55c5bcb9a7789f6a675547aba47bd440e2ccd505eb12f8fdc26934d6",
         "dweb:/ipfs/Qma928c879s5QKXGQY6AQKvYSrxt5L7tm8v2acg1kTAaaB"
       ]
     },
@@ -8257,7 +7619,6 @@
       "keccak256": "0xca8c85eb7aceddef7601f003405f748628b903c083cc1526861b53e4437a695a",
       "sha256": "0xe28f8b13c614edfdef15509d4da9d72a97062a2ce0b418f4083f3b11a3357d57",
       "urls": [
-        "bzzr://df3e92531d73e620d949e4ed2fd2928f145bbc709b0d1b0f443b0dbf07862ff3",
         "dweb:/ipfs/QmYhPipCAxG4qVJ4LWPMSBtTKtanYk32Gwtb9ND6ErXBYf"
       ]
     },
@@ -8270,7 +7631,6 @@
       "keccak256": "0xc45f7c44431ed5c44ea07c1ab492db3eb8d47d0c20fb308e04ec7426aa6ba5ed",
       "sha256": "0x84891f2f2138af2d94114c5745a970f7e21e2ec455b335e3b14d5b09f9b12c65",
       "urls": [
-        "bzzr://7a61a7a59a5fcadd1ad996e2709d44de79eee8ea865b3f0e395df496feba8154",
         "dweb:/ipfs/QmemJF2iQRDryUmBFQKfAPePu6eAEqY8D8wburprjhHoUt"
       ]
     },
@@ -8283,7 +7643,6 @@
       "keccak256": "0x7f548041b4d36aefa2e12d62b43c06a9e7830dea3652ddc0ba8e4965ac08bcf0",
       "sha256": "0xd55a23edbf9242ada09344c85e50f7f85f3269fba5fad99b0def3bcf447d4378",
       "urls": [
-        "bzzr://296e549a59c8050886fbb8c429d739da37636c2c86e674c7b7ccd44eb262387e",
         "dweb:/ipfs/QmcchdST13fpqzbcJZ2H9LSWofjnwQF3y9kef4Sc66KZJA"
       ]
     },
@@ -8296,7 +7655,6 @@
       "keccak256": "0xbb5d0388366c17c061f0a5276ada07c02085fab408143dda1243be861747a1cd",
       "sha256": "0xf7816ea15bc1cb7f166dd1e9f8820bb0ac2939b6588e470e85cb6a61dd951452",
       "urls": [
-        "bzzr://877f8ca279db599e3a4e03b2a3ad647e859ac30b55e6731c870e05834d3bc44f",
         "dweb:/ipfs/QmVv6qgXNoC1EcfWfghPLVvhwKDUVwajXx2HsJ2oebhGGp"
       ]
     },
@@ -8309,7 +7667,6 @@
       "keccak256": "0xe010caf14c26e42e110e7e75b93584ac09ad1dfd36982e2d632c24440ca4b060",
       "sha256": "0xc1890f0982fab50727778a64948623efe301a7d64a7cb1a9f18e4f32b7138538",
       "urls": [
-        "bzzr://bfaebcb4c916c3fbc939fa3d097f1e4bdfd471e8bc167d55805ab393434c2833",
         "dweb:/ipfs/QmdiEHRnkihqhehahG7VJh4cgdbZ54pAfs7jXPdE7gnkKr"
       ]
     },
@@ -8322,7 +7679,6 @@
       "keccak256": "0xc5ff051437e99702493d4b5ba7fa85df0bdf607a282773f24854e4fd737ccc01",
       "sha256": "0x2825ca8b15901a42a11f3688c06dad92ddebf696cfa3e85ba1a99d219b6960fe",
       "urls": [
-        "bzzr://04eb39289b86f6683ad6fa8ed25ca3eb831e2577f160bf1326f475e2f4552cf6",
         "dweb:/ipfs/QmVHNn5Wv4sTTGkCSb9PZwPD2JCdLnPFT9tBVwx5QSwrhW"
       ]
     },
@@ -8335,7 +7691,6 @@
       "keccak256": "0x203b92735013ba73c62ff27cb71954fdb295e6bb0133f92d22cae22d9020d334",
       "sha256": "0xa31dd70244b82a5c2f5f90ed9a30b1266ce927457019980afd4eb65f44629732",
       "urls": [
-        "bzzr://994044474d8de362fb7548132c72e64809d29970402c6c38cab29e9d3f639a2a",
         "dweb:/ipfs/QmWk1sgvDnaKeCKt2Dp1fZVvCk6j5947N24FTpRhjdLD7K"
       ]
     },
@@ -8348,7 +7703,6 @@
       "keccak256": "0x77fdda531139925af820575884579692b6fa01bfa2eb8d9dda48b2a874373490",
       "sha256": "0xc04a13c99669699fe764817101fdbf0d7cf108abd277596a7495d528d305940f",
       "urls": [
-        "bzzr://821695207333e5932fb51a4244cab4be45b9f5ffefdbaa456b35dbe70c4f6658",
         "dweb:/ipfs/QmQFXbar6QTWfHqzBAGBRCtyv5h28kWsQz96zLhpWpZh8A"
       ]
     },
@@ -8361,7 +7715,6 @@
       "keccak256": "0xda56167bc3233ef6e2f86298ebb0f8c7f09cee53950c98916b4c5cb2929e03ab",
       "sha256": "0x0348f79a77146735a93555c113c3e8b72cf683ad9bc135030f290011909ec9bc",
       "urls": [
-        "bzzr://b73cdd0d9a2e21a73c09111e8295851f44e7a91678b77e86a957faf6ba5c0aae",
         "dweb:/ipfs/QmeBNCWKyLAaRibfE7wnuXFepL3aCBAYH2T6psv5jVFnK4"
       ]
     },
@@ -8374,7 +7727,6 @@
       "keccak256": "0x895bcdfe96df52c8df42ca01997031525a4a2cb285fbe68cccc533eba7f4f949",
       "sha256": "0xd03bac274c0cbb1b9dedae883b22d18d55c17f49f86bf4520c0b55d54e969ee9",
       "urls": [
-        "bzzr://ffc72e9236ced6169ee6c680e35a1124b19c5f10dc4916010deea4b685a38c1f",
         "dweb:/ipfs/QmUTEaGYNQ9QS8d6zvw1BsqDGfPUxmyaETbayaQe33upkW"
       ]
     },
@@ -8387,7 +7739,6 @@
       "keccak256": "0x299c102986765e87ef155e8d6de5cd0d289167eb40f6afb4ecceb922947f63c5",
       "sha256": "0xd939ea85747b6d08ed9ad28425bd2e201ee983f9bd3be7a0fe0b622275acc8f7",
       "urls": [
-        "bzzr://53f9938ebc7540899b1406b1c2614f365f597bc7e50a91cc5b900254190adfba",
         "dweb:/ipfs/QmdWy7b3kZ6kgffnTUp9gjAc8qEaAJL3fCF1RzQLGrrCAw"
       ]
     },
@@ -8400,7 +7751,6 @@
       "keccak256": "0x4771b82ada4e5cc4b806ac09960aa59bc5b30bb7eb10da2e9f8e0d9e5e7f8cff",
       "sha256": "0x6d5b9e9606623eb913f4adc6b2ed3105a5743d78845f629eb496d51fb1d8381f",
       "urls": [
-        "bzzr://0d38169f3dec81a9a5bf2646e22462eab771e455c61706deda6639412d205860",
         "dweb:/ipfs/QmdYjFz9eZof7x5UiJB9twZE8nKBp8YpX2Ku6uwnCnHj4e"
       ]
     },
@@ -8412,7 +7762,6 @@
       "keccak256": "0xc90ad3242c8b9c0911c79e65d466b3ed3fadc74c142de2f40e7aa1ea7ef937a2",
       "sha256": "0xa9856e3ac7ae3c943f457054f95552a9cc128694e196e4774e183fd7fbd6f9ae",
       "urls": [
-        "bzzr://10e1cf972e0330409b59fc02157698209410534262ec5598db11480a42c6925c",
         "dweb:/ipfs/QmYwwdB1X6aivm8me71EwWXFZjGtjkAmUuT9qEDQBZmdSk"
       ]
     },
@@ -8425,7 +7774,6 @@
       "keccak256": "0xe1681642865ea3337b9a34c92f296df834c21aa92ac4a4acfd7c89882e2e984e",
       "sha256": "0xa0ae129ea074488080e9d7cfc09e4abb393a3240b811db613c46b9dd99118f0d",
       "urls": [
-        "bzzr://0b3b2c5ede0f60fe60f3e94df3af1945943523b398271824ba884bcf777bcc1d",
         "dweb:/ipfs/QmYKDHvotNE98nc2JvPFM8EUvC9fu8MvHX7FVL8jqRcpCL"
       ]
     },
@@ -8438,7 +7786,6 @@
       "keccak256": "0x578b226ebabab8128d1b5e5b52d7a4e28698488f5edc781f0317af3661252570",
       "sha256": "0xb1aa256dc49772b87c3d80a7609b3825562641ada958d5385f626232dd91c431",
       "urls": [
-        "bzzr://959ec6e91b46d417fe4d70de9e75cd056e982eb13a25c54dfbb563208390bc15",
         "dweb:/ipfs/QmNkob3H6kLZekeds7iSELwjfEqdddMPN5ZzcFJUVBAhud"
       ]
     },
@@ -8451,7 +7798,6 @@
       "keccak256": "0x82be0bdba2da6c01cbbfb2fb733d82adcae50d307dd8a5bddf3a635d0e039e73",
       "sha256": "0xe58892f7d5d681eac1ab1c413d2436aa4190ea49a8c3b676990bebb5fe662991",
       "urls": [
-        "bzzr://9bc11a097b7b33809919d7273bbeae44fa370e7f3548bd6cc0aa11da13f0ad1f",
         "dweb:/ipfs/QmW3cwTAk8py2tQ7gRbBnotoMribFqZhNwRUGMwMopYcwC"
       ]
     },
@@ -8464,7 +7810,6 @@
       "keccak256": "0x6d63ef55f655f2e2b004677d90f9cd88c9f3b18ff4aee1b748d17eff84e56147",
       "sha256": "0xe64bf43fedef837136795550a95c63ea698c0dc10ac023cd542585224e94c449",
       "urls": [
-        "bzzr://e6a8ed23773c9858dc84c1e3a83646558a09d2dce717ef72080f9ca742dd70b7",
         "dweb:/ipfs/QmNqwYnPwacFzWH7VjqdMAQg7KrSKnQuEZkWjCiXmX8V2V"
       ]
     },
@@ -8477,7 +7822,6 @@
       "keccak256": "0xaf0c77de4aace954d1b09e67f2d3ecdf8ff763898c082deb6d32fd4223478a7d",
       "sha256": "0xe50b3116191f81a958d668e3cc833bc74368fe1e827e3836d481feccd053c7be",
       "urls": [
-        "bzzr://46938db890b365eca1c63405fa78d4e75b7b322d8da36eed38d7f5b2ff1608d2",
         "dweb:/ipfs/QmackDcV3hy6A7UiRkPx6VnMPXLFCTbEM6XSYu7zpCgpam"
       ]
     },
@@ -8490,7 +7834,6 @@
       "keccak256": "0x73d41afea19c84a551a805794edb3b7343f6d0824c97926710f28a8fe0854e35",
       "sha256": "0xd51158fe9343c5e250801773b8d82e3b6c4d13c27c0be7e87ed056656eb6401c",
       "urls": [
-        "bzzr://126e33876936959ee8f2cf5d38304a741bf0be4303f26bb9e46310a414d19bbc",
         "dweb:/ipfs/QmWZHaf9U1bpriiCCnW4SrbrmEoths6jTtJv6MxCeSHu9X"
       ]
     },
@@ -8503,7 +7846,6 @@
       "keccak256": "0xa5051fd5073ce62dabd51f519670eaa2839ee7faf34429c4ee04d2705f79be66",
       "sha256": "0x6753c25c524b25e34e3e7d950696a04ddb625fbc8de64345d68a0d13f6ca8077",
       "urls": [
-        "bzzr://8d5027313f52cbf877abf5973efb220ae49a4be0fb0a56a2fdc0f49f8cc1cb84",
         "dweb:/ipfs/QmP6RtTpSimRqg87THr3BCzwXD1b2KJLKbsZApZAtxkxqS"
       ]
     },
@@ -8516,7 +7858,6 @@
       "keccak256": "0xa4ca2a4748b9e90832bf9835b426483b371563770acf9ccef4d81a30e3108ff8",
       "sha256": "0x26076dedcb61a65fe7220d43da24f7136423dec9d2ec40a1f83fe2a3722bb875",
       "urls": [
-        "bzzr://108c1dafaa5a842a1614485bd3bbc22d73c3862f2bfecb2c605c0acfb8792c7a",
         "dweb:/ipfs/QmdxrHTSWks7XfeebYzUL89SMy45rxy3j8hGsL12mKGk8Q"
       ]
     },
@@ -8529,7 +7870,6 @@
       "keccak256": "0x39312022d3a3b528331a9b35f2509bbb97682cb4a3b96782c973386855fcb2a0",
       "sha256": "0x82da7d45b4a19768c91252db518bacdec2a3c4ea69626a4a9e4c7c681db02710",
       "urls": [
-        "bzzr://108fdae44c3f5efe594b0c4a3d79ed2210f828ea5e099f3b0385bc4b0e36548b",
         "dweb:/ipfs/QmQB5biNVfhP8v2chwV4kCLmUdenkJNRr7iTp4XmpB5bF6"
       ]
     },
@@ -8542,7 +7882,6 @@
       "keccak256": "0x29e43fea5428ce188189d8d200d557751b5e625531fb0839bb36728a38ac282c",
       "sha256": "0x3e2849d032a738673f213d7f2d3bf7c49a823154a3be764d4a8f005aa91668c8",
       "urls": [
-        "bzzr://30f698949fdffdcd557f7e930cd43de30f61c2dcbd236c0deb0c0e87c25b4cab",
         "dweb:/ipfs/QmSiNFrLMgMXtJw5RLqXEmNLK8MSjcaLwqPxP4hauCB841"
       ]
     },
@@ -8555,7 +7894,6 @@
       "keccak256": "0x55c5bf50b5a75bdcd87e6344a2ff66600af3dc6131a7b11e9d4be569e8a2db4b",
       "sha256": "0x89db11878ac585aaf3c1574d3734e152900cd16bcd156f633886089462b5df7a",
       "urls": [
-        "bzzr://4947816f6f069ede4f33f61e68cf405b2fbb581d2269fc26a2931151886fff01",
         "dweb:/ipfs/QmP5mThfeZant4jHiUS6FSByKBHaLSsWjE2o2WGfF5fY8Y"
       ]
     },
@@ -8568,7 +7906,6 @@
       "keccak256": "0xeba4aaaa956d4ee7843d4f1c38e5d4fd38ae733a8feceb4e62561254926281de",
       "sha256": "0xcf5987ddc84b45e9f5f07ae77a8d69958717e1bd271edcfbf660c07861c174cb",
       "urls": [
-        "bzzr://1bb3757835d00d94b8f4561f4a51dcc7fbb6adea08b79299edfab0f10f6e3e95",
         "dweb:/ipfs/QmZWRj9HMGfyyaEceQRZQnWX6Kuvc8hZ1Z1bXqHbQP4GVX"
       ]
     },
@@ -8580,7 +7917,6 @@
       "keccak256": "0x6695104643815375924901787608f42c25607038d7c8834c849b19658ff68a03",
       "sha256": "0xf855a1e0816ac4426b8a9eebf37273b89acbb18b076a519935a05ca212c71f34",
       "urls": [
-        "bzzr://23950a583f2a109e175014e5400d104834adf8a1bfd822c97e83c82a3adaaf42",
         "dweb:/ipfs/QmYfvH1JSvt3uUiJdTCP7xAWF5zxUF2ESbgcTkaVDcGZa1"
       ]
     },
@@ -8593,7 +7929,6 @@
       "keccak256": "0xd0dd8284920022153ba76269f04de829deef39c203fe5837fb9f882929895eb8",
       "sha256": "0xe4a10667fecf645fbd594c88a180561c802cbc171cc4d3c28d7868faaa973ada",
       "urls": [
-        "bzzr://9a3d6e2b4d833fc6fb9e3dc0fbe253d16b11ee468dc3fada7694f9d9e801ab69",
         "dweb:/ipfs/QmXsTzaYZhxxRnPH92JEoBBQt6WTcurobRMGN9npcpkEVh"
       ]
     },
@@ -8606,7 +7941,6 @@
       "keccak256": "0xf52e5970fb9589f74570483c36d5076416ff62b81ed1c4ee35d01be081012275",
       "sha256": "0x93b8b372197b55d2dab4961a119add5f4e9b49ae1144bbddb8b59a8bd8cc2b89",
       "urls": [
-        "bzzr://e5150e5a0d0a327b9414cd53e79911d8d25dafe3f00a1af8d3f7465ece2b730a",
         "dweb:/ipfs/Qme9a7imLxpcGCFKeiZihFsCFekg6Zb3XJ2yTB4AYrFzbV"
       ]
     },
@@ -8619,7 +7953,6 @@
       "keccak256": "0x568b0e383ccebd3b1c42e02ada29bbed9e3a030795ee7706b68e393733ade177",
       "sha256": "0x7191ba4abd56ff47221e1f0364b14b6f4da876c0eee09d6721235c84b1a97342",
       "urls": [
-        "bzzr://8438b01590d25452202d3c3c4a31f7e33ffdb9b37a59e0e38731945ec453a559",
         "dweb:/ipfs/QmPvMsZjhAUrLxANTSkB5jbBSdhxnrAcPw6LJ5sMQgkC5o"
       ]
     },
@@ -8632,7 +7965,6 @@
       "keccak256": "0x074bc3a08fa9ef0935199d8ea572af92131a2b4805c4a8d2955c236233d09f7b",
       "sha256": "0xcf5ad4846fc946a79ce8417c0ff04c3cd6fc32a99345b06093c1839b4587e486",
       "urls": [
-        "bzzr://e872ce13be4989f9714d4f049da488e54822d449e958da4bb2ed1678b4e9d81d",
         "dweb:/ipfs/QmXJRaz67CwzTcbKwryMh5UmKudnktMXpCn4goY9icyS3w"
       ]
     },
@@ -8645,7 +7977,6 @@
       "keccak256": "0xa7d45fcf417dc513b22d0206d43302fd55a8088a70cde2104230ba33887fdcbf",
       "sha256": "0xea9ac4a9f504ed30273dac22c4dd81984bbf7fb1d5de76f3edc82f88e2472b18",
       "urls": [
-        "bzzr://0d9705180efbe25f74ccb956a4cac2ecad64d867b466185748f92b98758b7c7a",
         "dweb:/ipfs/QmNUheRYcsCj5igdepjLoTSpmdWjtd5odPxUPRRW3dC6KL"
       ]
     },
@@ -8658,7 +7989,6 @@
       "keccak256": "0x18128895ce2896bca0b848218cd435e7854f3788d492a2bb1e1234c08d76077a",
       "sha256": "0xb0a1af73b8a9b4f8aeb92d62a69cee7cd426941a0da176c819bf8afdd1e703a4",
       "urls": [
-        "bzzr://907e2b4a5a144e32cc43587d34979f83db710768192317ff8090b0d3f6b36313",
         "dweb:/ipfs/QmeJcuoAewvd96EgJzQ16xQdoZtCLJADsmAsTQPeLKMGrt"
       ]
     },
@@ -8671,7 +8001,6 @@
       "keccak256": "0xd8e8dcb0ad49115ecf48a13efdd0cc864b1746b76c3a1bd7bd9a6606c5cabe8c",
       "sha256": "0xaa8de3a4d9cca37bf2bbe80bf9b88d23826edade65aa3fd2729770d2cac02c90",
       "urls": [
-        "bzzr://5090e783723dd4dee643965cc17655deb1545756e92cff703759859e04a71e97",
         "dweb:/ipfs/QmXJviQRZVn2aFHWPezpcoQMM3zzbcMKg538QbsxQKU3xC"
       ]
     },
@@ -8684,7 +8013,6 @@
       "keccak256": "0x9821b9bc6aca93e5eefc7094d766bd41aa5a89896f36d2f470431587dbe87c96",
       "sha256": "0xffb507e3afb4601d7c81b3d0330a30d73c69dc7c10c3f452e233aa47352a9983",
       "urls": [
-        "bzzr://4e125afa6ebaf4beab4021064722d28a9a219da9494aac083363b3252044ede3",
         "dweb:/ipfs/QmUvwunpbB1NMY435up8APN7ADb8KY6a6ZAbwNET5dUc1S"
       ]
     },
@@ -8697,7 +8025,6 @@
       "keccak256": "0x1234677791131067032271567d40b52937589d9469346e35235219014e1d4075",
       "sha256": "0x95873ecef443785689d1efb0df7a696f9c9607d1748ba28989beab4ff5dfe4fc",
       "urls": [
-        "bzzr://8d720057a9f9ae483bcb97f331061a0125c63de32cb6caf53420532749588428",
         "dweb:/ipfs/QmT3zjcJj8Kgt8A6yhpSMF9Z3Y8qB1Nn4yjXmcs6mMxaNA"
       ]
     },
@@ -8710,7 +8037,6 @@
       "keccak256": "0xfc739b4a321daba46e06c5c2e8b9b093a23a8ddb111d73d02c3e4ec175f68178",
       "sha256": "0xf92fceb41a3c9d1f025ea14ad0878448b2f2fbe27d6eebdafac88459a248f143",
       "urls": [
-        "bzzr://aab25d2cbfa4df03bb45dff89b4e301f7c16d3ac607d4553fad496f67f80d4ce",
         "dweb:/ipfs/Qmc3MdS8R5HtBvhmjRmucG9o2614pmXo7vpuDK1rxHMwTg"
       ]
     },
@@ -8723,7 +8049,6 @@
       "keccak256": "0xa7cdc18fae2df526b4b8caf118cae137ece0f0b73309e77689721f6ed22a151b",
       "sha256": "0x7385fd815f52b7c06ae5bcc467e618ce0bf714f11aa9e0c23ef3c7eebf5d2221",
       "urls": [
-        "bzzr://484669ab1efca6a18ac0c348c2d317c4c4bfaecd5937d18efd62a11b9654625c",
         "dweb:/ipfs/QmSU5EbDTAh8krvUS8SgHVWukziCKxsd2Uku7uisXGcjuS"
       ]
     },
@@ -8736,7 +8061,6 @@
       "keccak256": "0x95b88a6561d15583af84c0d89a938245584ccf71fcdf150ccd130929324e3693",
       "sha256": "0x96355ce21ae0c330895ac7527d9d00e4ffa329ef652d8f1401f24b2cf50fd030",
       "urls": [
-        "bzzr://306e6927104eefeb76306ace4f2df428fb621a77073aed31f0287a08f4a1f7d5",
         "dweb:/ipfs/QmUNYNyvTmW85y4jYmcVKyWjQqj9D12W1p763yWNqrLk3Q"
       ]
     },
@@ -8749,7 +8073,6 @@
       "keccak256": "0xe37e176e70b30aaf877584cad2d766f2fce0e4370331161d7e1e186e4286c6a0",
       "sha256": "0xb2863000717ea928dd0c934963c82d3ec3205da55927b2992e3f2bc728b2300c",
       "urls": [
-        "bzzr://8eb413f3e292efa1de808f54719c4a1398d1dc89cd3cec1465103a327eda5818",
         "dweb:/ipfs/QmZ1eUZdtd47cgRSDPK7LzNZmNpbEABqMMpk9k6BwUstyN"
       ]
     },
@@ -8762,7 +8085,6 @@
       "keccak256": "0x8a90467121cc67a8633924922a9d99c5c5d5355a75dba2c85e4b0ad10e73f7d8",
       "sha256": "0xf498ed59d6957b6070a3b121efd648467480e31fd13e32b7741b50fa182d413a",
       "urls": [
-        "bzzr://6b5b9d878b0baba8ce11d4125b490ce362cdf680d2257921957f3aa818448eb3",
         "dweb:/ipfs/QmQZz6R4SRoqmfGZWpC46NUTgLXK3kApN1Z1qNMCdPjn8G"
       ]
     },
@@ -8775,7 +8097,6 @@
       "keccak256": "0xed8555d125f14edf822cad5df4406713285060848ab7ed27001cf24a26f3837f",
       "sha256": "0xb73fb3a5a39a51abab1fa9cf034fc49cc994b63048046bab2707ce20eb0c2923",
       "urls": [
-        "bzzr://302bb6fda40744e4f418293eb222824159e24c08c86f2324eef94e5150977186",
         "dweb:/ipfs/QmafqirmLehbdzcgV1ut5G1xp9Hhyk11j1BDytGAH1cvVU"
       ]
     },
@@ -8787,7 +8108,6 @@
       "keccak256": "0xd8d79f6a3c2bb4f74a26dad18b99b8368051574415758c872f41e2c8235c68a8",
       "sha256": "0x306e67055dab5a25572a322b6eee5c82018750f97ebd5700ee46913d06d0fc80",
       "urls": [
-        "bzzr://b703170cfd59ffa43d30147ab4727b3f8a193becf701b473d2b99d4f7eb667bc",
         "dweb:/ipfs/Qmei5XTKBwKJSctz3DjTJuUD3BMoAQBAn6Y26qgoFDvFgx"
       ]
     },
@@ -8800,7 +8120,6 @@
       "keccak256": "0xdf33f3fbadfd50d61320db9d5178ea22f50c5bd31bc4b0e4ec7e1c1495a4f72e",
       "sha256": "0x26165e15738f60fa4508fe24c7d5bab60e0ef7a352b8c57764c734e808a24800",
       "urls": [
-        "bzzr://855d538751584e5b931a6e511eb98fdfd8cc16ffdc87bf8fd2a4f09741778bea",
         "dweb:/ipfs/QmZ7BvVsoxcMchNmAurk9NPm24UU5aVkeV2A893ZPcLA1S"
       ]
     },
@@ -8813,7 +8132,6 @@
       "keccak256": "0xa5f15124cc2784ec6ea3d08915c35e3f92c738432afbaad5429fb53c756df61e",
       "sha256": "0xd6e704f50381993c349e8b5d06d6ea71a9d201ffa3d86b6bddb57da1dd7a4f58",
       "urls": [
-        "bzzr://eee58f1ae89c50699a6fbf52f0128215254520425c0d3cbb2a53609a5177c727",
         "dweb:/ipfs/QmQhNPCj17ZE2Aa5KoRZdQsiDDuToBy7RrqWekH8jHNyFa"
       ]
     },
@@ -8826,7 +8144,6 @@
       "keccak256": "0x59352271fa198e51b41642bc0b3390669dafa262c95f26cbccbe38aeb14a199c",
       "sha256": "0xbd10cdb69a3731590e0ab4013b2df14dd7135fc4d480913c26124c80af5288e6",
       "urls": [
-        "bzzr://24242565be96446ac6641d520ea5f15175f085d000cc11af4e24a3d974acd761",
         "dweb:/ipfs/QmRpNp9TbehetmGhgPnRscL6JiMEJwg44opsU4fhvmHL6P"
       ]
     },
@@ -8839,7 +8156,6 @@
       "keccak256": "0x4f33f00c4be4a05bc656ba1c4c996f634dfefe776a020403e31098f78e51c91c",
       "sha256": "0x9003826d8ebf0100794f257764ae888e452ec5e300bd71a2cc0a6786f77999bc",
       "urls": [
-        "bzzr://a330db8dc0c01552f77f8c80f6d0a5071ccbd4f8f5fd7d1b09810aec94f057eb",
         "dweb:/ipfs/QmZDEsch7aEAhP6Gd4JtcqXgzpkwF5D43nA4nhnHDaqDY9"
       ]
     },
@@ -8852,7 +8168,6 @@
       "keccak256": "0x26da296635d5413afa44e4884670240ec2de32d96a87cd2948c57cf4ea3d6aeb",
       "sha256": "0x8464f2d93a824499c5daedadc202a9c1bb20cd65b1f7d075df87325054bfb191",
       "urls": [
-        "bzzr://bbfe4b099ef11f3b856cbb091dbf2897e0fe46861735b80689b2982685fe478c",
         "dweb:/ipfs/QmYLrnBXJNv9Yz2tJPJLw5NfS4HCa3J3z73w69enhUFnrp"
       ]
     },
@@ -8865,7 +8180,6 @@
       "keccak256": "0x2acd0064757304a11e15faa5491074bc4b3a2a2b6d0b13347f9e6ef0137e231a",
       "sha256": "0x4567ad770203e28585703ed0935d080a9f26db0eb79a824a9d8f0e2cfc0ad394",
       "urls": [
-        "bzzr://e25ff29f4321ab45eb36da5d74156c7f5c823628fa7bf6d22907102ca453a19e",
         "dweb:/ipfs/QmWYD33N3xuQnwsE4YqQey9DTQ2d4WiEZpVjXC12sNLT6D"
       ]
     },
@@ -8878,7 +8192,6 @@
       "keccak256": "0xc6cb673014a53bbe7695b473607605cc1e22672496f5c8d1e047476f6efd2ed4",
       "sha256": "0x6ba697a84667def0eaef75c4de3e2b59f0c8d693ef4634bc6085d60339a06606",
       "urls": [
-        "bzzr://ae41d6f2be3ab589daec773891bbfe7c2a3cfd9a3c8bd6494315775a1302427a",
         "dweb:/ipfs/QmauYrvZCHNs11DPT8KFb9NSpE1HQbh5GAD3N5X6UsimiE"
       ]
     },
@@ -8891,7 +8204,6 @@
       "keccak256": "0x62ba5f6ec1288dc031b2f6b05088b7f47011accffcc5ccde58170422bb7cd67d",
       "sha256": "0x1bf1ace9372da874d8194e5964d6dcc2ebd771e56cbab65932e3b17d8da79b54",
       "urls": [
-        "bzzr://de9d0f40ff08d771cc28fa9f3f2709394ea729a2cd1ed7218fc7083d05c3fbcd",
         "dweb:/ipfs/QmRtUxA5bcpKLrY8Ew8jbWsRH51pAVt3BQRUVEagY7pk1g"
       ]
     },
@@ -8904,7 +8216,6 @@
       "keccak256": "0x34a3b06644198cee18eaea32ca7b33fe9c5fa0deaa61af7362cb9d57113032a8",
       "sha256": "0xd7727ad2b6aedb52c41c1c8bba64cc4f513cc174648a1574d3fff64fcffaca38",
       "urls": [
-        "bzzr://fdccab1bdae42ffb3673797146ca9492a08492d5a96a14458a23c3cc568b9143",
         "dweb:/ipfs/QmaoHFcFBiQ46eL2o443wXeB5oumHHQckWNj9Fo5xS7V9q"
       ]
     },
@@ -8917,7 +8228,6 @@
       "keccak256": "0xdfb80be59ab0162a8f0ad4c943e52e5a3e1eab2cb4f1946d75863ef778f868f8",
       "sha256": "0xb1ee876f4284d194bb31d954e1c8bb3bfbda16ba5e64cb5e61c497a5c19efe96",
       "urls": [
-        "bzzr://95804a42c53a2c69190ab4f9503b9227260845f38122e35c9607fee182e3d499",
         "dweb:/ipfs/QmQtwJ2hjnLwimKeMERjZKecrJ7aDNfQutc4XK132Xu8qo"
       ]
     },
@@ -8930,7 +8240,6 @@
       "keccak256": "0x7cd3d683c0841626c0635934a9d933b21181cbe9d5ee4a88fb7f0f724dc3d261",
       "sha256": "0x3733de193923616092c1b608d53ec20e91031dbe0584affd235a84635e2fc796",
       "urls": [
-        "bzzr://c82cdba4be56cc3566c031076b298d93b438c3a97f597b9c2622a3fe8a8a598d",
         "dweb:/ipfs/QmNYbznu5iWvSAebfLn9HePf9BkmVSNEMYNseRxXym9hNq"
       ]
     },
@@ -8943,7 +8252,6 @@
       "keccak256": "0xef109f15163e774e094fa2b885ef8fd7e0a5e018f23907ca975622a8c9a33336",
       "sha256": "0x6480c4dee4d15f515eb70dc2931d327ebb42e6ea5e750562c90bb97ee4f17d0a",
       "urls": [
-        "bzzr://2ab765f94a6286b1f57d4b2e776914f9bb27aaf95a48096af30ba8886c154ad1",
         "dweb:/ipfs/QmYbemtQBDb7AFfKgppy1qNqF2hXrJduNeDQPgEUQAnZ1J"
       ]
     },
@@ -8956,7 +8264,6 @@
       "keccak256": "0xd895a8797783089325e25bbfaf578c55e3822097d2c1111f5121bcff7d8eaf01",
       "sha256": "0xcfb46b1ae6f3ab5272675555e1f0b42a7ac8184d1681c85db97891e02bbe23bf",
       "urls": [
-        "bzzr://b166594b5d72401fff74d5e6463c3c45e94a5f1fbd5f119b9340673f2b06cce1",
         "dweb:/ipfs/QmPuSKF8ea7z8qiufVt935Axyzj3uJ1gBAB2ji8vivLAiw"
       ]
     },
@@ -8969,7 +8276,6 @@
       "keccak256": "0x47d2bf196ccc052052a6c756f4c9b6312b261f6ba297362f79712be0f377a518",
       "sha256": "0x91eada0f2e711d3c50fb9b2f3473b401aebc8244b8e4acf539765644245ed883",
       "urls": [
-        "bzzr://c56be14a95fb989c3b89e2a62c527c74d70b8753cd72b26a4e139a2997497110",
         "dweb:/ipfs/QmQtNKzytvU5iGM774P4nmL9KFZpvxVHviW1XhMfouhebc"
       ]
     },
@@ -8981,7 +8287,6 @@
       "keccak256": "0xfe04e7343a4daba43a2344ff196251f832a9dfdc2b54af84044aaa4b10363351",
       "sha256": "0xb0ed6d5b9ff105e8169887da4798a4a1421a7317b02f1cacd06bfe6f69e5d389",
       "urls": [
-        "bzzr://f83c27f2d98d0f33056e999594ac32c962c8be737f0762ccf2bce4fd52eb8cf8",
         "dweb:/ipfs/QmNd62qF3urZxCcj7hSdJZkua5gw9LTR1WC6FsSVUGzvXL"
       ]
     },
@@ -8994,7 +8299,6 @@
       "keccak256": "0xf28085632d5dfd9ad455b23abf26e0947041b5e1f7094070f23492924769325b",
       "sha256": "0xb0c11d351e844b7e0bb8149236edb0937e3cec9f294ca878e0e716a18cc1de66",
       "urls": [
-        "bzzr://47b8f60f312b8bd67765f60c2600a420a59d18e80efd5c925125090e4b8fd96b",
         "dweb:/ipfs/QmQLVmL2UaSHSKPe6RWsYBzVBbEGaBZ8MmRBMgP5uNmJxC"
       ]
     },
@@ -9007,7 +8311,6 @@
       "keccak256": "0xc8de19269b115585a25e12f2db1b3c94830dd169dcaa45ba4a7e54c44672b745",
       "sha256": "0x6ac6df64bc83e970a2ca873ba2ec8ee8ec439ef09c5de16f2ca62868999c18c6",
       "urls": [
-        "bzzr://ce20a1c747369cad7bf35ddbae594010c7b5cdb271a62064928089a715a381ad",
         "dweb:/ipfs/QmcBzuAmBNxyZTgWBiRFhJiB5NEaG57eoyayr1RSQZSugJ"
       ]
     },
@@ -9020,7 +8323,6 @@
       "keccak256": "0xcd72c67d5a120f3e29b3856e1daa24dbf2af454591161b03096e6053b1342c2b",
       "sha256": "0x34f9bd8002d8537217b7270749a128d777f2ed09c40655ad35fc3e8239d80bd4",
       "urls": [
-        "bzzr://0366069c667f017a3cb48639752d04849b11c78ec621df7a6f4111217561aab4",
         "dweb:/ipfs/QmRkoChiKSEp5EnPzKjkFxNRd8ztRoBvbKuxAuM6WQq8BK"
       ]
     },
@@ -9033,7 +8335,6 @@
       "keccak256": "0x58b8bbb6b0e6e70f6b60300ba40d38512b6c360c6ad006a6a45893212791e9ca",
       "sha256": "0x290c93033ad0b51227730df0d27c9521cb57428c36bdd9895fa2ed4f8320f8d8",
       "urls": [
-        "bzzr://212cf00ee735b3843aefa49a9e89fd3321d27a1015ad3e831b025c60bee4e71a",
         "dweb:/ipfs/QmdSeDzbMU42T8o9sij95ED1u2hrAzXwxmURqpQicTkyFz"
       ]
     },
@@ -9046,7 +8347,6 @@
       "keccak256": "0xac164fa143a7f7b495d728d12a01a8cad27655972ffab59f917e737e9d737890",
       "sha256": "0x29958a931d13ba24576b1d130215f96836c43cfc9984dfa722e446032b5d758a",
       "urls": [
-        "bzzr://ea787c58bcf307941f67ce399551ada996edcdb9a2b8326d759ddec17547a51f",
         "dweb:/ipfs/QmQzAkWqXjTPyTEk2a8HXEEjWbgm2qGtgRyE8FsLiw9p3Q"
       ]
     },
@@ -9059,7 +8359,6 @@
       "keccak256": "0x3ff123f50eb3a541c2c0db5fd7c85204a032a729d302f218335261f3ca0cc688",
       "sha256": "0x8b450bd5d7ef4d34bed8010c99c7dae7a3595861cecaf325a1d9cf068a063aa1",
       "urls": [
-        "bzzr://0bd1b777787636ca4e77ad5d30ac59f2a37b467aa582cc86c1a17ade69ec7f50",
         "dweb:/ipfs/QmRnksyKtXPNm6NZg56KhbVNykmivJ7JHDQePGH1ZLGs83"
       ]
     },
@@ -9072,7 +8371,6 @@
       "keccak256": "0xd761390cbfe1f7bb419ecb2f526c1e02ff1cd5dd8d02b04cafee599b3755042b",
       "sha256": "0xd5b2957dc91e152b8e37b5dfe6c6312ae0af57ef033b417d104fa49e2bb672e9",
       "urls": [
-        "bzzr://d4828c71fba9492a4569249c65dfacc39cd831b5187a1ed880634352365a3741",
         "dweb:/ipfs/QmdpBagXAwbrGXNdSfM3BwhMXWowzntY8SdsJJibr4wNiV"
       ]
     },
@@ -9085,7 +8383,6 @@
       "keccak256": "0xb41c0780b8db9801c8dc5abce4f2f718a8a59e974b035917e76e50e3aeb24fef",
       "sha256": "0x86bba07ff8196c26586cc4c0fa44b69fe2e29b4fc104d3a5992c50fc685f77e8",
       "urls": [
-        "bzzr://5ccb6af03ce8ded2facfa82ebe6dd4820f41d259bdb02c200476d222acf3c587",
         "dweb:/ipfs/QmZb6DBAaA3JbBQLSzRzrBMbQtVueuEeSyJt7XWnR9f5HP"
       ]
     },
@@ -9098,7 +8395,6 @@
       "keccak256": "0xe6672dd3eaa8c71f4f5892a7e0f41aa628c069731fabb1860c5c99237dbd86e2",
       "sha256": "0xd11c5b56da77aa93faec7ed81a33c32803462f3f3d768270414eebddc71c6c4c",
       "urls": [
-        "bzzr://74a52b7052920819fc43c7663126979b601d1864a53d859df636bfdbe7556a93",
         "dweb:/ipfs/QmSMDo2ZeLDGqJNCVD6mUoHazWmWt72FrLKS33xmq2BLUT"
       ]
     },
@@ -9111,7 +8407,6 @@
       "keccak256": "0x2093ac10c1b274429a523b864e02daf3755f04861a4d8fd0a2231d04379f4dbf",
       "sha256": "0xd3266eeb43e693296325319d182457fdba60f02bfc14107b9eecdabe9cc7104d",
       "urls": [
-        "bzzr://d91b51ca393ed921a309db36ed2bfbc8fb2908a1b2cc58c736bfe0de474bb097",
         "dweb:/ipfs/QmXrRoXQTxRcjzR2FoLhHuWzPKDwhCaFe5dGjtmppdNGSt"
       ]
     },
@@ -9124,7 +8419,6 @@
       "keccak256": "0xd2e3adbb6144c07e74f0c31d338359d80d12b39520ea23ddb5593c380ab6443f",
       "sha256": "0x952ec93a88468bb92b8970551a43dfcdaf58da08826eb53ea67bc85a0c343a0a",
       "urls": [
-        "bzzr://8b8014c7071c1f35c676f30fd20d65385280c3adfe103713faac62a6ddff2133",
         "dweb:/ipfs/QmYKDjJ8FYNCozD2xjfogJPVuZTcGLrvqz9XJhCaM8NNny"
       ]
     },
@@ -9137,7 +8431,6 @@
       "keccak256": "0x92fa452a84f81dcd05ebb0e0f767cd9f94fc771f0a9996dde1807834fe006a32",
       "sha256": "0xea85995e174aa1ce95bd2d516c01d9a38ff3cc330aa0377f9c2d695cfd5ba8d5",
       "urls": [
-        "bzzr://900c1d362613b0be71b590a41d67ab9a388bfe83d8de510ef3ece1a9cbac68f1",
         "dweb:/ipfs/QmNkvJj92MA3Jd3QMZy4d4ZMuiQSgZBfijY3wTvE2Zx4Kf"
       ]
     },
@@ -9150,7 +8443,6 @@
       "keccak256": "0xe2f2d02ba326fafd3d3d7566687740b3cc7c904cd1475af85e96863a925c43e7",
       "sha256": "0xcfeb5438703a13bef30580928a88250702be15686dab6a549379f3bd88f36434",
       "urls": [
-        "bzzr://e3541b14e5667d6de96f2b3fc34a7e12791a1f3a37f454c4ac372a17d436b945",
         "dweb:/ipfs/QmT3ZSgaEK5eiyc6CWuGMo6ksDzgDbimX1x3pg5kSGuemW"
       ]
     },
@@ -9163,7 +8455,6 @@
       "keccak256": "0xaa5b7eed94ce0617ecf5d62cd037ea594fd13638cb36eeb1c8f1c4a227fa26bb",
       "sha256": "0xa0ea5941ea31e8477a1aeacd6804f7450916b5128736d9918f745983a217a7f2",
       "urls": [
-        "bzzr://f5b4083c69cd5dad9d1bf237664397a06fdd1defa4892e6b471720579b45d766",
         "dweb:/ipfs/QmUNqwh7WN34XLKky3yGcjm2Rz8FFHteiJkcDN5df1aZG6"
       ]
     },
@@ -9176,7 +8467,6 @@
       "keccak256": "0x86f3a251417d1546fc8aa89419334dadf223ac75c538a11459277d1f30c79404",
       "sha256": "0x6637de2675ebcc127adc3c684fe4f6db227d813f0c2c8c1c44353b9628e3dd6f",
       "urls": [
-        "bzzr://42d609a5e6d79da576c4561161a45e6517225419219bf6d0c000b3334c175c1a",
         "dweb:/ipfs/QmVxz88K7yPqq1n6Wk7omRz9yCT9DWkmh4q2GFNEKmWaYT"
       ]
     },
@@ -9188,7 +8478,6 @@
       "keccak256": "0x7dab358bfe745766bf640e78799beb84646a856717b773eb36c08d274f24fd21",
       "sha256": "0x4b78ddd0da9d01983e9893dbe6d66152f4049dca09ca97cf26a6b8939bc793e3",
       "urls": [
-        "bzzr://b1d6cee21ac31939a391b84c465160725699c5baf3b7ab74f27f45ecc91387ad",
         "dweb:/ipfs/QmPULESv1DkHo9nimf7CRcfrPVKZSUppJBcvehgGorER5f"
       ]
     },
@@ -9201,7 +8490,6 @@
       "keccak256": "0x6a779dab9b81f72ce10c4eaccbd348ab161e686be7751ada3939ec4921e8d3c1",
       "sha256": "0x8ef8f02939252239fe655f906e2db51df40fba815a9ae213107d7cf6800f65c0",
       "urls": [
-        "bzzr://266d168a31519c89b391b2a763128ce632d95caae1700b73e9158d7bdc85717b",
         "dweb:/ipfs/QmaXKAgWwWpfHJ2LYE9FCJhv4QWjToqdQBbhDKz5PwBB5c"
       ]
     },
@@ -9214,7 +8502,6 @@
       "keccak256": "0x067a8270714ebb6203aca0e6d877ccec715df993d444241f7f639b0dc88bcc14",
       "sha256": "0x178993a93cbb5b139c2c50c1a47c2a54ba6a806f393e991e54d93bc7012e913c",
       "urls": [
-        "bzzr://314a9992ebc7061e1e7fd0cf93d5e3b137b78d8a74f45e89dec965bd2a19ca40",
         "dweb:/ipfs/QmUbMDCwFjrTsAB6348KM7zos3cbqrxVCEjZjcwkdHmX1C"
       ]
     },
@@ -9227,7 +8514,6 @@
       "keccak256": "0x36d45a92f56fe48cd1d4ac53b300a9a66620f2cea16edcfb69d745231b2309b1",
       "sha256": "0xb68e0e9438ce1a8142c933aff65eebe84b07d0971265427195c1f9eb3d022b1b",
       "urls": [
-        "bzzr://7024e323b8c0ea3a263b6f98bf2257b492ce0bd47a89eaac3a80a2f2446f39c2",
         "dweb:/ipfs/QmcNjZUfSVJfdUvebdCzRu3jG3LVqjUV11bMxTxkLZWeJ8"
       ]
     },
@@ -9239,7 +8525,6 @@
       "keccak256": "0x79b5637e6ed22dc77ba31b231b0cb53cd52f578c83a666a43e3e2b966d6798ab",
       "sha256": "0xef3429cc24ff6d6e89484210d72bbc43ba2541b9d2f00f797b6575270ece69d4",
       "urls": [
-        "bzzr://5c74dd1e1563fa833a35f2a1a9732aec28cbeeb5e8b0afe7a74133c863a370bd",
         "dweb:/ipfs/Qmf7qLYQVZsEfhwWCyWefVibZMZ4jp6ZqYnVsVzeA5wpMR"
       ]
     },
@@ -9252,7 +8537,6 @@
       "keccak256": "0x21f2613c9ac8033b239749b790055503806593d3576be66457a774ec544d5a5e",
       "sha256": "0x1a05b046d97bf50ca22342f82802e2f90b30a60d6efbe8b61b54b0d233e95aa8",
       "urls": [
-        "bzzr://87d0b653f7235469354f0dd755f36ff87de41a2edada6226ece956156d98d460",
         "dweb:/ipfs/QmS7XReNZhUWo5WWb9s9jiNRZfhdtBr4SH12dTyMvACKGi"
       ]
     },
@@ -9265,7 +8549,6 @@
       "keccak256": "0xf1bbd0fea6cecbf6c424da10afce0723b20583c480441aa18c062f963eca6732",
       "sha256": "0x62115f7f60d71e8fbd0eb70a2dcaa099254a0daa01a7cb81dc834f21e99e7b71",
       "urls": [
-        "bzzr://b8640d8edef26e63296f9e3e8bfe985f16851c4d38cc497c741602ca969fc076",
         "dweb:/ipfs/QmUpDXqhiLkmcCHc6zcSZEQ7eNjk5HpLg51tuxXQNbAuny"
       ]
     },
@@ -9278,7 +8561,6 @@
       "keccak256": "0xc4c60b3596693d9e5929da6084fcb81b3913332ecf1ef3a8ea05499d08f1ea78",
       "sha256": "0x43d04d9a8312a2647401caccd20e5d144d6cc58d4818ceec30ecd9d5a0af8ff1",
       "urls": [
-        "bzzr://d294786cbcd798b43076094dfcace09455e6beda06317fc30a6e593a1f89ff49",
         "dweb:/ipfs/QmWgHbQ9nMj2Ptc2SyeRFYE3xLrupjkbSJyyw98cVUqBVv"
       ]
     },
@@ -9291,7 +8573,6 @@
       "keccak256": "0x58ccccd206222170ae9c71869c2e3679ad15d04c38c541b0d11be0d55fff7c29",
       "sha256": "0xf594d1d5fbc664a0a26cd7fc5c478cc79b36bb8f155917894ca2903f2f2d8c4e",
       "urls": [
-        "bzzr://b2580a22a3c4f33cf379c5257b494f31e940892d3666fe610a8434d8620746da",
         "dweb:/ipfs/QmPX9tHixPTdfrmeGiE2gP4Cy6DCvU2cXN6ob7PGPi3FsZ"
       ]
     },
@@ -9304,7 +8585,6 @@
       "keccak256": "0xa1e9ed8992ce16516dcce314434cbb16feb7f417f67cecf6db7456ccf14e3eba",
       "sha256": "0xff15de848ddc706b329fa86e2ed830b3534323f3ab16441126b4a446645bce22",
       "urls": [
-        "bzzr://c1f9c50ccd8c1bf2c3c4f09fd18219e5a27ec57c86140208f23c980f034ddd2c",
         "dweb:/ipfs/QmUg4Jp8Hp9SoP9SYCBJGLw3YMFkpWeHmj92cYzQRCxxB5"
       ]
     },
@@ -9317,7 +8597,6 @@
       "keccak256": "0xb8c40183cad60589ad1bbec54df5cd9e84c16899a6fbf09d42ccfbc1e9a41157",
       "sha256": "0xc3d52af3259094bb554546a1ea37736eecffc8f7d31e5db5633d14e4803bc6ce",
       "urls": [
-        "bzzr://1bdd502109be82a214deaac122c27731d3c42cd5855532493ef5050bb5197a25",
         "dweb:/ipfs/QmSUUhz7BPYsKyCx7AF3JZsdjAq3Ux4jxmXMStWauWMMyD"
       ]
     },
@@ -9330,7 +8609,6 @@
       "keccak256": "0x63a0c4c0e8081d12e367f6fe6c548b5e70f2800a48f74a40917407529c6fe8e6",
       "sha256": "0x5425d49fd44b3056f054344a1700edf74faeac281e2aac69d0a24e12b81982dd",
       "urls": [
-        "bzzr://9b8d53099fc9a85424c4b617f2392242b46a4005864dce1b85a8967f0925a5be",
         "dweb:/ipfs/QmQ9cVh9tmNmYZBBzNGmrwnihXESeFRjP1mVE4D6WXv1CU"
       ]
     },
@@ -9343,7 +8621,6 @@
       "keccak256": "0xfc432404a8ee2bb5120fb6a0e66dd2029e9e7027dc92d774e66301adf17bb1b2",
       "sha256": "0x4b007b778e251d10efaba0f4a375083bd445d9380973ab438cc64ba8bcab9d55",
       "urls": [
-        "bzzr://314476179a48e44fc34965c6982d4bc7cf4c81c7ed19afa67548bc75856a6a95",
         "dweb:/ipfs/QmdS11aWi41Dg76g2btVhAFFjEMcUs6dqsh74RHxuSTFsP"
       ]
     },
@@ -9356,7 +8633,6 @@
       "keccak256": "0x6f265944689b39b29d8149ee570b1a9225a37482436523d53f3b9e463921ab75",
       "sha256": "0x0b4072226b156dd7a5f76bb910f7c6c128495bdbd907cce591fd807e7c871a9f",
       "urls": [
-        "bzzr://aeb7e3ca92d88211014705e6953a3b181e3da0d3393828d54b214d1f2659fbe6",
         "dweb:/ipfs/QmQFE6ZVQFdNSZSdpdegtvjfQaV69qunhyBY9krSvVQiid"
       ]
     },
@@ -9368,7 +8644,6 @@
       "keccak256": "0x20fdb5337e832c6d0fa736d8506241e5a6cf0ccd3d6611069d920cff5a9bc2c4",
       "sha256": "0x704e67e356ad4df45425c03f8852b4ce67152121abe41486a90afe9d65b1c72b",
       "urls": [
-        "bzzr://b1a85faf1d9909bb38d44b2d34d0c9aac0a0d4cbbee45ad063c75221e4ee68b6",
         "dweb:/ipfs/QmSxMWTNYSeT1s9ydzWLbBW3x2CopkVnaxWY1PfWg5ytJL"
       ]
     },
@@ -9381,7 +8656,6 @@
       "keccak256": "0xc867d5edffb1cb823a93fe0428b8f16aa9427d11084e2e7c25f5df2f81a8e037",
       "sha256": "0x0a8a95f70c860d6e0721fe26c402c04b48249fcbbc44f2b4c572715b6a3baed5",
       "urls": [
-        "bzzr://4bc2d9576a03aa9cab39e19bbe921a66f5a040af77b0bf4fda64ebc64dc4d27a",
         "dweb:/ipfs/QmVW1PrEL4N5L5JHxwf1cG3MeP9pEgyREKzcAcYDNew2gt"
       ]
     },
@@ -9394,7 +8668,6 @@
       "keccak256": "0x4637667b0b0eab767e8fa766887b7239307289b2c1c6159f6dfa2948000534c4",
       "sha256": "0x284419d65ebb9a53159fb247cd341683c7ed5eadaa009158866910ead780e407",
       "urls": [
-        "bzzr://5a396b4e5201bc9c3ebc0472d77a6f5afb1b2718d2ede53536c3946a25ae038c",
         "dweb:/ipfs/QmRpAMHaHXVRqyBcy9v3nkKqPjw8MHkaBtFhfRJEoTigMG"
       ]
     },
@@ -9407,7 +8680,6 @@
       "keccak256": "0xfd1c2fb459d3cab795932a4d5a9c4facc2af4d39a91aaf20dc5e71f4733342cd",
       "sha256": "0x2f147b0d707f7b009ec1f7dea6aea6467b352d6d55130d9fd97e590ae6a1adf9",
       "urls": [
-        "bzzr://a836b8ee5352715551c206eb1fc6bf225326a4c0dd1a3ad71a2254fcf226a94b",
         "dweb:/ipfs/QmaerKU3u2Ro9p3h1kEJetYstxhTksrp7SWNb3tgqh6jGi"
       ]
     },
@@ -9420,7 +8692,6 @@
       "keccak256": "0x5cfa4d1264703287921d40ce2f6b798ee30388c3a983c29a8744ade4beda9b91",
       "sha256": "0x7c587c2ed151c2f38e9e4902509bb3f2901805ed47c81f7412a9e225b25ed45d",
       "urls": [
-        "bzzr://13a03106f51255c8aec4eb4710d07abf694d35018231da1e79af6bf0be79761a",
         "dweb:/ipfs/QmbTwYQzUBw4z1iieseEDPngjC3FxsbrmDuuQRMbcq9UJs"
       ]
     },
@@ -9433,7 +8704,6 @@
       "keccak256": "0xe24b737a827899fb0e74d9edf4ce72855218097b6bfc0da4d38b5b33a3523fa7",
       "sha256": "0xfb72185e6cfcf224480f2b924c2db913f5e62e633a25ca1c527fe161aaa8a291",
       "urls": [
-        "bzzr://ca3994a4b55a65132f66df557e21d9e18c99be9a0d3004450ecac8993983d40a",
         "dweb:/ipfs/QmPdeQhPuSdYFsSu1Sk4DzGJ4TTAm7HH2KUQZUHFM9htqD"
       ]
     },
@@ -9446,7 +8716,6 @@
       "keccak256": "0x844c1524a25ccddddfc413b852030153219eb289e9d13e41062ab3d904a904a5",
       "sha256": "0x88fe562fc2077eab1ac5f0d8323548c431b2fb08a75532d5f2833df8e1aaea7f",
       "urls": [
-        "bzzr://cd6d5df948761c256b4473cebb42423441bfecc313d765a951412b868063450a",
         "dweb:/ipfs/QmbpEmokovbCrPtF9Sd51BYQ3ko8TZ52KV9mPcdZL1cwBQ"
       ]
     },
@@ -9459,7 +8728,6 @@
       "keccak256": "0x68eebc56957e25e23df83a8073310907dd8609bc65ea385151ab936936c6264f",
       "sha256": "0x4df59dc5aac6be6461812658ce6ef913ddff7adc6906280fae851ec6bf716f3d",
       "urls": [
-        "bzzr://b088d6dcac0966f262f57610afc8d88839e0b84d69e3a2f7fdff6e4744e11780",
         "dweb:/ipfs/QmNUseD21ituiagy8K9m8URpAFMqyT1Qh6ZfpaPA6NHfhX"
       ]
     },
@@ -9472,7 +8740,6 @@
       "keccak256": "0x50090ce8a49c9d82e8f30e82c8c9bbc7c3c7eab3b5cc642da77abfbe02ddbd6b",
       "sha256": "0xe0cbba9d70b7a7534d67731707a4941521fd2dda43150a812effaa850518636f",
       "urls": [
-        "bzzr://4387a9ed2795a9f123e5ca30ae669ab2a3cec58523a51916a5be27008c7a40ad",
         "dweb:/ipfs/QmbsXtJ8FT9mmJPRbbJjn5TdSnr64BmzKAMPzqTUHxok5s"
       ]
     },
@@ -9485,7 +8752,6 @@
       "keccak256": "0x829ce66a1dae7d529f31fefc185ddb5adef2a1664d6228b561ae6bbe9e8ef15b",
       "sha256": "0xd9a14bce542470cd44c6550f84952ffc2a3ba3b3ef55d4b131f31b5f5c7f8089",
       "urls": [
-        "bzzr://a760b7c80c723ecc11dd3b1d08ca8499357cbc89c440f5100ccc1da59c057ec5",
         "dweb:/ipfs/QmbM4o2vhupQyHxV2LdSeZNpQVrGdXAKAuJf9XdKzKhUwW"
       ]
     },
@@ -9498,7 +8764,6 @@
       "keccak256": "0x16a2bfeb3ef755b7a745e9792640a7bddec0d2fa29b42e9096a6a57243313908",
       "sha256": "0x0aebece76598cb7255198984e3527d908b28a5eaddae4a8ebcb458e0c533a4b8",
       "urls": [
-        "bzzr://d2d49fd6ec6a093ee33aafe9cd2cabf3e126d1c2d669c8890baf6e34a2fe32e9",
         "dweb:/ipfs/QmVXAi5Vz7rNRxCmwtWnKaSvgguLqcQHpgGLQwasoxaW9B"
       ]
     },
@@ -9511,7 +8776,6 @@
       "keccak256": "0xb5e7b05fd18b8bfa9b8851e09e90938feb1deb1f7fa3c5949051475f6206310e",
       "sha256": "0x841382a8968133580665218da258470aa42d1826799000314ea86c2f78d5b483",
       "urls": [
-        "bzzr://7a325aefa58710a1dd5a72e6eaf991413694ca8a8bcd468371e98ae1531f41c4",
         "dweb:/ipfs/QmThK6v3171y94zH2uZYaq14jxfVUyUyCkCLNQWD1SBnXZ"
       ]
     },
@@ -9524,7 +8788,6 @@
       "keccak256": "0xbe43541168c7c390655c12c8cb83f54f936fd756f9b0af8da950b1d827fb3550",
       "sha256": "0x14d2f8c15c1bdb3800ef42612a078f8cd10992682c8f00b22e1c7e02af005dc6",
       "urls": [
-        "bzzr://13999715f07b2e81005af39d298db2a35708343e5769b996462b085a6638f8d6",
         "dweb:/ipfs/QmYDUhWbkhxJddvumLkejA7CMAFPtsNHmqNTiDFTc8EA8V"
       ]
     },
@@ -9537,7 +8800,6 @@
       "keccak256": "0x00bf27a36ee9759d63ccbc111d16ab4febfcd2d3ef90e33239210af12225c84e",
       "sha256": "0xfe9629895d69d194cb8da5449f3e81046124d6014f91cb07fc718371cf752248",
       "urls": [
-        "bzzr://9248401bd015815af07eeddbe99fbff0c38a1db1aa29759db18e82b496a72616",
         "dweb:/ipfs/QmeJyw7RQSvHksFUSZKsHwE8j48Fsen6y7Wd9EhQCqA2gP"
       ]
     },
@@ -9550,7 +8812,6 @@
       "keccak256": "0x63223001df891a6b9169fa00109e1e6dead778a314ec3b062ccf38be9b47d105",
       "sha256": "0x4ca6920c1f58098c788d24e8a9033498b49c9bbf466cd8c5a0922c92acab5ddd",
       "urls": [
-        "bzzr://cb555a2d7eb5f2394578106b5973c366e4b36a147dfa671e0f36230e4f891663",
         "dweb:/ipfs/QmbyJz1oKKhZaCzcJwdswUH1Ui44hCcqoVrLqEbZdaowrZ"
       ]
     },
@@ -9563,7 +8824,6 @@
       "keccak256": "0xaa18d0dca7cbabeaa1cdd7c018fc6b029e702d500a9570c3af8b7193af423f43",
       "sha256": "0xaa3f2d7456644440c3b10639f4c7f227cef4d77076f9182770f8ae32514edaf9",
       "urls": [
-        "bzzr://10bbdfaf69e2a18a106366d9daaa6d84157ab0bd3fd1d4c027a6c0515a5cc370",
         "dweb:/ipfs/QmWsXESBNYHrV2eZZhY9t44cfgTVzsB5nz4eQ8pUNFk6Xu"
       ]
     },
@@ -9576,7 +8836,6 @@
       "keccak256": "0x568309b2e4e4b50f56528cd7e4eb085471adaef1922b977c910b92d8d1d139ab",
       "sha256": "0x48082006f5d0554ede8516539fa41b1e87b989e9d3d1d7169ea388d7aa4a17e5",
       "urls": [
-        "bzzr://86dfd0ae010ce866a95b00332a9ac4838fb235201265a304821575de536e6cc1",
         "dweb:/ipfs/QmNn38wrUuBjuyahmiGxtjsT7kER6sLXv2MgcppyqTtBZi"
       ]
     },
@@ -9589,7 +8848,6 @@
       "keccak256": "0x2e2361ee325c7e41b330bc5f981cc58a63612fc55ab826c901323f3da79ca9bf",
       "sha256": "0x70f059a5ed0f35a3254a125c2496e5ff27ceb6f25ab521f10cef3338b3599432",
       "urls": [
-        "bzzr://0687b3a5f882479dba368411af5a31d4e73e788c1de720dd6dff6db07b53c2d7",
         "dweb:/ipfs/QmUkR2Y4SCxJa79VCGfyP7QHAWBH9u577UwH7BezwRRRHw"
       ]
     },
@@ -9602,7 +8860,6 @@
       "keccak256": "0x29455c517733d89a30417ee1611e7975506a1ba3b399ca8cc83c47479e48bb00",
       "sha256": "0xa5b9878970ef6ae22dc517e0e96ce708563f9154d0db6892806dbb8e0ce8efa5",
       "urls": [
-        "bzzr://8572f937508ae503ab73d819907a5f2e8c89ee760b51e098a92e28a1db79cc2e",
         "dweb:/ipfs/QmVUyDtV1h7J1R3fi2tAjqQAdzF6UAqKJSVuXVeCNWFjVN"
       ]
     },
@@ -9615,7 +8872,6 @@
       "keccak256": "0xe2ede7cf5190c585d281ef00221cd436b694a0d78cc91bdf099d9b2c30d66377",
       "sha256": "0xe3e5ba14108d716cf2359694335b1fbb046b481371134542402fbd0ec1adb82e",
       "urls": [
-        "bzzr://df5817648f13ab32d3915de2efb1b0d1ec2439eb7bb3ac31e5cf9b34e98e4b0a",
         "dweb:/ipfs/QmVWRQTHmEMG7PbMKBg4bfMQT2gdu8DY7VPqQBtxCS8CsE"
       ]
     },
@@ -9628,7 +8884,6 @@
       "keccak256": "0xce39898536674e248d47d140b7087e980d269f83b699d9d9153009bf1948613a",
       "sha256": "0x1f15a9078592eeb5dfa995f02b816308ef02b1c73572977d6dcbc92886f475d1",
       "urls": [
-        "bzzr://7b39beac253d5b27e4280830671dba1ac88cbfd22d2b450e74966959e7aa4a06",
         "dweb:/ipfs/QmZfCS4DFYu2qCycfzQsBawpxF7YERn3NfwYATts7C9mcN"
       ]
     },
@@ -9641,7 +8896,6 @@
       "keccak256": "0xe4c126dcb80a436884354ea7ce4b46fac648ea4576fb88b69def310ad1345949",
       "sha256": "0x515804558d921d0ca5f5ea679aaff8d4772e08ef99f0bec187fc8173ebd57085",
       "urls": [
-        "bzzr://b93a53243c25e537d00782c95ff4042bdc7bf35c80a018267150f5011ce4df9f",
         "dweb:/ipfs/QmeyVh4h4CqAmqzFe7rzhEju98fhSxFvuoqJdLpMTbk4u3"
       ]
     },
@@ -9654,7 +8908,6 @@
       "keccak256": "0x4914f6199aaa3f62848295f42ff125111b205fdfecd10221c41ea1f4699a8c91",
       "sha256": "0x88020a2f9421fdecd4a8573f90041bb6ab6392f9d8b4e628ef3e4e8f242c1652",
       "urls": [
-        "bzzr://f0f2fe8d0a3254da6b41ca8bbc3c1950675d10915f64284559a36b57e4ac517d",
         "dweb:/ipfs/QmcGTjPbwKshK8jv9R1cvYC2XpdJFHHLMPaPUNXeA2oQ8C"
       ]
     },
@@ -9666,7 +8919,6 @@
       "keccak256": "0x7bdfc3e09790d5b1f488b10a8c0da4f85a8a64482c2be5566969feafdd7deb9d",
       "sha256": "0xdda3f35c4bd4380ae66a3268df92c260d707cea256dfcafa265637b6d8bd63f5",
       "urls": [
-        "bzzr://8923240b6d3f6e2f38ced6d5f8bfeb1b8a64ee49cdd358ea5c582dde194a699a",
         "dweb:/ipfs/QmdLsm73rn9KSHukKrZPbuzWGUmrwKugdpDExKSqowvHgz"
       ]
     },
@@ -9679,7 +8931,6 @@
       "keccak256": "0x988de7f94ef97b22d6e244b26b74a064db0603981d0956553535760d0e85dcaf",
       "sha256": "0x0fddde744671d1f9c731d3cb025900ea50324f8209308fec984ea980eedc0eb5",
       "urls": [
-        "bzzr://333aff9ed8cb8895102faea3fa14aac4b829e095052f7cb94c32337af61dcaed",
         "dweb:/ipfs/Qmc1H6rEwNBkDBWEjB9MuEDZDBpstr5itYKvkF4K4oxbQs"
       ]
     },
@@ -9692,7 +8943,6 @@
       "keccak256": "0x13db9e2a9228e59a04477ee16cc94d0e1f100f7da4e5dd61917d3a7a399221a4",
       "sha256": "0x9b6b867ffe7e9fd70099ffb32fd8bbf9e2507a5d8deeaf7b397c00c778738b56",
       "urls": [
-        "bzzr://e4e000df8cb8d2f48658d58347ae3a16d4e26e670b4984ab78bef0e19ed2bd91",
         "dweb:/ipfs/QmaqSF9qDthgwuSKDaM2XmDGJFvtxkRMVnrz3xDLvxgdYP"
       ]
     },
@@ -9705,7 +8955,6 @@
       "keccak256": "0x8f77106be76a42288569ce1dbfbe334275949bc3b3ca148261304b13276a9f8f",
       "sha256": "0xce0a13063cb3a03027a0b82ab494a41d7711bd516b563dfa38940f4fb428affd",
       "urls": [
-        "bzzr://d66beeda32d905aee9465591cf54d9f8738d450068e5c95f6d4cf01182a2973b",
         "dweb:/ipfs/QmYGeKuJb5BEQJUTfcvodH8jo2vWw271KUyxqhiztMmNA7"
       ]
     },
@@ -9718,7 +8967,6 @@
       "keccak256": "0x38ac982902d8affe5fef53e95ab3a05b7d84f56200a6df95bc48d5889de9f95f",
       "sha256": "0x400d9faea4877c648fa8645f58646699ae16c49e217aa57c8f95f3a5aa654d1c",
       "urls": [
-        "bzzr://31db3ee4736f93c65b2c012f5d1bdd22851572f1f07c6dec2b69b00a9a238b2b",
         "dweb:/ipfs/QmSzRxUvLYUZhxP2ttvRiWVSPRdN6TSAXrdDb64yotUZeH"
       ]
     },
@@ -9731,7 +8979,6 @@
       "keccak256": "0x9e84635dce880d47c57cd57e19efa04aff001ba6a1308b0d6cab515199919da6",
       "sha256": "0x83742e8ffa5896de1e20ec7fe31a7b742b33155c1daff84bf5c6b419fd222f65",
       "urls": [
-        "bzzr://646ad4c507ad6c76dd7a860135562b98b4f28872a4f5ed456f79340e21b9e1bd",
         "dweb:/ipfs/QmYHftAjDQmXqS9QLTr4zvFn3jXGprN3nApa6PapAijpjh"
       ]
     },
@@ -9744,7 +8991,6 @@
       "keccak256": "0x6cf9f3753069b0c674e9892fc053421ccad974369332afe8189fbfa357d851d5",
       "sha256": "0xd6307f73de1d52cbfb7f32fd3ffe84555ad6b07a5b72f0956217e7f93738a980",
       "urls": [
-        "bzzr://963126a8cbe24bfd3c776387fbd9f626413ebfe810b07b43325466fcae2748a6",
         "dweb:/ipfs/QmTZzc2CYAXnCVtEvy32Mi52fKMFNSfKPwKzBWM6eJYiAB"
       ]
     },
@@ -9757,7 +9003,6 @@
       "keccak256": "0x2b4ff81e784d48565e2f0df4be06e6bd053a6e7509ff90c552f4d89b7166570b",
       "sha256": "0x4f842840bf807c94a16fc45ed311cd7a0b58a4463e455647b71a88c67b12ac8e",
       "urls": [
-        "bzzr://d17f348a4535db14da7c4637be51c195f11bf8d80d39d2ddaa1c630b1f682eaf",
         "dweb:/ipfs/QmcVJc3uh8eVEiz3ou45K657xbLzXpnnbwGgGmNLmxJQq9"
       ]
     },
@@ -9770,7 +9015,6 @@
       "keccak256": "0x94fc9f165916b2bb75ad707a89b421ef3a89dd9cea109f988077fe5a497a548a",
       "sha256": "0xb47e543de5175d91cda6337b17f5b238cd4a453b3857b47bc1a451bad8846f1f",
       "urls": [
-        "bzzr://374b026137f5690582f46f8150d8125f363e9df55bb64dbbd019ad52857df6a6",
         "dweb:/ipfs/QmUfipHbfroyKqQHh519GwVRXYJ988cD4wqL7HBYsVqLQr"
       ]
     },
@@ -9783,7 +9027,6 @@
       "keccak256": "0x24a5504155692708c214faf52ea780e21ce933a625aaa0f2931efde7ded9e0f0",
       "sha256": "0x8afd9ab536605be0a2478948bccf0d8ab956dd95e37d4a3357f3b64edcc92c61",
       "urls": [
-        "bzzr://5d2f7176676bf0d3bbbcc6156f53b52c15b54301216490e6c0feaaad28fabaa2",
         "dweb:/ipfs/QmSvPpsphMVXBQKp7dD4HwrmcwFHNjQSu9KkJ5XLwkTvqP"
       ]
     },
@@ -9796,7 +9039,6 @@
       "keccak256": "0x82696d50c881a1c53fdea6caf0b792e7c1dfc21c66007abcd467e97400d066c9",
       "sha256": "0xe0d86e2eb8b30262209ea5e6227c04ec26d9c08581f37459a1e60d6055c679cc",
       "urls": [
-        "bzzr://c6f546610a8951e4d543fac99c12d072eb289e50e014139e5687910cb3f0a743",
         "dweb:/ipfs/QmZcs2TGgrdYRnPQQgWZt3ugaSZXhXDtJenududNXEtwC5"
       ]
     },
@@ -9809,7 +9051,6 @@
       "keccak256": "0x51fbd989cd7c9da90838b40983e38a4971abd39b695d35032f40e2fb20216006",
       "sha256": "0xec8af12ca968ad28e4b952edd0a3e99c8a216f812b9cdcadb9609f142461d5ec",
       "urls": [
-        "bzzr://e0e2f107333ae574d293332ea3b37e6f8a881d24f895519e7233be3a2dcdb41f",
         "dweb:/ipfs/QmZrHoDyBA3LQ1f2qPs9L4yLegA3Voao4xgBURWWBSxLLf"
       ]
     },
@@ -9822,7 +9063,6 @@
       "keccak256": "0xafda10a4d0cea803fcb55c1c08cc594e20ad3892207e386afae9d20ff5cc40cb",
       "sha256": "0x76d67defa13b5379bfa848ae2a8d472ae329cbb38d2d62760a273adc7e26371e",
       "urls": [
-        "bzzr://cf935a9f203e7f50beed2783643d863205fe5b055cfb9dde7b214d1655d05453",
         "dweb:/ipfs/QmVBYUGvc2prdhgtStF5rYHAx2nyTCZ9tCMDtaW4EiT3V5"
       ]
     },
@@ -9835,7 +9075,6 @@
       "keccak256": "0x75ffbcae3a0e4c8721f6c3ef4df6caec100dabe3218aada46afc3800c13d0512",
       "sha256": "0xf72c0df6168d685904ebac85dad3876888fd5ec4c214d7a121cba7fd38afaa3e",
       "urls": [
-        "bzzr://59b5915afd792db6dd4687eb4335381b964d7e2eac73d1b09f58cafa42987c7b",
         "dweb:/ipfs/Qmc2rUcs6Kqchd1WVMSqm2sFYaxxzkp77kRKeewHuRUkaP"
       ]
     },
@@ -9848,7 +9087,6 @@
       "keccak256": "0xaf95b84e7faf43f622ffd5d5583792a3cc2468a4740b49a9df3c5b13fd8dde61",
       "sha256": "0x389b95a7d5c8d6196a4d4ee10d24642669c91467e8132df9ee5d6684952cf8d5",
       "urls": [
-        "bzzr://29499954893605e5a3d6b17366015b67eb90302e0c374cdb435c70c77cab6095",
         "dweb:/ipfs/QmRHPhBMg6LeyWA4LjKd3fBk1ycn2L85n7jMcAfnehsBny"
       ]
     },
@@ -9861,7 +9099,6 @@
       "keccak256": "0x25763517d775ab5ea510c7c00cee64505a51c780a2a408a41ef36dd90fe053b3",
       "sha256": "0xd00d7c0cfcecca4d0305ed8e2059422efec75a291f9cd45d51bc1960eccf8cb9",
       "urls": [
-        "bzzr://8bb7ac5a1f9d3708edaba28f645623eb8429c8c19fce6636c4aa9f8a7a9a07eb",
         "dweb:/ipfs/QmWMpFKmE2iiXFeH5mRaz4VNo8EEa29qy6DM4wC2gzKSoc"
       ]
     },
@@ -9874,7 +9111,6 @@
       "keccak256": "0x9eae0882b4c81843d6081fd6ae944d8054f3755e5d83abbe97f7e3b861f10ca6",
       "sha256": "0x67c4d148065d1a51d9c637c7a92dcbe7405bce8e3a1d2576dbb8e1fa6e0b4133",
       "urls": [
-        "bzzr://31a7c6701dac929a629bb6cd0fb442745f9a551c65b3417f6e2b8a3ab87e679d",
         "dweb:/ipfs/QmWn7xre4ef82PpqsWSpTiJaiX9rCR49XABXPjz2fr1Ux7"
       ]
     },
@@ -9887,7 +9123,6 @@
       "keccak256": "0xb240d2dd701d6fb4e963b0e3a67623b2b9cf346287eff2dbc9ec35b27d2f6de3",
       "sha256": "0x9a655013a0f8037fb651b4dc5f90d378faeba19f4418a144c6be47232f2f22bf",
       "urls": [
-        "bzzr://09bcb2c8912d7acd643e1ee5e8732ea73bb37d4b8da031eef72983051f160db0",
         "dweb:/ipfs/QmNzkr4m1YRiFPoSXdVd4MobX73b8BG3qazZWBjT3KSoWb"
       ]
     },
@@ -9900,7 +9135,6 @@
       "keccak256": "0xb157e77f715f9a40b61e8207948d7b28d9a593a556ddf68e396339928e5c0ce2",
       "sha256": "0xb185b71e9a85a05d9c8803f5e0368f1c39a24dc7ce0a709ee1a6c20f830edb6e",
       "urls": [
-        "bzzr://c71061632345a65f940d079ef39f12960e0b59d70322e9c48210f6552a622a45",
         "dweb:/ipfs/QmSkrzYPtuDfEiv9VLpV4omvMpBSVAsKka5jsyDpQJbtj4"
       ]
     },
@@ -9913,7 +9147,6 @@
       "keccak256": "0xa62ae5cea9e7660f8ad9164b161b258dccbf905ebe54484770e92aea17b53b4c",
       "sha256": "0xa1ff266e5f8c61379a1fb1231d0e4aceb4da05de39a13b183b9ef0fe31f64fb2",
       "urls": [
-        "bzzr://bb46a6c30dc67e139197f88052e7b7e41a066996475bce40808649a15c22f7d6",
         "dweb:/ipfs/QmbbyBKjwD4Tt1MNTYftix8isQUL1jhXDza233gUVuEh71"
       ]
     },
@@ -9925,7 +9158,6 @@
       "keccak256": "0xdb31c4cd1a6445eb7b469b8ba49f8dfd79fc86b4f5aa55fc601947c868f1edb0",
       "sha256": "0x9c6970aeed958d8d169857f728cbeb36aaff77bf7b56d1a8b219de4b983f765b",
       "urls": [
-        "bzzr://fdb7f85ba080a97770830c9188529fb5ef387b54759d8a865b116aa39706e759",
         "dweb:/ipfs/QmTL3fJQw9tDsYM6UcRJknZiyGuAQyJ3ypQV9yo9pPGpRm"
       ]
     },
@@ -9937,7 +9169,6 @@
       "keccak256": "0x435c60eb61083f14782d1cc071f9c745b8761413ff00fce2678772690d418fb4",
       "sha256": "0x83e62e6e63fc85c856a0f8eca2a613927f6e749b27f19b7f85aafc762e783034",
       "urls": [
-        "bzzr://7f8f74b93df99ba6bb527c5597614075838eeb84ef84c90d9a5a81ec2c60cb12",
         "dweb:/ipfs/QmcyGFNgw86sMFNfjdYeXtQADFMUc55JPMrJStnFPLoH8n"
       ]
     },
@@ -9950,7 +9181,6 @@
       "keccak256": "0x06a0fc95e337a25828dad03f21ccd5e55d6524fba90fb013e96c6883c56e066a",
       "sha256": "0xb982892c6c75cf0654add2f2fabcfaaad03e41f45fa5580064e03be285ebc4a5",
       "urls": [
-        "bzzr://c93bc2c21e1803f2443fc6a3fd636c6f5af2555bc1e01cf10533fdf3ba7e6334",
         "dweb:/ipfs/QmPZcLUVdUXLydtpxuNpxqeMF9jPy4KMwWjnsfzF5XSRyP"
       ]
     },
@@ -9963,7 +9193,6 @@
       "keccak256": "0xc490d3e2804ce5cce1ca56f362ed148083244b8897871cc1f3cf90516acb8be0",
       "sha256": "0xc9cc88a82768f04d22efd24789b2cbe3ea0d82b614450634e5b0f35cc4bc1da6",
       "urls": [
-        "bzzr://140667ea714e18daeaef2685fab99969d92a1aef930110c59acb6554a5e8da07",
         "dweb:/ipfs/QmVizUYLqh62ajzbLoGKaHYkBu79EAfskYCe1jr3vW7Hi4"
       ]
     },
@@ -9976,7 +9205,6 @@
       "keccak256": "0x10d4946f571ba94b9cc173f8b95bc3a2c0afae24554abefc95fc4d25f975c8bc",
       "sha256": "0x6604f39687282468f1f6d1418da69fe5ea0a6440bacc1ff552db5c7a2a1d9113",
       "urls": [
-        "bzzr://bfa739b99bef64a024790b2f234445dc1ef69b91eed6e6f8f386c90bbc32c4c2",
         "dweb:/ipfs/QmR7KYFShJgecvxUhArpxwd6RCMH91jDza2CM8ZJ6uKf4J"
       ]
     },
@@ -9989,7 +9217,6 @@
       "keccak256": "0x39e9fdffe9ccdb0dcad0efbc9db36e47079acb7e8cd2ae85bbccb4f166ec8a51",
       "sha256": "0x1db628be616238e2f456100dba012df296df45d0db5dfe59baffe3dedf0be8b9",
       "urls": [
-        "bzzr://57d8dcd4e67be5cfaf31854cbf6541d8d4e6b350f1ab7e22fa8785a89aef54ba",
         "dweb:/ipfs/Qmc2eXzxttRqKg31WRVt5RbNSj6mw37cPbGdSzeWjmwnxa"
       ]
     },
@@ -10002,7 +9229,6 @@
       "keccak256": "0x848f3fc64e2c2962aed2a9ff5aca6803559063f46beeee05b86bf97eef51e419",
       "sha256": "0xada6be1da7d8f6b414e47f00d0beba0edd344780100d7666601173a5a00cac35",
       "urls": [
-        "bzzr://25fc710adb778e8dab5601be829cd2e1b16ee73a60b5032ecd635fd86ef988ff",
         "dweb:/ipfs/QmTx6iGUv52qJakeG7MPmWWqB6tpcQ5BHEMHCFbNx18Z19"
       ]
     },
@@ -10015,7 +9241,6 @@
       "keccak256": "0x8c55b8713356b6d76534f3aab71e9289363af8aafcf7c0602bce490a07d41589",
       "sha256": "0x3fdd7984fc7066f5bf5ea889fb971dfcb62b87bf64c74f0fb1d5729956d8441c",
       "urls": [
-        "bzzr://08b5a02043d53a99e0f0782aaf6d004afb8de28029e163e18990292a84bb942d",
         "dweb:/ipfs/QmX7vfaavvMRVtmUPsY2gHYPX2J4QzSQUry7YjVXFXXvrq"
       ]
     },
@@ -10028,7 +9253,6 @@
       "keccak256": "0x47063a976036454e02b815d54ee0385b79030b5ef34d3c5b002cede1ca3ee07a",
       "sha256": "0x6172517fd25afad0d0c9dd5f03ecd4107bb518a7c1f62d10087096ace7b9f736",
       "urls": [
-        "bzzr://6a984624bcbc35b99578979f5fcb67c2ef4b8b00f3fe334e28e8f4d84f8d8d86",
         "dweb:/ipfs/QmZn1tRYhiKxNXYDDNTgCeeMfKY1skN9pRsHj8pU4Vaedm"
       ]
     },
@@ -10041,7 +9265,6 @@
       "keccak256": "0x3d341a6a1a71d2b5f19d982d3c30b63e4213d66407a03835cb4244a57e84a318",
       "sha256": "0xf0ece3e66be5f8d36d645bb0d14b4f97b094ee0921aece8b7588d3e949c88e46",
       "urls": [
-        "bzzr://0e557c648ffac85f50b13c1ed14853ab597225abc982fac5999d03e91adf20c2",
         "dweb:/ipfs/QmTvy5hzbwJh258b5oE9bXhXrRL5nipJgPAvi6fBeJzc38"
       ]
     },
@@ -10054,7 +9277,6 @@
       "keccak256": "0x114711de14494e8c180fafe06cc792144d33a73336225ec9466da0e15fb0da4e",
       "sha256": "0xdfe8908ff37cfb4501be3b9b887123a22b1a11914afdea3164a630fa9d261716",
       "urls": [
-        "bzzr://c51dbed037b0cc9b1db8ccaa89372f5edb2369441ceb022f3f89614ee4711ed1",
         "dweb:/ipfs/QmVSM3AwYERPBrHW79T3Sdk1KJXSBYuXPCy96VqooXciDz"
       ]
     },
@@ -10067,7 +9289,6 @@
       "keccak256": "0xfca0674b1a944dd783f88ec917ad6db501282c22126a51462cf54c2f74a99228",
       "sha256": "0xdfd2a67bc34c5a9abce47f8c07d63a5d0e4fa61a37d7615b315d5afb3356d8f0",
       "urls": [
-        "bzzr://a40f6e976286d0b5200e5ccdc3eaed160e75db0e959473104456209647a32a61",
         "dweb:/ipfs/QmcgomsJ33EvHVqWDqQgTqC2yKxdmAZeSQJYUNkDFRM8w1"
       ]
     },
@@ -10080,7 +9301,6 @@
       "keccak256": "0x056ba1a349fc42d6a2967e1bec10d70aa539ff780f24f1e1fc04aa52e02c3e37",
       "sha256": "0x044caa622e84db1958bd9abe3ba4ad2c8c9f7bf87710ddebebec4db6eb2ef766",
       "urls": [
-        "bzzr://4d19d948e2f7d365a58241b8b8219f2d1db7865a36ba31dc889f48404180e398",
         "dweb:/ipfs/QmUCQBP9qpEERhpW9ZWTTdiD3UdUjkfwbVGbDvyCZWuBk4"
       ]
     },
@@ -10093,7 +9313,6 @@
       "keccak256": "0xec695b0a19de6a708ed957e2d8de62c3cc615a2c3d07df236f29f72f64e19002",
       "sha256": "0x617e2649caae8c83253eb5c7bdc688abc4da07a80f58d3fc5f9cd9c7aac07ffc",
       "urls": [
-        "bzzr://7984c699ccc1df699496cda15ad1082d8676801a18f60f6193d7ba9ab0ae6d79",
         "dweb:/ipfs/QmQBzPc8N1J6zC3AGFkphRndXfMsWqHmW7h9r9CktiEZYm"
       ]
     },
@@ -10106,7 +9325,6 @@
       "keccak256": "0x61ade2d2a02398554a937c59ac32242b34112ef7ca012cca32f991b513a1287c",
       "sha256": "0x4a7d38a79b1db070fbf33d43f551826f6e02e9703a93f2fe5a5dfb66aaecbb74",
       "urls": [
-        "bzzr://3af9079c064715ec12c332a0486f5651418c1edd937da3c101dd71993405ae84",
         "dweb:/ipfs/QmTAaBahzicXhwpwzVPHwAEsDGFwwcERRTetq4dCtsMbRj"
       ]
     },
@@ -10119,7 +9337,6 @@
       "keccak256": "0x646d0ed6912a29b353ee81ec9a2ad050dff83197c41a10fbd4fd7ebc2861b561",
       "sha256": "0x8fc4fc5ed406cdc8ad2311d80533bdc2d32e0439c9e1b12e16930f5ac6d4c2f3",
       "urls": [
-        "bzzr://99d5a3cbf25320239c70bec85545b50582c80ef81a277b3ddb23c246ad4bd159",
         "dweb:/ipfs/Qmcq9jo7WuQQCN29VZMkcpXZADe97kVNoN2bPbtk91ubDe"
       ]
     },
@@ -10132,7 +9349,6 @@
       "keccak256": "0x541867f005d5b2c3309250861108673f5e9778b98ccf8fd8b88a81247bed25c7",
       "sha256": "0x2a48b373f1913e45f6e5dae73b949268e03065558d6cd2ddb3261b6afa5c52c8",
       "urls": [
-        "bzzr://752579ad6089e6a283c80457dede04938b3f18b42e2db3810dc0a631966474a1",
         "dweb:/ipfs/QmQYHPC8Jp7watXf7pfeqmsCXob1SN6AhYqrbrbtLc3qrq"
       ]
     },
@@ -10145,7 +9361,6 @@
       "keccak256": "0xbccb7e0486a423d2b21e57fc602343065514c58d98ab0070c8d5312a290f4f55",
       "sha256": "0xd4ff59c9dead14db6aa60116bf95e3323a9b757f363a045ff8b0f26489b684b7",
       "urls": [
-        "bzzr://9b45d3519ab08ac4c26e8546cadf0fe0fdba30ee8209822e05e7eb454dffe1fe",
         "dweb:/ipfs/Qmd1PQvaNuaPcQFyn1za2cqsX6LSWkTomGjiC67hHZfodi"
       ]
     },
@@ -10158,7 +9373,6 @@
       "keccak256": "0xe0e4587bbd7ca653a8c61c019d34afa6ad85334310b3d5466aa79710fea70bc6",
       "sha256": "0x9d08a0cd6c5eb808ef485a4bc76b53f42270d180c9ae1fbf309d4ec87de4331b",
       "urls": [
-        "bzzr://5482e07e2667325cb0fa2a5d9ebef44cc3a6fa668494749d88a92c076bdf9ae6",
         "dweb:/ipfs/QmQmpBE1hzTmfzxQBuznuSupkSenXDXD4cHmFQw51jiXia"
       ]
     },
@@ -10170,7 +9384,6 @@
       "keccak256": "0xfe117d69aa8d50aab3ffc2d88352e3c2e624e6de58430af60cf7e09c705fc212",
       "sha256": "0x025e26a7c16f1ad2c2afd43b82bcc0ab90e56149c153524a4e7e72365c16c31f",
       "urls": [
-        "bzzr://d0f225f299a766aab366c9087c740fb7c5c6122262674576a98fd1fe6a7ed198",
         "dweb:/ipfs/QmcSnmitYaHxgWdqstA68iU2P8rPR6a5dcQ7qxsVs5suX3"
       ]
     },
@@ -10183,7 +9396,6 @@
       "keccak256": "0xf3e9a6bb7c8f331767aa116cb9f0f428f1c66dd205f677b873925a7190d16eff",
       "sha256": "0x87d6c877aa206bbdea382b9028c8446ed7c409deb66324b9ae8062ec0ddd6ccd",
       "urls": [
-        "bzzr://6110748a0deca8916a10a0e2f0f5971b597c5937b2c5397c08288477ed99cd73",
         "dweb:/ipfs/QmaY53sj6yvgyVdSys31tiqf9gDkyXD6EJjYhkYsL9BSr5"
       ]
     },
@@ -10196,7 +9408,6 @@
       "keccak256": "0x971a84c492d146dca5e10a5ba13ff1322bc2f4bf5099a3282f5e93ebea88ea61",
       "sha256": "0xd7fbe218006e6aba4e4b19a6043efd6aadcc7700cc44924a51ff5c663b778af8",
       "urls": [
-        "bzzr://06f157d1edd4e006011c8dec8a77badc408741e7510aae3e43975f91e049b228",
         "dweb:/ipfs/QmRPiHk1xFR3LweSjSAA5dRAdktJiCcDzYCFMfYFtiAGiA"
       ]
     },
@@ -10209,7 +9420,6 @@
       "keccak256": "0x2be38486326b2cbc6b8af07730ae5de4f1d5eddaf8294c244d0cd204a9722e0e",
       "sha256": "0xee06a731cbd27942f31c0c3718a0d832dddb3035ba297fb4f1c1466e20dcbce0",
       "urls": [
-        "bzzr://fec763a2459437f18dccc7d6970802db705c62f3b1d04221cc8ba0786fd8f508",
         "dweb:/ipfs/QmVRf6srZ2hGrkgVvxw1PEN9kP2i9nWZ7kkXt4f6tKKNDo"
       ]
     },
@@ -10222,7 +9432,6 @@
       "keccak256": "0x043076c1372612960b46ba80977321447799c2188509735e26ba991bfd1ac394",
       "sha256": "0xeb319b04ffc3e5de71dd8fb813ba82e44c3c85abec864869a82fa5c9d20d7b87",
       "urls": [
-        "bzzr://329b6178ee5d16ee0942a8473c3aa15e06ae8b8c4b29990b8ecf38e083550fc7",
         "dweb:/ipfs/Qmdf7YKmxY72AqKuDPzEbWdzjKazJXmJA8svCuhM1wubyS"
       ]
     },
@@ -10235,7 +9444,6 @@
       "keccak256": "0x842cc7aee0ba34c031da01f02f16324cbd65ed55a2c4c56169cefc0d6c78e814",
       "sha256": "0xfc3c1aeb3de38c5b794b21bf5d37351b41e947ee6f06b908299896532772d3d8",
       "urls": [
-        "bzzr://867ee3ef2438b5639284e9149b4b823ba9058fd9cf1e66eb96667770c763f3a0",
         "dweb:/ipfs/QmTbwwPD9PA5x7TJR8rumHN4vrUT7Ka7AtwKZQ45JzWRNM"
       ]
     },
@@ -10248,7 +9456,6 @@
       "keccak256": "0x4e6f54c1ff8d8011ce8be8a55233b0bf4e9053d337cb69416e780a861050f78e",
       "sha256": "0x1cb1784302a6ce27e7dedd5b6f9d3853c9fc4d85aab411b024dcce591f234211",
       "urls": [
-        "bzzr://8698f8d4a1fcdc9d387d56208c09429f6b64cc8de7844648a7898165df400275",
         "dweb:/ipfs/QmTRS76PiHz5UJLshRZk9oYHmoo5L6egtRvpP3J2S367hj"
       ]
     },
@@ -10261,7 +9468,6 @@
       "keccak256": "0x8f299458defd714b94ee9e7d36ca6b8862ddb26add88e35068031abb262a4b0e",
       "sha256": "0x37e4958a349ca97ed49d5aa0fe9c479e20b4cffa3494dadb9d0a35ce7a87ac92",
       "urls": [
-        "bzzr://3fd9211c05d11f324d4cf506761d99966596272c535566b7b6271fb77847f3eb",
         "dweb:/ipfs/QmSpKyV6j9zoK7PTRdwCX8Z5ieTwoN54JK11ATKUwJAmBn"
       ]
     },
@@ -10274,7 +9480,6 @@
       "keccak256": "0xf16a1de9a82b3d12b7a2893440e6a34568e62b401abc3bf4bad475bb16afad3c",
       "sha256": "0xcde48a117893cb2549ac72f4017114944f4459502013e127f446b8cc8ee95f3b",
       "urls": [
-        "bzzr://6e7b30cb7ebec3e9a942e408678d923732ee5f3b4544b56fcc9133dbfdf8d74b",
         "dweb:/ipfs/Qmag2KREpv9kDZuUuCipCPEHBwt6Lcc63KHhnvCjPy1W82"
       ]
     },
@@ -10287,7 +9492,6 @@
       "keccak256": "0x96ad003cef8f58c3ddf496aaa0f19e3e8b41b738314d33b75b7266883f7e3703",
       "sha256": "0xeb05eaf5620816802cd18d41a71a2f7eec3e37ddadc8925a0fca686d2edeb356",
       "urls": [
-        "bzzr://cee7da74d00ce2034807458e2d58e5321dbc33148d652304e53321dd8a045087",
         "dweb:/ipfs/QmQpwdezJVM4hPVyxmAcPP4jcQgsLYyYHig2pxoVNt6BbJ"
       ]
     },
@@ -10300,7 +9504,6 @@
       "keccak256": "0x22865cb98153e91ae8541cea52788e03c424cb3d6f1c689cc76af1ccc734369f",
       "sha256": "0x3c39f5f315addda9e49568fa1329b80b1aebd34ab2f3e59a8eef00e4a6376bd9",
       "urls": [
-        "bzzr://03623748948409e84ae8dc98629f769e92f87c32921d071c6baa1db5b9c39e3e",
         "dweb:/ipfs/QmQTBrdBDW5mUBPf6cKLBPSn4SxRDVdhtojyzsxGoDAhfY"
       ]
     },
@@ -10313,7 +9516,6 @@
       "keccak256": "0xe129f0df3e3651765f09d703f612e2f70bf6b58f11bfda2a8af9c4dfa59b63eb",
       "sha256": "0xdeabf4f515c88e913afbc726688dda5bb92f0bbca89a4b94cb0dd65a78efe864",
       "urls": [
-        "bzzr://c52724d08eaa25938d76c881863712f25d686a479a4110068964c0de4e3c8682",
         "dweb:/ipfs/QmbvMwB4hTmnHfZfR6JsDb1SxM8bUpFsBPLtm1cwGpSf16"
       ]
     },
@@ -10326,7 +9528,6 @@
       "keccak256": "0x9e4fa158623c6649dfd63a54d565380172438f005e7bcb1addafc94c73f7eb06",
       "sha256": "0x13fa500184f77f6bea54b454244b03a997c6dd9418a43b0d260ed2d202afb0a6",
       "urls": [
-        "bzzr://6835a66ed264446d3f3bbcf44406a384f375227b0177e15fd9cf70be6bcd093f",
         "dweb:/ipfs/QmbUBjmncjeeyGXVhprzRqTjL98HYTZYqtYDpnY76bnEAk"
       ]
     },
@@ -10339,7 +9540,6 @@
       "keccak256": "0x9d0997e51aa3b318bbfa95d8cf053ce7eb5694128d1ef7b81e1ef6a29ace5313",
       "sha256": "0x9eff2e1d8fdc61a40d8d09dad0bbd25a6d04e7abb5484adc3be490ec52ce415d",
       "urls": [
-        "bzzr://6cba38e3884a18d6d4d47bde265b8113fb159b65ac0a9c7d2c79731e39ea3959",
         "dweb:/ipfs/QmS4vRA13F8fiJvCvGVnpKnBPk7YqSC74tu5iMJCbSuyUS"
       ]
     },
@@ -10352,7 +9552,6 @@
       "keccak256": "0x6383b9a1cb768b22f5d5795f4125f34e0c4359d0d95b26075199d4b8e64bc08f",
       "sha256": "0x7a271dd98341946f8a58ef23c63d6ef59983dfae4a99a76513580dd87a20aace",
       "urls": [
-        "bzzr://fe683eea71e31cb091c1eb6d08881fa891c86575efb46ddaf694a2214515d86a",
         "dweb:/ipfs/QmcoXykZgaJRUhDLZGrPsbdtKsBso4KV3Pb6LyuGpejxC2"
       ]
     },
@@ -10365,7 +9564,6 @@
       "keccak256": "0xa7c05e7e3f6b4e61c3d0c25e86c085c52d415476e8bda42312a2b158f3c6f04c",
       "sha256": "0x10ad4f0e6768513ee4b579a8132b5f4afd8eddcc910b7d554eaab674c75175c0",
       "urls": [
-        "bzzr://362a9d981a2d99be3a3beb04b629347a2e91a118f10179754cf743335d99cb80",
         "dweb:/ipfs/QmRXvXxehhayMU6eBFaawPiiXbnqiH2nLKqMyG71JDMx1A"
       ]
     },
@@ -10378,7 +9576,6 @@
       "keccak256": "0xa1a16a863cca391f498a8d006eb00bfcc4c0b577038a871befa1f7394f0dcba8",
       "sha256": "0x0afbba9481525013704baac84e0262a65ddaa74340c6c04375b5c85c48dfee54",
       "urls": [
-        "bzzr://51a00a45c1c8da2e2eab574acbae2cb9de715b331f76840e9ffaa4f2db743f3e",
         "dweb:/ipfs/QmaYVJHq4DVKtkryHez2vzioTdZmXHaANes6zkaGpJoR3y"
       ]
     },
@@ -10391,7 +9588,6 @@
       "keccak256": "0x8d4bdafc056d43bf6e9063d2f8d2396030398cb48d91f92989a25ff79b99c245",
       "sha256": "0xb85f4a5f9e059659e7c920f4994423aaccc773a286dbba9d82495485dcb0813e",
       "urls": [
-        "bzzr://0643353912a6ba309632b721251c08f49a5f26eeb39cd9453e1397eefc065a13",
         "dweb:/ipfs/QmVhyBUtP9DfYkPaDQyVUYab6CUBBAhufo3GrmtnCwnqk1"
       ]
     },
@@ -10404,7 +9600,6 @@
       "keccak256": "0xf66d19b43b7885175452f20f094ca87017c078ac4a2bd37ab33e0745434fad45",
       "sha256": "0x6861d803592eef5d1c6de73f4564538a35af72b7d474f0663e28d3332ce73687",
       "urls": [
-        "bzzr://cb9879af27b9db695aca09cdf563c3e0df9b5a71f2c1f6d6d6549977a7721a1a",
         "dweb:/ipfs/QmTYwPchzCx9i8uXF3AoJiTwdHvLKmpCgpg5NXkq2UGw9L"
       ]
     },
@@ -10417,7 +9612,6 @@
       "keccak256": "0x7dc685100818a4d8bec4df65a76c137fdc86d18b21434e664337c44a1ebdf043",
       "sha256": "0xfb2d610e78d29bb655af4e583e7fd1f88882192dfffb191fc1709f137eb35978",
       "urls": [
-        "bzzr://11eef4cd35a9e059f53116a673fe075daae28c33fff66955555310584293ae87",
         "dweb:/ipfs/QmPuqrnv3r9saAUVoBFSLRspx95QNbdzVnaeLysqGbpG5s"
       ]
     },
@@ -10430,7 +9624,6 @@
       "keccak256": "0xd22428e2d071c448ed44e491c01e90ef797009d1ea53fdce38e86030ae55d6f1",
       "sha256": "0x5095a914d30a158a2c63afc615e3acad1d24a0da54def285a1d9a25ff0961520",
       "urls": [
-        "bzzr://1cb187c78f46538b54583efdb4944b33ec7e59b397fda42b21b3c72ccb6aa645",
         "dweb:/ipfs/QmToBcbk8RzU5yrivaD5TKgKeZmSBGVNrQyUFNduDmHCsC"
       ]
     },
@@ -10443,7 +9636,6 @@
       "keccak256": "0x2acf5bbc6162e7d6263eab6ce813b54354ae05e113151af3cc9442c1b71cc060",
       "sha256": "0x5b608e9f5d3502872315c13020be7f4246f9bfb4f68d0b518bb44e27feca47a7",
       "urls": [
-        "bzzr://928d30f027c742f29afc1664d77953f1e3bd713904b1de7cd850a6c7f471fbc2",
         "dweb:/ipfs/QmZGAywyfybP1GKqwtpj6y5hmeq3jRPmJg868is76MqfWx"
       ]
     },
@@ -10456,7 +9648,6 @@
       "keccak256": "0xf3bf25435047f2a00406ac6de3db4b55df639d27c664e0e9eecd12146b0c900e",
       "sha256": "0x602303d4304fee1e4ac74689a3bf131855e72bd48b19c384e575a39f91fd5b57",
       "urls": [
-        "bzzr://b5cbc97aaec807ec01b992e9799192c90afda80b55d12852cf5314c4111d6ab1",
         "dweb:/ipfs/QmSqFdSR1DxcCbxgFdGKkpa6XrH9HUW58QBBhdD4uweRpH"
       ]
     },
@@ -10469,7 +9660,6 @@
       "keccak256": "0x7c20b9a02ebf065727a65c552e054d32c82236e9c215e7e264948418c6d2e175",
       "sha256": "0xdbc88ac9c2681d61e3f48e8c3304de2e44b999c735b0582f1dbf9325ca930e5f",
       "urls": [
-        "bzzr://4ddfad27a1f8ae5be8e2fb00228de6ad4c66b8292149e2fd8cf1d1bbbc20f941",
         "dweb:/ipfs/QmXeemkCxntDoq34vQTGMZtaMr8CisfGvT4Z9ZJpvsrH8T"
       ]
     },
@@ -10482,7 +9672,6 @@
       "keccak256": "0x9e551776d16a353a58ef2c201271488c1dc39d5b6cd16d1137d3f52247c19161",
       "sha256": "0x1d48e7e8d861391f7e02cc712763459bf3f0edaaf0c1ef1d8e840117f1cb8243",
       "urls": [
-        "bzzr://913ddfb1c08e1ad42b1643b829eb7f165cc6574d2bd6dc078d3c0da65c2fece4",
         "dweb:/ipfs/QmS5pCqJmGHAax9VAKXczGG1N3xY9rCksjFy57Rq6zSd5m"
       ]
     },
@@ -10495,7 +9684,6 @@
       "keccak256": "0x8eaaf06cf3dc26bda3216e2ffa25845094a2a89cb98a15829a0e4c8092bc16af",
       "sha256": "0x191f18cafab9ad71caaab9a4a42b4a2198de90e194ef67360d850c4741873733",
       "urls": [
-        "bzzr://35758a41ad64a0524ce02e7aab3476ae9efcbd47526a6ae1a6c69ace15cb5af6",
         "dweb:/ipfs/QmZXZcL8oyjGcrE8C1RTVMgt1p4q5k1ANYqraF13g3tQB1"
       ]
     },
@@ -10508,7 +9696,6 @@
       "keccak256": "0x77bd95e75a0e80d33b83dd38b9eeea3129c4745e2ad1d5ca9a97159608e35681",
       "sha256": "0x7ed0f7d6e72eb15ed9cede549985c8b17d3f27f24fc53a03668896d1d16dbfe3",
       "urls": [
-        "bzzr://46420da22cd5db60e7eae0d620cbfa59cdc3714bcc14fffe26b9293688ddb7db",
         "dweb:/ipfs/QmTeephDLbeij74Ak8ZLSt56SYFACBbMK8h7W5M6bc1H5M"
       ]
     },
@@ -10521,7 +9708,6 @@
       "keccak256": "0x8cbd73dc295275765c04c22aa3759bb0108bf3e45905418a3750f167efa9fe7e",
       "sha256": "0xf2c2a05ce8c81ac22ae05e2e2269f43f38a8a67d61cef6c35e1695dd3122d69a",
       "urls": [
-        "bzzr://b12b8941dc2b4af386494ca9db79172f04ee32f37cf3b820a06dd31286fc22d6",
         "dweb:/ipfs/QmUFuGCbnppKU64CdFhE1mWgrrMTK2Sy5PHL5sG9K49Pty"
       ]
     },
@@ -10534,7 +9720,6 @@
       "keccak256": "0x1b0736a820913af60af132040134f91bde3135cb820241a3df34e2f181d327f3",
       "sha256": "0xa235b3a5814ca8271e9a38902bd6541a6a8a5c349c91f34190035eccfb3ad04c",
       "urls": [
-        "bzzr://4549da787df5f3b26acec836ad96adedffeab36f2bcb90c5c24d32da262b305e",
         "dweb:/ipfs/QmZTTSXMoeZp2FsjbHN4hdEMSuJ5tbWQR9jQV9fEGUuURH"
       ]
     },
@@ -10547,7 +9732,6 @@
       "keccak256": "0x22683efe302d61772c555ba49d4c1f696beb482c5d1e531638eda445d8d61651",
       "sha256": "0x430d0f4564ec242af1aaa0a8fd83f573a5c607097735d3f7141c5c313389a4bf",
       "urls": [
-        "bzzr://f486c2b94eafc8c35f3bcacf875d915bcfe150ebc35b72cab3f2755d0441ee6b",
         "dweb:/ipfs/QmZCPaRFDP1R9rwFGcGTNysTDyH5Gnr9iK8jNFfHisYMct"
       ]
     },
@@ -10560,7 +9744,6 @@
       "keccak256": "0x6a72d13f07d9b03a79ff975d67f6ad63a6dd8f47d474ebf2a011e540e258ee0c",
       "sha256": "0xdfbb390e39cdcb7ff6ba3c479d5563781cf8e01348d246f7d1be55a0fabd626d",
       "urls": [
-        "bzzr://43ddaa5ca151fbfb349e05de81001e077c903b977ea34ba6b1db029d61d84de4",
         "dweb:/ipfs/QmVitGDwCXgY5dw44NXo1zc8QGZZSkbAVWRf77TSbhngKZ"
       ]
     },
@@ -10572,7 +9755,6 @@
       "keccak256": "0xc17ac23500f490e479bd4f82f7ac93111cb950af5b388d1002972d42613feda2",
       "sha256": "0xb6012fb777a7f842a6e7efe8c50cb2eba3b3997c72b761810823e796d4390d44",
       "urls": [
-        "bzzr://f7136a4e9d4771a12407ff4dd8a5932840a79d77cafed760caacaa63d7a60d81",
         "dweb:/ipfs/QmNr26EpsCrNuPHBHbZvDAV4PFDG1XWShpmxZhtr4QsUcN"
       ]
     },
@@ -10584,7 +9766,6 @@
       "keccak256": "0x1e158d4219caaefca3e9d0fa5cebb19cee56b1452a99d50a72f8795f62dce536",
       "sha256": "0x31dce3fd8f587dec8d7b0bcb0d99ad2f62160fe071d0f64deb5b549fb924c244",
       "urls": [
-        "bzzr://584397ffedeece5b3766443eba34de03f38a5589176aacffe568e079b8de94c3",
         "dweb:/ipfs/QmVUDz1LMQSfknu7ZXC3YNZrNkbP81gKezfeXeqELvz4LU"
       ]
     },
@@ -10597,7 +9778,6 @@
       "keccak256": "0x3f051580135b8803f5957d0c02ef6fb52f7ee9587351c2c6aa80cdfbaeed20db",
       "sha256": "0xdd25d7e9fe1202e7296041687c776f90ff94985e601446e485926848201cee3c",
       "urls": [
-        "bzzr://44980d4625ca57adc862a868cdc57d21dfb61fcbe09816cce705f33c32d0e45b",
         "dweb:/ipfs/QmasQUwq54BJC2NdKhjBerDCW7ViAwbvDfxZkvcUSu5p7s"
       ]
     },
@@ -10610,7 +9790,6 @@
       "keccak256": "0x51cf2388f6ceafe18cbbd25f5e589b08d59d37930761e2ae4d5508d64a22fdc9",
       "sha256": "0xa56cb06a5c6b112e836d3cd249f699fd90308b8cc3b33be9a3278f80e6f338a4",
       "urls": [
-        "bzzr://ba7e5fd45e42acaca4c4316264d5de6673f06da3bdf8904324699ecbd0c581b4",
         "dweb:/ipfs/QmYYWEvtweXCseqH5L2XRc6k42X7C2TaGq9oGkAgxQJ5vf"
       ]
     },
@@ -10623,7 +9802,6 @@
       "keccak256": "0x675c70013eb41257ff671a6dc2b5b2b11a975dbc7e68491e03aa2646022c11ef",
       "sha256": "0x03871e963211c3dff4393c099ab16fd16214615ebc464a2ac118402b0c9097a0",
       "urls": [
-        "bzzr://34985df4ac7e9836c5f43c83a9563473e9fdae0047e51fdccbdcf52792951ab2",
         "dweb:/ipfs/QmWh8xhiDJjfGdUQf22jquSWsKG24y38fsX3hxb7pk81CB"
       ]
     },
@@ -10636,7 +9814,6 @@
       "keccak256": "0xf0b6742a26e3227f992ccaf6dfeec3210e1d700e2883d89d705c02deba0dd6bb",
       "sha256": "0x9b95ac6419a17870f7fafd7b7c345326bbdbba27e9e2a8e4ccc6664354f9c54f",
       "urls": [
-        "bzzr://3b6a70b1fc8c368592770a1496ce7180afaa00db35fbec2ea837296b81f02926",
         "dweb:/ipfs/QmYgzER6VUbeSW9nwoLxzbFa48UeVpjejpeit6VoXL6EmH"
       ]
     },
@@ -10649,7 +9826,6 @@
       "keccak256": "0xbfb71c959e23b4815ed8dc55bbb6d6ebd29414b204fa4d88b539ccedb595dd55",
       "sha256": "0x4ac478bc53f1d1ec1c63dae1ffb1b9502ee7d387d2e3be06b99c0566a0531aa8",
       "urls": [
-        "bzzr://1e7334a462925b782a3dddadfe18e6e3ef410c97464a736213c1f886197b45f1",
         "dweb:/ipfs/QmSujZZrfPsa99tbwykSxkVAcSTUMgUyBKtBdE4EfbNYuh"
       ]
     },
@@ -10662,7 +9838,6 @@
       "keccak256": "0x79c600430e5bb67002b366d2e838d78e9635d06b95a07139896ac843e40744f6",
       "sha256": "0xcb09c2a34c597fdeadc5294ca06f53f61c2fe99a9e2c2ad9f9b87b883af493e9",
       "urls": [
-        "bzzr://354f7199a28e06e08146f05d72257b20f18bf3ca40db64de23d54abe6f95d4bd",
         "dweb:/ipfs/QmRaGnnjo4fmCTFGb9eXPji3iJXRkTsJA8EfG5bLas1yxQ"
       ]
     },
@@ -10675,7 +9850,6 @@
       "keccak256": "0x19afc4cfe45d8d14fd76a7d01d3a261535de14930bef46344f909ec36adfbf5a",
       "sha256": "0x764c6174ce65750b9de87ae00788e65a0fe32e4ba70d9bede19efc52a8907b3a",
       "urls": [
-        "bzzr://54e45f15c71dff3c4531c59463e62394eceef35ef2f569f9157bddde506f1711",
         "dweb:/ipfs/QmQaQfZp7BR5bhC39iog4zt9ZRk7ot47aXhp8MgtynP4W4"
       ]
     },
@@ -10688,7 +9862,6 @@
       "keccak256": "0x9fda061713284c530a60bdd0508d67fe37745ff871adbbcab4c0f9ef677bccc6",
       "sha256": "0x6540f153de717217be27f4bbf30752f1a6fdd396a1f222bad793518e2829f6ae",
       "urls": [
-        "bzzr://793e555845e553f99308e92d04ba5cc7b9763e069166a87877f8160bd1add0ea",
         "dweb:/ipfs/QmbM2kAduL1JjQ7TGQ6JMBojMdFH5MKnU2k1DbM135Ec3U"
       ]
     },
@@ -10701,7 +9874,6 @@
       "keccak256": "0x9f668d5d7cfea7834ed9fc0bef9bbb529bf9dc175e00ac11f01187a0a508b66e",
       "sha256": "0xc854eb532d7ec92c94e029edd8d33ebd4ab3b49d7eadf850b1aba303c3c3322d",
       "urls": [
-        "bzzr://c9570824e39890ff10f45e3ffb2e937619a7d097c13870b96321fd89f0838f60",
         "dweb:/ipfs/QmaswFv6KLmW2Vp3JALyBDjVD1VWub4YHcmKwTAoZRra3g"
       ]
     },
@@ -10714,7 +9886,6 @@
       "keccak256": "0x274e8718592c1da313401a15035d1608fc6d2dc40e9b4d71bee39aab04422242",
       "sha256": "0x06299572746a84ee31308155b6891f65d20a83b34efebed2ee1955da95a47e9f",
       "urls": [
-        "bzzr://078765781d996c97140547ae5d1797e948e76537fc4a4d0305a77227d00a2122",
         "dweb:/ipfs/QmZqirERgPmXBSZzoGG8EtaUkojrRhdcGBGF9Ngjr1aUp1"
       ]
     },
@@ -10727,7 +9898,6 @@
       "keccak256": "0xc75ffa219ba10c39ce1df2c51cb32fd4fa16f1340f1712bb01e7b12f0ffcab25",
       "sha256": "0x4cd1a5b0ce28a7e269c7c94ee22aa2bb7beeb8be5d05c8edfd9438818bc4d29d",
       "urls": [
-        "bzzr://018c162f7922ee68611b3733ab3a63e7fbb18b154b27a22e443e099c5dc58306",
         "dweb:/ipfs/Qmeinx5S1Z8ffW36NeCiLMkVC1sU3GF6iJSMKe3pbA5CDQ"
       ]
     },
@@ -10740,7 +9910,6 @@
       "keccak256": "0x6a1b553043ee609e3f248e07958109506edbde68441d46e0ff14d238c23c7da7",
       "sha256": "0xd490605b4bb00b2c64941a9c3d6bc981d868943467b5eb2fe71dd744d428a179",
       "urls": [
-        "bzzr://bc20dfdea30e7bc4fd87e31763eb7cd7f738919d96f577c5762f6affd4118b80",
         "dweb:/ipfs/QmWB9JEkhLaivhiVUqZWJkraVrN7dvDFPPqXerrigQEhys"
       ]
     },
@@ -10753,7 +9922,6 @@
       "keccak256": "0x5e72f4fe20e4f53ab8bae75b979b39ec35135c1fe9220784c84f34554ec1a10d",
       "sha256": "0xc6701322295cd48844e9a7ef8813d833c5703bd527d50b34e21a3bb4f95533ee",
       "urls": [
-        "bzzr://9edd388b746366fa76169c4ab9da04826b5e54009ded765ba4b7bb665de46a6b",
         "dweb:/ipfs/QmZuBp3pN96PUbg9mf9yk7cYGLFHfMie4yE16n4e7XaCfm"
       ]
     },
@@ -10766,7 +9934,6 @@
       "keccak256": "0xd9c021ffc0bab087cf81bc75f68ab78fbb6f5f8af3343073cd7f7b948ed98950",
       "sha256": "0xbdd407ba8c6cbd2a5f556cecb5307c53439058a1b2491842fe42d10a448df8e1",
       "urls": [
-        "bzzr://a5882286f31dfce9abef939b0b223de2fa57899961ab3fbe1bd922eca7086444",
         "dweb:/ipfs/QmVbTPespRmCbDX2fL2CGJu48KsdF2E9hsR6Az9LJa4KYB"
       ]
     },
@@ -10779,7 +9946,6 @@
       "keccak256": "0x446228a569e9e2b17e39339424170f1878d9cc9619247bd2553dc5f7c20ac713",
       "sha256": "0xd0bb80cea62cb74bd6e0e942762874223c8365a2173644a680b4e7b66ef9f463",
       "urls": [
-        "bzzr://c31ca050ae5a390992f424785c01d97e5bf5e3cd7e0b94d7d25b149284cb2b42",
         "dweb:/ipfs/QmT11yerVEyd3q9iak9p9J5UgDrjMDBrKxBfQ62ZZehRLx"
       ]
     },
@@ -10792,7 +9958,6 @@
       "keccak256": "0xfe7e453ccbd369cb67514880ddcfbd9b3d2c8d1fe22811af261dbfef6c5a9362",
       "sha256": "0x840e4fd1d60eb081b5f9543b309717027615d2270dc9d89b548d36ba807ef27e",
       "urls": [
-        "bzzr://f133539247c13675b043a2f1afe7d0f2b1ae7698213592bdb5b14c7961c65f48",
         "dweb:/ipfs/QmPQgG4ZPAFAzRpWF7GGiAd2RJfAya6wnrBjQGG27YqKMP"
       ]
     },
@@ -10805,7 +9970,6 @@
       "keccak256": "0xbe785b1cb29b4b1f48b7edcbd85e8326ad0fe7986acac2cd78d818cab5e76c52",
       "sha256": "0x9c0d93a2b7b0c32de9f9bf97c6a7a21de99c05e83cc2c38e1492e5ca209c3693",
       "urls": [
-        "bzzr://8038fe535ed7af91a595640c405fabfcfcd997d64aa9e0837ddf2a476d94f8a2",
         "dweb:/ipfs/QmYstGskAw3PmdVJgkAzWZdWqais7XzdX9Q8mykAcVUXF1"
       ]
     },
@@ -10818,7 +9982,6 @@
       "keccak256": "0x89855122c97c573c2d9e4f4ceba44241f46d27e9e4d1fd3b46786822b7e89751",
       "sha256": "0x255dee0498af59673aab42af6ad50da57cce36721b192fe3005f82a16ed8f528",
       "urls": [
-        "bzzr://5d4a5b6a8ae5e70ab7bed46e7e5ab5f434565b8a63292fcc6d408d6b34e225ac",
         "dweb:/ipfs/QmeFZXixAigxPVv7zMomYVgSTkEEcinYsqNutY4WYYuLSi"
       ]
     },
@@ -10831,7 +9994,6 @@
       "keccak256": "0xc0ecbad723ad73f38ea16ef5ff0d1b2d53b70358268bb710ffdfc39675f8a43a",
       "sha256": "0x2c80cbd7ffd21f44f3785513e70d51d2407437600770684022af27ce474db999",
       "urls": [
-        "bzzr://a2252fdea678e373dbe7700ceb58a80758fdc72c136d6ef583df745dc1c1fec8",
         "dweb:/ipfs/QmV9LzL8QzoZMt6ceEci2vVm4KHhpbq3GeW8yuEtXYEgia"
       ]
     },
@@ -10844,7 +10006,6 @@
       "keccak256": "0x3c88925e049be362ff081b0a2c18bebbe7cd2502c58680859140e1cc47435185",
       "sha256": "0x71dd44db6297a54d5987fec829a06f3359fbf563bc2e6d24da0682a7aa21c100",
       "urls": [
-        "bzzr://fc0e4be2d0e3add9d5c7dfa56241800c45e39befba32bf7a444a4bfaab76a2ed",
         "dweb:/ipfs/QmaKqVveRmpiMyYkKkubG1iPN2JMTCpbdNPANLfnKHMNxK"
       ]
     },
@@ -10857,7 +10018,6 @@
       "keccak256": "0x7d7405ea2061072641805d3a33c200d977f4874db859d4a0a0bebd70e80a30e8",
       "sha256": "0x7a25e1d7848c0c89ec9b5ef642c2b3590df754826f4420170c9e316b6a50e57a",
       "urls": [
-        "bzzr://5f2ead5e3fe917c73573e676eb152e2aa04a08519c91eeb8dffd9010f4bcb867",
         "dweb:/ipfs/QmPcbzmhyFvfJvo7L2JBEJ78J2UMm6mEh51ufjsqUbd1Tn"
       ]
     },
@@ -10870,7 +10030,6 @@
       "keccak256": "0x5a081e5101f9695a66641f16553ee83494d54b5466537fbc0d8341115180b10a",
       "sha256": "0xa84991d81aaca137662d6619fafa8aafcfbc99473b9d40649d6ea80d8e8f238a",
       "urls": [
-        "bzzr://487e301117e30e738ad4c6289abb4e0e7d866fe695265c37b24c38f4a9030728",
         "dweb:/ipfs/QmR1pmjfNmH1xsHrh3y88uQNe6QdXeNXWFp9fZfuYUJLj5"
       ]
     },
@@ -10883,7 +10042,6 @@
       "keccak256": "0x929f4fa4d56b394031fed5131bd839938fc8cb15496b66090d6b7deb309dc36d",
       "sha256": "0x1387a52da77c1e3da7c0649473c60935ab53cc922b490d1c0de9324fd5423e36",
       "urls": [
-        "bzzr://3f21d9e3b45866e8a3070270290397ca638d705b0992d13984f60b2c6c1dfed4",
         "dweb:/ipfs/QmR8LZrMuTzhBFArAVxDLys13ruVXdbJ8kcUopCHHeLu5m"
       ]
     },
@@ -10896,7 +10054,6 @@
       "keccak256": "0x078c0a6a35420ddd518165f00acefdebc6cc413a1dd0a1fd9ab2fe22ff33d548",
       "sha256": "0x03dc2e3a57f2bbf027455f26edd3b963643865b60339e3ae8d53cae32f12380f",
       "urls": [
-        "bzzr://ae484a2085ee8d718501afe32e041975cd4a9ff31099107460865f2975d4364e",
         "dweb:/ipfs/QmfP6ZDYvmFGMGN5q5s5Ls4GYGRWtaXQhDFx9Jc6UMgNYZ"
       ]
     },
@@ -10909,7 +10066,6 @@
       "keccak256": "0x82146aed825e35d8e4e4683145bd9cb651fb4c9a37f01b463496a52183dee562",
       "sha256": "0x2ccb4f24c90c4fd00a27bc6f3d0c82518ff268d829058cb19c42e42955d7eda9",
       "urls": [
-        "bzzr://fe11fb696654524ea5fb0821a2f0d4b70ab3f19ccb14e47b2b05c7347b9fef51",
         "dweb:/ipfs/QmZ1amsfbgfAR5YQXbUPetWHu6MK1edoj9KhPSZA583ZLt"
       ]
     },
@@ -10922,7 +10078,6 @@
       "keccak256": "0x0f79565a5c89f3b5b7d40980b629add34187c26e549b4a12af15b64b9e7715dd",
       "sha256": "0xaa8148c850ccfc56bca3f36c45c0c48786346c4d9e32f7ebb52cc96bf98b89e8",
       "urls": [
-        "bzzr://1a776ca0ed524006b7c84a030434484e4c079a97f8673f8edd6cd5aa544b9351",
         "dweb:/ipfs/QmVpcrd4is4iy2hGF7RH42rXtfthrnQNS8arzGw1fXzSV9"
       ]
     },
@@ -10935,7 +10090,6 @@
       "keccak256": "0x9574d50340d79fe53ed72c7e18c5302c77ea9aa7c8825d1a74ee346af4284141",
       "sha256": "0x15b4d1d947d84ffc531206d7b256ecfbd51d3fc27fb986c8dcfa157257aac251",
       "urls": [
-        "bzzr://ae6c54d9296d53cdbe8c3cb32c8138b9dfb0f72dadc0afb5239ab45261371f2f",
         "dweb:/ipfs/Qma524CgJx2nKFKYS5pUxpvtJ53JZeEBNcryenAWMnqb1k"
       ]
     },
@@ -10947,7 +10101,6 @@
       "keccak256": "0xd9a08eaf125656f3f54112be048895aaf9816181cce6851217188674b87c19d7",
       "sha256": "0x6fac4f65543e0796886a7e9b01869a2b53e2dcbe898f818220d0bae64e98cd13",
       "urls": [
-        "bzzr://d068ce879ce77252522aba3999bf80baffb5af3bfdbe2fcd5507f4510a04df84",
         "dweb:/ipfs/QmRsfQvuNyweNzvu1mvABxxVvni1EEYmqdmYrKVLKWqQft"
       ]
     },
@@ -10960,7 +10113,6 @@
       "keccak256": "0x16c434529f62a01b3bd89b891bfdf273be3b8c72b0832171610b1cf899403f97",
       "sha256": "0xf6cff1982d47a830880ff1b03e84b077ff72b6a63a01e5b6bb2662cfc91f9b62",
       "urls": [
-        "bzzr://cdb1dfa9b2fc0feeb694bd85a8402a045d2f6a33a4eed4e9392f1cc034eab81f",
         "dweb:/ipfs/QmUPjdJw352SkRWk2JcLtE1Uaqz4RAhMtGzLPzsh1sb7m6"
       ]
     },
@@ -10973,7 +10125,6 @@
       "keccak256": "0x64164e6365db56ef8560105456548e0e46347299dfd9a8997456dfafae6d1269",
       "sha256": "0xb8a850f846509804c18eb47cd6b1a5d34cb28428a3cec0c0661319d738c5eaae",
       "urls": [
-        "bzzr://3e1af1bfbb96429b603eb17af44945dbf05c6862de990a06ef2866c5eaa13906",
         "dweb:/ipfs/QmSHYzkHX2gnokF2aqy4g5GMCTgcBfJUcQNxf4v2goREDo"
       ]
     },
@@ -10986,7 +10137,6 @@
       "keccak256": "0xb6394b9c2efb985d8b76e69cdd9f6e4312711c3cd9baaa73f72c3757fb5a805f",
       "sha256": "0x8b1f8bb89ebd42d4090e38c70d58ee17a0cfd015fa43170ae8be7f8a79d14510",
       "urls": [
-        "bzzr://7eeceaa034d0d26dc9f3a2433c8f6277ff152f1cc7fb7aa4deba9b6294528a79",
         "dweb:/ipfs/QmUDN5utDFB14R957hDLwjXSbMBdaimPAjnWZK4W2QzZrX"
       ]
     },
@@ -10999,7 +10149,6 @@
       "keccak256": "0x98e66643b6904c36f91947304b8b40af59b58f0d6cf444bda89c5edee41e5923",
       "sha256": "0x3338851aa660387f3dfaf9508ea1d3251de8b41fb5ede73a7e69fafc63255aef",
       "urls": [
-        "bzzr://5f543ce468a78c14ed3d01b10cab7bf2391dc96a73ec435568a77f7bcdf7e74c",
         "dweb:/ipfs/QmcbKoEXfrQZgHMpc3m2BUvuKhPSP6ZHswZbHhRYHPG3Bn"
       ]
     },
@@ -11012,7 +10161,6 @@
       "keccak256": "0x7f15617ff3fdee78a3c2f70bcbdad4250ad46fbe4d6bcdc41a6607e9e4b9df29",
       "sha256": "0xe457b2b0e9262d598b2ad24c0da51b7b87a1a6737edba2009df34a8f8caae372",
       "urls": [
-        "bzzr://f0ffa215772b58a32674c3341aa93c63fb38c6208b1a8e02d8b4fc1ba34a2b71",
         "dweb:/ipfs/QmQmo5pjnrkqCSzPMdvUbJPN3HTm78aJiMKp1yYSh5pfsh"
       ]
     },
@@ -11025,7 +10173,6 @@
       "keccak256": "0x44c93646a954939e7e00f47471ffcf09a871777ff3462e408743941bb66c66bc",
       "sha256": "0x852f7acc6edd42e46f98159a7e58df4eb5a068e0245e68de866fc3db16c0acdb",
       "urls": [
-        "bzzr://6d7562e1424516697752916dfa6ab5a444f0c33c772e5fff65b1f27273694174",
         "dweb:/ipfs/QmTxjdLUd5jqfJLE9tgCE8JYBdouQDwKzyXmBhZzzP4Y16"
       ]
     },
@@ -11038,7 +10185,6 @@
       "keccak256": "0x3e63f172a99935a7262e90f2d839168aa69e1c7ab34214e5f0a478417d6cd455",
       "sha256": "0x092935d5f8a1e8deff48e6cb1f3992ba77fdd3dbe5d21c40699e0cdbc767d980",
       "urls": [
-        "bzzr://9a34a9e2aa7b17b3dd350cc9ee11dc94394832f52230094e3b100265535f7553",
         "dweb:/ipfs/QmcPXm2ew4ncJZupSQuxsZBEd95BbNidnpaddBbK3ajsgT"
       ]
     },
@@ -11051,7 +10197,6 @@
       "keccak256": "0x7ad80936806c5981c39186a5e37db8c1a890c58d1eafdc269bdb50684fcd79a2",
       "sha256": "0x337835ab7df9e701fd75b5a76e9c52f546e7913d5a65a5d085370a9f4f31da54",
       "urls": [
-        "bzzr://444f45af7c00a8157e85d4fb1f20bb2305bc6764ab0ce8cde429e9f7ea39761d",
         "dweb:/ipfs/QmZ65EFuLsBXgisvGfkcz1dGRkESqBBVShpdZDGq5kCZGo"
       ]
     },
@@ -11064,7 +10209,6 @@
       "keccak256": "0x9cae5f3d1a3afc29eee2805bcdc33c5d34a84652e7dfd5a95b7586171c8474e7",
       "sha256": "0x923c58c68142c684143aa2ffd88cf220363c71ba5081a07968b852464670fbbf",
       "urls": [
-        "bzzr://13057e89be756055e1e68b693f02214a0a9f3e6026eb59d9f09de9e295e9a57a",
         "dweb:/ipfs/QmZxNKXfjxiaB1oTp2DzPyda1V3uGBjJFkY4r7NyhBr7Y3"
       ]
     },
@@ -11077,7 +10221,6 @@
       "keccak256": "0xf7a1cb6284d3dc14a27f430438943198bcc3ad48abda398a0e5279c1c3022faf",
       "sha256": "0xa363e47eab720c26f8f9e4e21ba5965e6e204504f422bc5400f0c862a4c0186f",
       "urls": [
-        "bzzr://717c867771cc64d1bc1a6b82fcd395400985644b76a2be0c91cdd9589e1b1949",
         "dweb:/ipfs/QmQ42pZBdUT9VjrPQZrjVUCmvE3wKabnwgLy6BcpHM4dUx"
       ]
     },
@@ -11090,7 +10233,6 @@
       "keccak256": "0x3a86daa605a402ce24cb8d93a6eecb7acd689b0147939ad5f99204a1cfb194fd",
       "sha256": "0xe35c8107fb1ace3fa98284738eeb78772b9c94e0a5651e721ecf72ae3fa14684",
       "urls": [
-        "bzzr://84ff8d42db50c6cdafa0e63f0f6772e7da046cae160b204971aaae71ac3424d5",
         "dweb:/ipfs/QmNZzxjQzTXMzEahsman9NGafcqTh36BNeBUTFbWwxVW6r"
       ]
     },
@@ -11103,7 +10245,6 @@
       "keccak256": "0xe1f471acb7954cecf62ec9c548d883564237b4d1fc1747a858d7056ef4e9a89e",
       "sha256": "0xae367b03d377f151e4c31a3027dc15849f43e88dec3bc3d611971aeb88f1ed29",
       "urls": [
-        "bzzr://b7708f3262248f789c336376fd188f76bd10333f00b12e24577a9cdc2d41bfbd",
         "dweb:/ipfs/QmZWwVpp2pQDTKSBjr6wSx9Xa569hL7TXi1rCYULo7NbHx"
       ]
     },
@@ -11116,7 +10257,6 @@
       "keccak256": "0xc0316dfa8c34e0995c08aa860420d86eaaea5ec5d83dc84fc4511500a2255504",
       "sha256": "0x790356a88974b01348fd153ae314cbd10635c1b81275fa2fe9108059f1135d76",
       "urls": [
-        "bzzr://3da91f1ebf1733886529180700f8a312dcc61423687494e6f3da4ef9b91cdcfa",
         "dweb:/ipfs/QmcQEomVRHt9qDqzjQJycCG85UM3WmDdDd2HoYGESGNxNb"
       ]
     },
@@ -11129,7 +10269,6 @@
       "keccak256": "0x8a7c7095eaf58cdfadbdad25c0dce16177a95a7b7295006361437f2e84ecebb3",
       "sha256": "0xd75a22b1e05c74a9f628572b570f484b407886c30acae2bba0a3c45fa17f3d9f",
       "urls": [
-        "bzzr://a0dbd0cf7b79cd90256acfac691c035959f8ff3452e9c86beab53f07fd5c708b",
         "dweb:/ipfs/QmRggFdDErbWP2eFQ8YttsknKVPmJ7b1kpnHHFXypTkTc3"
       ]
     },
@@ -11142,7 +10281,6 @@
       "keccak256": "0x4248232192df4944e641587c677815bcd324cda0ba6af37e87359233b7b85770",
       "sha256": "0xff8b2afd5ed5380a21d4cc479765875c97c0033d81e65ad597c20e6923c6bcf8",
       "urls": [
-        "bzzr://be64dcf7cbfdafd7ec2f4a8592788ea6e76df0cff30ab30714519170124277be",
         "dweb:/ipfs/QmaxK3BoS2tjMCDPUihku2rTLcphhq56ubH2YX8mmY7dbr"
       ]
     },
@@ -11155,7 +10293,6 @@
       "keccak256": "0x9d5ec009d9cf99d05c6032bb31291b63683bdde12ea65c43fb43ba5061dd4254",
       "sha256": "0x735f561100d90d98b665f74b6c9358d73edaeca9825e92ab5be21b960cc602d0",
       "urls": [
-        "bzzr://37b7a174976bca903be501ea081eebb7be7f424360d04976b4f7e0f8675f9adc",
         "dweb:/ipfs/QmbM9wKC8cRexT5A5KaJqw9s48Xitdn6ZLMbF7qWjuBnU2"
       ]
     },
@@ -11168,7 +10305,6 @@
       "keccak256": "0x2b1c89600b36c7ac93f0396319a8b9a946563f94bc8024b1586798c6b76bda0f",
       "sha256": "0x32cf3c112cd115ee9ba1d06da2be787e1bc322d1d38c4c39b73f843c420ebae6",
       "urls": [
-        "bzzr://414fb9f8af1791c9a233f023f18e57ac63e7d171a0e83a92dd4adf8688a73e0a",
         "dweb:/ipfs/QmSDdptafBMu78QwhaDctuu4iGiGeSLXR5Wgiu2fs6fhrd"
       ]
     },
@@ -11181,7 +10317,6 @@
       "keccak256": "0x0a1bc8a06397e66ce87eacec3c85a56a0604ee7d270b42d82a42e4c34cf6228c",
       "sha256": "0x4750589ae05139d582843edfb96299ba963771a90cf86854f00db23fc5a73020",
       "urls": [
-        "bzzr://39d3f48c2149b007059bc789fe52c16951d91ed84dbb911a0c702a005d4c2402",
         "dweb:/ipfs/QmNXzfQZnHkutjsqUjPtTypeRQgNc3w2XsUhvxGaf63ivc"
       ]
     },
@@ -11194,7 +10329,6 @@
       "keccak256": "0x8c314f1113a83987c8fc2a44ccb7dc44b19e727c06294dad2eff7c64d3422492",
       "sha256": "0x5e6140208e73ce532b6d035d4a4d34d2a0f95c9c43f763702c8c9fd45e3ebaca",
       "urls": [
-        "bzzr://e049d6e122aed1fd905966228b16f1e825737442edddf2f7b108c3023552e0ef",
         "dweb:/ipfs/QmPFuYrtFu4tB63iYrAnz1m713CDSVhKMkVcWJgGyEMnLu"
       ]
     },
@@ -11207,7 +10341,6 @@
       "keccak256": "0xbced808645a748f4e237fffdec7e67ea74c5f5c855150327cf9d9b88feae135d",
       "sha256": "0x6a1174ef23ece6ce081a2ae44705bcf9edda933b2a5bd37020942405c052f50b",
       "urls": [
-        "bzzr://20858915cb214eee4c0e858ee52e283c34ba454860fd5ed9d664e33dcaca74ab",
         "dweb:/ipfs/QmTNHCd4WHtZkRRmxDv1BDskzrKdiB3A6P2Gc26vQae1sJ"
       ]
     },
@@ -11220,7 +10353,6 @@
       "keccak256": "0xa076806e9fc95468f5645ea142ab3108332fa4f8a2d47cb1a54a11850dd7abdb",
       "sha256": "0xe8cacf2fc3b135dca2880b2a9a716ff3f94c61ec2f1fd2fc19f484ff60e4e858",
       "urls": [
-        "bzzr://c174ad8970241ee0ea2f127f497ce2da4be153cf6b9b89eaf60e80ea71820f75",
         "dweb:/ipfs/QmWybqTU5EfVQnFx5WG3q8BPkyBAxhLzfsdtsUvqrs7VyZ"
       ]
     },
@@ -11233,7 +10365,6 @@
       "keccak256": "0xfed92855311e8888d9787d7af67f9eacf8e193bafc6a618f661271e9f828949e",
       "sha256": "0x7a15ff65e70b8a63d63f5f8c75e7eff3673d72de7a2c8154e3c251b626800b68",
       "urls": [
-        "bzzr://8e51f77a65933c7c8b5c8a18e2a3d9ba1c3d0ba173daae9644ef9ac64c8414af",
         "dweb:/ipfs/Qmdz2oZAMscExXX5PyC92iGvSNAmiBGRKifSBN6sobwvGN"
       ]
     },
@@ -11246,7 +10377,6 @@
       "keccak256": "0x9d3a87f78eafe2b122daeed0ea0500c2623947acc64fca0078079a06115cc58f",
       "sha256": "0xf37a29f203a419a41521e0646ed2526c82c8ad320bb9412b75c7c97d0f4ff669",
       "urls": [
-        "bzzr://544da2df9335f8dc3c2867a6290572cbc566e6068b4df3dfb49002e30d52bb83",
         "dweb:/ipfs/QmdBCFPsDPgVnaREu7q3FYHKt4Jh8Kww1jYgAWpsstywUi"
       ]
     },
@@ -11259,7 +10389,6 @@
       "keccak256": "0xcc00bca97d28485bb5151962202507dae73239578025d43fa12ca1c9950427d8",
       "sha256": "0x1fc50d71b0581293260c8c723a284bf5092deb9a248a7bff982264a1d519f414",
       "urls": [
-        "bzzr://f67129cda3cb7179de41104ba95f1ee6bd6322da84305f716872f26706653b14",
         "dweb:/ipfs/QmZNLZJspbq4RENz6xRkwK7e93PUsSMpHDMMtS5wJLBN1f"
       ]
     },
@@ -11272,7 +10401,6 @@
       "keccak256": "0x63234a904bd35d720c04e0015ecfccba29f2eccf13aea5b9dfb4f91cb9d14461",
       "sha256": "0x5a457e3ab02755a15d5beb961a23dfe75769a736ea6d087228c0c41d822dae76",
       "urls": [
-        "bzzr://f07f73d23446bb43f3ae3d59fbd870d485b930f7f3fc8c14bf8e5a37baf2e871",
         "dweb:/ipfs/QmaF8QXcPv5DBGa9SnravVMAnxch89kXTQm8zCmvD6jUcB"
       ]
     },
@@ -11284,7 +10412,6 @@
       "keccak256": "0x2c7b2b4bfe208f30f731a296d4ef30d0b1fbd477d7d2be0bacbcca2523d43417",
       "sha256": "0x89b634fb1c6010ea3c45fe9fc2365601c3d38289ecc7ae02807a0433bc198ba1",
       "urls": [
-        "bzzr://86a0346de1e5e1d66086507da482ccfbe9bed8ea3daab249851324c64cdb7f4e",
         "dweb:/ipfs/QmVKpiJJsjwfiD1Zjxc3LupgJ9fYSLNdvRfWVwnv787xdx"
       ]
     },
@@ -11297,7 +10424,6 @@
       "keccak256": "0x7f832389e8ac050fd316f123157f3b2d0f2684475571ffbe3ce25f4ff164a3b8",
       "sha256": "0x22ce635c5ddeecfc85d1566275c40a10ddad31710c1a228936260377f4d99dfb",
       "urls": [
-        "bzzr://b29948e91a1a76f1cae82811a221966f53fbb973b35c101fe14c0396b52a9bd8",
         "dweb:/ipfs/QmShMZvrMWeZy585eHU6tPd4h9oti9pbd64EjMNUqubveB"
       ]
     },
@@ -11310,7 +10436,6 @@
       "keccak256": "0x8330153872e1d34a062cd679acdcfee84215f832f1abfdaaf96258ffa330f0da",
       "sha256": "0x8671a4d3472bf4fef3110d2893de6ea907f7a3175a249cfbd0659e1f37b627c3",
       "urls": [
-        "bzzr://220f0c5be8d50dc950143b448f8f50c00d11e0956a3c8bd1a48db3ba67549db9",
         "dweb:/ipfs/QmPu8u2sWztUH6TUqMBd31adgikMXhMZkc6As7HKpNGw3F"
       ]
     },
@@ -11323,7 +10448,6 @@
       "keccak256": "0x09ec688688a33cbde9999c0e9776a53c26e64954ad3a7eb0fa7f62217d048e36",
       "sha256": "0x17ff9648a3ad95b37ee5649b8f3d6037e479d59a9023e39479670981c5c623c7",
       "urls": [
-        "bzzr://d84092e1e9afc77a135a21f755cbc5eb1f89178b1178ded1f40c778823840ce2",
         "dweb:/ipfs/QmW3LGX8sMWiZb4JL6CBFqeuMCj91t6JFBWEf5APne8S1k"
       ]
     },
@@ -11336,7 +10460,6 @@
       "keccak256": "0x50d38c7e619e7262b3695a564b59d1f930833bf68e180b963d3986409f031c48",
       "sha256": "0x0d48e31298786078c16115164a6a53b612adc6af8ce3d00a0caf278cf7a0bc49",
       "urls": [
-        "bzzr://1aeca63d181c126147b29e3471a96496f198bbaf1e4753067feda80ac50176c7",
         "dweb:/ipfs/QmSmwCpWT2cVgUAgFBrfeJJLkFuScj4FJXtjYQKdXNrvx9"
       ]
     },
@@ -11349,7 +10472,6 @@
       "keccak256": "0xf5c38eee8c919b207761e8624d4a6e346a9233cfe3caea9627f11aa1a2d6601e",
       "sha256": "0xbd81b22be3ac35d817d9c26aa042f6d09657602057c428a012191b3dad62d3be",
       "urls": [
-        "bzzr://3f01f8cd09ab728110c3e0c839498e11b7e6aa2cfac26c479e90d701d2506277",
         "dweb:/ipfs/Qmap34aWWDx4dZqEqDnXAt7zrVxQ5yNPQY7DqtKDkzrz1k"
       ]
     },
@@ -11362,7 +10484,6 @@
       "keccak256": "0xb0e68f64b9fa2c049adffe1c914f34ad8690ce22bda39c7e1795ccdb87666338",
       "sha256": "0xfedcc8f4664c21639674f6f9d49223a390df2b4598663392d75cafc946e2be91",
       "urls": [
-        "bzzr://2209cc5484d1d07a517702a47cafa4f05502bf4587308c04f16376dde9846844",
         "dweb:/ipfs/QmPHT6sqi9nCvw8csnFj71axTPvtUgTvvsoGPDakMa3ZBo"
       ]
     },
@@ -11375,7 +10496,6 @@
       "keccak256": "0x24c8604ec1d6aaf7cf2f07ebe5623a3a45945cc71df80286a9498f25e485a93c",
       "sha256": "0x162ec851e73b118f134bae8be9c1c018c0466b75727a252d499041f29b905e3a",
       "urls": [
-        "bzzr://a59bca11891fed7f9f879eab48abb1fc3a2dfa1beacd4401295443536a4a98d0",
         "dweb:/ipfs/QmQUa82SKnm271649XianESnQAXAon75TJpADvVrGPvxWU"
       ]
     },
@@ -11388,7 +10508,6 @@
       "keccak256": "0xf7ffd318e684c12c5cc1277343112b1789db998c5df3477d8bbd638a380d8df6",
       "sha256": "0xdb8746c91ec608fd0faa127d2b1782cb4739c05de20421dc6b3022b209f97ed1",
       "urls": [
-        "bzzr://b264a53fc223346867bd1c6acca88f0fca2886f22e57e1c022af2904e672c5bd",
         "dweb:/ipfs/QmP77Z7wNp7HnjphcNkn9VFS1C2ksY4pioQRe6hoMGawQ9"
       ]
     },
@@ -11401,7 +10520,6 @@
       "keccak256": "0x5e50eab8e33603ca6ef8a4e718334aa25a24ac75c18c05b6f54c6da5e3fd66e1",
       "sha256": "0xb19fa4acadb37046123f1832f8806c6814502ec888b391e9b9f75bab94cbf2e2",
       "urls": [
-        "bzzr://373cd52a5e7561170f99e9fe67357a43b657fc40b24fed44a3836887cae70b95",
         "dweb:/ipfs/QmbCViHvTm7xRYWPUMtazdpBtAmPLoTWmQgV5oENwUhy9C"
       ]
     },
@@ -11414,7 +10532,6 @@
       "keccak256": "0x0cb46c72b8cdc2bbac7edb7de4eeab1953f780119e5432d9232dc4aba6df6de1",
       "sha256": "0x9f1d71fe7523f93771e0ff51ec24df948c89bdce72a554685a0bd85a8ed6f514",
       "urls": [
-        "bzzr://b8ef3a739be691fdc1ef608dc04d3c2b2a717cba57d16815f2b4a3af3c6dfff1",
         "dweb:/ipfs/QmQkL63CsJ5RrBv2uMF1B8RhxaJUMFvG2pihvSpLXPEPzc"
       ]
     },
@@ -11427,7 +10544,6 @@
       "keccak256": "0x844617c506014c9302be6de20eb1c584c44a1c5310e580cf58a5f2d2ae6fdc37",
       "sha256": "0x59cb5665ee27a284fee21c9a1cf2b3086deec27f319078990ef3bedfb2137422",
       "urls": [
-        "bzzr://fd50878eed9a2f20d433046cc32639e76b0352e56c9edb896580c6e562f0af49",
         "dweb:/ipfs/QmWFoWAmj6A2X9DkSApCLQuJnAyeUDEaqX6gSDpVLeWXi9"
       ]
     },
@@ -11440,7 +10556,6 @@
       "keccak256": "0x3f94677c4607ee46952e2e91d2dab0250e1da79672c7f5036595001f88a495a6",
       "sha256": "0x5e7eeafd7b9688ff07d1285f931589ab8c1c57602d00ad50e3f9103fa5a9e807",
       "urls": [
-        "bzzr://333312c1e65540324b4e1664be80fadb7785f03f70684b09018c4543427bb8bf",
         "dweb:/ipfs/Qmf3WFGGZck9oJwDCZ4QQHFqPeHNZ2PeVQ1BFJ9z4JaKpn"
       ]
     },
@@ -11453,7 +10568,6 @@
       "keccak256": "0x746987993bbc142c51949e49a3ef9e08ff2eebf192871ea0da4ef156ac088653",
       "sha256": "0xa0f83268c606c1885709e4ccc1df5b6ce2f5cb5cf1582696e883912dc632054b",
       "urls": [
-        "bzzr://51f394b0b36f7214d8003e08a30472b59d544d10802592bd03153994a6a3cd97",
         "dweb:/ipfs/QmUG9NPZ6LFEMVJ9hBFGVP7BpVf3p8PdMcxpJoUUQsLw7Z"
       ]
     },
@@ -11466,7 +10580,6 @@
       "keccak256": "0x6ec1313bb0bb9d397c3c9322df31150aa2b70d78d20464a7f9c0ac21cd16518f",
       "sha256": "0x59cb9b1762e71210ac604a6708517dbb300a68b6703d2c64771828161c3ce61d",
       "urls": [
-        "bzzr://81c7bf8813457e8c980ded0dce066462477e70bc997a32cd13d743ade649f056",
         "dweb:/ipfs/QmWAtjcJ53JKcxz2QTRYpEjDBD3mREKWhBizZzGdSCyfkf"
       ]
     },
@@ -11479,7 +10592,6 @@
       "keccak256": "0x596171107fffa0ab7b9c267da503f42f58848fcfc6f9f238b03dd4529ab46b1e",
       "sha256": "0x55a6393a35e0ac7c10f9a0cceda2110e2b762a56933c0a3b56d26874e9a5aa4a",
       "urls": [
-        "bzzr://9741f6c008684472c7cc40ccf382b888eb8feb194becf93cb39db19637de8625",
         "dweb:/ipfs/Qmbh2z6mXWUtkfGGMc8RHgux6HCNQebGVandkNAgQoVAZ7"
       ]
     },
@@ -11492,7 +10604,6 @@
       "keccak256": "0x76d409b8de7e4ead339fc064b7c9469ac253a45ffa7e8d6cd6279fb9472e81d3",
       "sha256": "0xb9a164bb158b8c280877adfb813ae00a6e675a10d9f86bde925e4432302e229a",
       "urls": [
-        "bzzr://723c25230cc35dafd8554da6905a4ec63e5dfc50b17b4fff7454ecfaa11aee7c",
         "dweb:/ipfs/QmUDBMNZWm2z6BrYWG4xnUeHTGsQpQwatP485q8cPPcE8z"
       ]
     },
@@ -11504,7 +10615,6 @@
       "keccak256": "0x809ba589a8cd03938036739fec44e8f539471fa58af0cb0a7c0917fd65c7ac84",
       "sha256": "0xde67a88e4c35bd5da5dc7a8f538ae3116e97bec0df8af6edd26bbe843d41082e",
       "urls": [
-        "bzzr://1178e539b10083b2a417e39f128a38a76d6f92a6f0c36dea430f433bb73548a6",
         "dweb:/ipfs/QmRge6ua71ZBeiLzEJR1jAty1gDD1PqTnaqxw84VQ8E8ok"
       ]
     },
@@ -11516,7 +10626,6 @@
       "keccak256": "0x09bad5cab9326f921c8f6a4d57fde317fb0cf5a66568defc48aeb682d37b0e68",
       "sha256": "0x5ec673e7ed29b0b23900d95ec926b3c32190831213f0d0b043e9112ef07534cf",
       "urls": [
-        "bzzr://668f46bbfabb58cabac9bce5c5b9003206222130b1783d602ea8709581ddda87",
         "dweb:/ipfs/QmU2HA9E95zcvAcQU1DnJrC7F4NQ2SQ3w5sW4koFxDBLRt"
       ]
     },
@@ -11528,7 +10637,6 @@
       "keccak256": "0x4600bf758fe009e1f50bd11f8bf0be96bd356b0f37be3ee31b55d80a5063b6a9",
       "sha256": "0x52ad76de0634e875ac3d50e09a0057532ff53c6d851ef61204af1b0d620797b6",
       "urls": [
-        "bzzr://490c3c517413fde92c954ac36932eedd3bf6f62f0fdf9400eea0a21632074cbe",
         "dweb:/ipfs/QmazV6RyW7mipfnmvSrtbpMQWYXnyLr6NpyiVQq3DRmKyP"
       ]
     },
@@ -11540,7 +10648,6 @@
       "keccak256": "0x49f812573d20aa8df2ff53cd9ad8398e66d63c088c1ca4f6fe33332c8a057054",
       "sha256": "0xdac1bc7560247d3e69bce9891f7eb2218a6a8d0106d9cdb4de8e03ede4546153",
       "urls": [
-        "bzzr://b9ce3b908fb7800cbe31559d7126a8d08f3b6f18f9568e905023caf3f852da47",
         "dweb:/ipfs/QmQcBV8t6Bpj8BPetd8SNWKZjcdocgWTCebxpSUk5yYXvk"
       ]
     },
@@ -11553,7 +10660,6 @@
       "keccak256": "0x222464388ebafb6485ee2d24ed052bb823992de16d0ef04c05020e92e61a9462",
       "sha256": "0x505a0956ba2fcc4d82e79a6613c79dd6620d6d434ab9e955df8bb958d4b881e3",
       "urls": [
-        "bzzr://15861893edb454c53bd66f62dcb54fe9021e6d68663f27c51bf14c1e05d11ad9",
         "dweb:/ipfs/QmRCefxYvnAkQTyPn7ntKb5agAnzMKRgVM1kJTb9Cb2Xy9"
       ]
     },
@@ -11566,7 +10672,6 @@
       "keccak256": "0xa8104981b48ed9948737d30907d30388484a392e94ff8078f9635e7b6598cb23",
       "sha256": "0x367392b777e95b77267c901d4d71fe8b8d06ce5a7d92388fe21ccc4ef23907c1",
       "urls": [
-        "bzzr://f3dee36fea58aafa1ff7c13092f5c97138cfef11abe5a5cc4a9d1f42aa83ffb7",
         "dweb:/ipfs/QmWg5dW2QD5kaMsHwcSyTUosf7wY1VJJYX83KDa44RXFrP"
       ]
     },
@@ -11579,7 +10684,6 @@
       "keccak256": "0x40530fbb03e5fba376c969df5f027ed22cf37be1511d3431235c914f683b30be",
       "sha256": "0x4924f9e1c972b552af9dece6c2502acc5484efafca96567d9597f65ff75d450f",
       "urls": [
-        "bzzr://1ce680bf3f9abd787fd55173f35c2b74738021fb426d47d64e0b275b726bff69",
         "dweb:/ipfs/QmTeYnZRRY3beTvxpCZkSC36qWVrmYFQZNFahbQc9Mqd25"
       ]
     },
@@ -11592,7 +10696,6 @@
       "keccak256": "0xcb7353f4a09baa272de421d79498e0ba86bbda5531889648a4d9a56d39f29479",
       "sha256": "0x8b254e670c36cea6510e36bf022590e5d103d95d3930e2060f42f3ed132aac10",
       "urls": [
-        "bzzr://a8f2748ec1c9305401abfc3570a7f4d4397476f8c1943a4c32bcb6a23942abe1",
         "dweb:/ipfs/QmWH8jEn5HoubwYZmcy6Dap9HSERUvZWkTv3RXTXjkwVN7"
       ]
     },
@@ -11605,7 +10708,6 @@
       "keccak256": "0xe6d39f900b14bd22477d3bb6d77da1e2cb556ef0d07d869c888df56c4ca72244",
       "sha256": "0xad1cb746204394e364f2a6992730e3ed9e4408cb47236d8eb18cb1686261e5e0",
       "urls": [
-        "bzzr://d97d8bc1e5fdf7a7f58678be03f4f81136c1fd5b4ae0ffbaae07c7484812ebf2",
         "dweb:/ipfs/QmZ49q8KgRrzKx8ZA5cmwEDW2ctoQcmcAZhCJncjMH64Jq"
       ]
     },
@@ -11618,7 +10720,6 @@
       "keccak256": "0xb82026c5654fbdd9ac14fd8e8a0dfbe15de0d880e4b53b083b87999d4c54830a",
       "sha256": "0x44aed5f11f12309c56a5d51f6c0493d42c7a17d286aa9e0bb6e8c8606e5a271d",
       "urls": [
-        "bzzr://981dc2b6b86e92a8cba4bae5b60dd72f81a36d61da1d1a41402c851ca0b6cb09",
         "dweb:/ipfs/QmUpsiHFG8uuEgEsc3fQJoEpjgdgThLNrXS1Jn2hbAoKUm"
       ]
     },
@@ -11631,7 +10732,6 @@
       "keccak256": "0x5809c4abf1c6f778a4719c897d3b98d92bcc2115cb0b6b936a9f04eda2ea3558",
       "sha256": "0xbbd57d63b0e1a6189764ffe2910e572ba3e0c17b673a23769b004bce290dd6d5",
       "urls": [
-        "bzzr://e031a04a50f4a32d6975d37333b081cc3b36848b7a37c786dc133388ea20ad79",
         "dweb:/ipfs/QmdUa3WoCdjSh598oW15qShcv6iZWvFJs7E5mkAuScKWKV"
       ]
     },
@@ -11643,7 +10743,6 @@
       "keccak256": "0x7ec496e409af23346e2edfada124fa19fd4e16cf70789f401f1d81af39f9ccec",
       "sha256": "0x4a9223dc645e2600d5e250420ed50f77b6f5180b1519711195b9d5bae8e643de",
       "urls": [
-        "bzzr://24c043e403b02279c04ecf1237bf30de16d2893fe90982e2a4686b9d2956b5f5",
         "dweb:/ipfs/QmV6Uqh6bUCBhaGDK1VafDvwGXh7bcE6P9Vs1SN1PmZeXk"
       ]
     },
@@ -11656,7 +10755,6 @@
       "keccak256": "0x9f8781fe276f3c0794a9e0f7683603280bafbd5904f9eac444b693ae5259868c",
       "sha256": "0xa6b83dfaa7aa85ccc7e2979cafaefca0e8127ad705b393cbe9d79335342f9ff0",
       "urls": [
-        "bzzr://e2fed58b8b5e9550ffd3ffef23634654d5f3de562a9f13a664d145ea89d61353",
         "dweb:/ipfs/QmUggxsoK5Xc39cvjzXj6m2mHH5QvejCs1tmyeZ6k3c6bi"
       ]
     },
@@ -11669,7 +10767,6 @@
       "keccak256": "0x4192dee2048749c88e3cfd7113973afc824251185e6c3fa1c6ff754bc1366f56",
       "sha256": "0x3977963e4934398d0e07db8777cf14cc935fc73763826a29758f631b177eea43",
       "urls": [
-        "bzzr://7eb8534dc8afe479ae4b42cb5ba251f027d65e3b3d57512a4a40b3ef23c2d114",
         "dweb:/ipfs/QmWA8rWNojNgw3gKbi7jCePywCrWCqi8an6mTpjSfZzYHG"
       ]
     },
@@ -11682,7 +10779,6 @@
       "keccak256": "0xaa4c7a65cdfc5b2261aedd141e321cd8c28a156f7d7dcc7c5c0d35fc3645ccd8",
       "sha256": "0x9ca6c3a9929fa85b3972d43d8fe4879f2dab94a59bddcb3c497aeff5ccc13f97",
       "urls": [
-        "bzzr://1ba0c0fcaf75251e654fdd309377d8f16b8c1ec5ac24e2a39b4580aaa6ffe703",
         "dweb:/ipfs/QmQmZHUvQkbrF5M3L7xFHhieeLAzvNv31qTg8h2QghHa6x"
       ]
     },
@@ -11695,7 +10791,6 @@
       "keccak256": "0xccdebf261ab1cbd8057ff6204a1a45a1aa4b5719573a05cf214a25ff519df86e",
       "sha256": "0xd8fc6046184de9120b9eb9fa3caa95748a00408a6fe34f19f8fabc540dfc3208",
       "urls": [
-        "bzzr://78e8a68aa5aa5a600864b55968f9d5d433a47244f242e5dc0a287f5c947bc459",
         "dweb:/ipfs/QmeiYNi5EvsRcCT4eZGPerXhZf81858p3JtSf8JPug5S2T"
       ]
     },
@@ -11708,7 +10803,6 @@
       "keccak256": "0xc7ba943964a30f714470a864ab50a27b7be1dbf1708647b6d8ebfe86b77632d1",
       "sha256": "0xe352e2d9fc8f4c89cf1a1acbd7299c95dba194a8eec3401b7d1ff76b042a5808",
       "urls": [
-        "bzzr://b31710395eb7f2ee2a8053c049041db0ee73759d62b0b48d01141113a1470c16",
         "dweb:/ipfs/QmVWQ79VjeA8xCKvJUdyMj79nKp7xr6eoFLQDZ7XwVeQQN"
       ]
     },
@@ -11721,7 +10815,6 @@
       "keccak256": "0x627f4268424b37f25e929868de6fbbac9e9f8201a3232bfba72cf9871b051be9",
       "sha256": "0x1b0157043fd8a5097831b8d23243e3e30810e18ddcb824156622ffc1b3982c82",
       "urls": [
-        "bzzr://3a956c85004497cae99dd3d588ee274af49ae3459183df72e60725f1f8e13b8b",
         "dweb:/ipfs/QmdU3YUaPFjob2J6wA79hfqcaRuCDKrMk16wvNRGrou6h4"
       ]
     },
@@ -11734,7 +10827,6 @@
       "keccak256": "0x50dadd1c29a87f65adfff49af8288e9699059e0912da80f83acb6569f16fbc2f",
       "sha256": "0xfc8fbfd02a6a3d90d5b9d22a1a46a2e657ae2f92777599630a316208238f64dc",
       "urls": [
-        "bzzr://9f1f5927ec601e36334d84f5a831a7ff3a4f32578328f84fbefc58f89a47391f",
         "dweb:/ipfs/Qmeog2dEEfccwLFGtqVY11uRsCTnZAyfre5oR83idcjMtL"
       ]
     },
@@ -11746,7 +10838,6 @@
       "keccak256": "0x587599c37a414855dfb389a774a3eb80e252e3b90ee8b84852ea100fb3662787",
       "sha256": "0x599cfe3faf33c09e3792b245d1e5d5c5eba07acc452f29c98e461d3bf060fda9",
       "urls": [
-        "bzzr://9a4a2e4c3afbb116036d2955b11d9cf28968d085796badb8d309ae64075cfe5c",
         "dweb:/ipfs/QmdJ5D8cf2EuBU2sRYvkFnKmJ6HA7ELRL9u9TG2RRU3Q69"
       ]
     },
@@ -11759,7 +10850,6 @@
       "keccak256": "0xc6701ee4e2592bafba60aef4a5e122abb8cf89f548e3aa7b5a6092e7957635cb",
       "sha256": "0xcad18884e9cb04282dcdc202d40ef48ff9f38e244ccfa43df57af2826256fefd",
       "urls": [
-        "bzzr://8030beae7da89fbd037820fe809c1eeb464d8424f258b7b318bf1cd55bf93380",
         "dweb:/ipfs/QmWmkhCK5o88KJn3WJ2h9An862CWcz6Td1AZELyCcee4UD"
       ]
     },
@@ -11772,7 +10862,6 @@
       "keccak256": "0x3482a1c7e9a44abed973cf23c69d4d9f75c78a49d38790ab81bde77a617c2656",
       "sha256": "0xf8d575d3ecb7c985265c8e26288dd79265abada976c795c7a3f01df5fecf4f67",
       "urls": [
-        "bzzr://c8ed7b3e3319ebb7423f3cb882eb931013d3cabc31039c28db719db8b531f41c",
         "dweb:/ipfs/QmQX1xmELtLqyC6r3noy1GEGcoR3HDMGTJC27qurC4jmdR"
       ]
     },
@@ -11785,7 +10874,6 @@
       "keccak256": "0x05231e4da87886261f5506d99eb091ace796992723982d5138172c06f240cc19",
       "sha256": "0xdac1d49442804e804b286b0daf9b2c8c9a3d92c838f03055ff15e32eb46c6b7a",
       "urls": [
-        "bzzr://817aaea6e8082ff8c0ce4b0404f97371dd218385f1038169956914c4511ba8af",
         "dweb:/ipfs/Qmbf4QM6CKaijsB497RZF6vvur2aWS4SJkxeHPmEBTEPxq"
       ]
     },
@@ -11798,7 +10886,6 @@
       "keccak256": "0x50666925696a6351e3fc1ff52e0bfe7e15057ce68effe2da1740adce6fc0942a",
       "sha256": "0x96d2c03d58ebaf6a50456a6d591e808a030b8d551e485c60a471e0972155dfcf",
       "urls": [
-        "bzzr://1f6eca655dd7948dfc7a7a8e226d70170a439e51cd469e6cbe0b2d48ec8929d5",
         "dweb:/ipfs/QmazkygiauSnV2n5kB2EhJMF7YjkXXzcxTfdbZBfDtA3Ej"
       ]
     },
@@ -11811,7 +10898,6 @@
       "keccak256": "0xa5fcf88141cb95b4c516e3f4a2715ef82e2a09ee52df2bbcbab0250a0a4280ee",
       "sha256": "0x96594d6ac05a9b9b03fe81628f3be35fca877cbafcb9b71b68d41ae596c51600",
       "urls": [
-        "bzzr://7e6b0cf7b5a5a4c8ae3d4a6399e1ee19a07dc9d217dc3177f0089719b07889ed",
         "dweb:/ipfs/Qmaw3uP2XY4Z3RxVtjkf54Q9Fw8gX6yA17MFTjB9DnAJtB"
       ]
     },
@@ -11824,7 +10910,6 @@
       "keccak256": "0x99bd0fdd38a244f2f46bebb0198752c80c219fc3a3d727fcb8617743efc7e85e",
       "sha256": "0x873688831bf139b26b4ee44101908ed8aa5cd8e8a7a8f7620e97cc2cc87a5be9",
       "urls": [
-        "bzzr://62cc4f079fee6145896fa6937b4cac42439e12b2f1e90efcf3a43b230a2e5be1",
         "dweb:/ipfs/QmbNmCExN7aMVkUconJZqBZG8sc2UHxRkgQkgZNmnvVun7"
       ]
     },
@@ -11837,7 +10922,6 @@
       "keccak256": "0xf5a25ac66358fb7902e4ec2fb333f9164fd136b310c20af08341cd04de41f7ec",
       "sha256": "0xe17367b4daa5351d4f5cb24f2e6ac7a1a422c14cdf6d42ce3bc79d92d728cd6e",
       "urls": [
-        "bzzr://42ce00dd809f0502db73c938fb92aa3315d8cdf79644cb185ca82d195917729a",
         "dweb:/ipfs/QmVg1oQsoeCBSfouBwQmihKQ1psrXZ1Su35oPGjp7veoS3"
       ]
     },
@@ -11850,7 +10934,6 @@
       "keccak256": "0xf02d412995c6e95eccaf9cabd892d6bae3ef4560ef54b2b3e29c136d1ab8cb02",
       "sha256": "0x74e06c1d59b1e88a8348b8a89241f822b004802749dbc0d8714a6bd15858122e",
       "urls": [
-        "bzzr://9d612b089ea550ac05cb390ac35420a99c1ca805180c9a6fd1c4ba99165a375c",
         "dweb:/ipfs/QmTYvzcjnAqgAwyXFYKcxddMzB4Aazdv5qXAvxjXNC6KX6"
       ]
     },
@@ -11863,7 +10946,6 @@
       "keccak256": "0xd1918ff23a1dafa1c4d52fcd87ec7354805ac1f415a6253ccdfacd738c414436",
       "sha256": "0x3917bf3fdf88beac40199c306092f20681feaf0a0896504e1ad0ac6619765c0f",
       "urls": [
-        "bzzr://6b17c50533e48aeead3506d243278c4d166fa76418ee7db28c65f410ba441f0b",
         "dweb:/ipfs/QmYthpsk8x6vKh5fYcmwXpHCWbuTcMk3cbthqiVCZNERJU"
       ]
     },
@@ -11876,7 +10958,6 @@
       "keccak256": "0xa735b416fde2c174215bfa3335a13a083060df6825bd0fce48c20d77589e6f0e",
       "sha256": "0x65f82ca0cc1454da4012d6a731831f05027f8b3e6a3202d2c297469be1d2feef",
       "urls": [
-        "bzzr://8a8548ccccd937cb6f780349680c7ca5f0e503e9ccb257aac7ce61eda68fc451",
         "dweb:/ipfs/QmW21QKdeeMDfjUrTJYp7McAWMkTWwzaDqm6CsJ7dwobXE"
       ]
     },
@@ -11889,7 +10970,6 @@
       "keccak256": "0xc595fa5c0a2b7a20d85516c17a7ce47e8ad5a183aec5c92bc7b770224e8f334c",
       "sha256": "0xcf87eab528f6be9e833641a4456e023f9deb7df3072728afd601637505711cd9",
       "urls": [
-        "bzzr://17605467b95873fd200ec5f360510e23ff3871db9cc2678b90161c2bb159d4ea",
         "dweb:/ipfs/QmTtPqEdh62FUN72NEpgs5eoPqf6v9MNbQfJe4S9eY6j4w"
       ]
     },
@@ -11902,7 +10982,6 @@
       "keccak256": "0xab238eb402bf9e7b32183c0ee1b40c4773e86008d794fa0961c36541c54a5e1f",
       "sha256": "0x98b8394ebf80a9e1f11ac895a2903fb1ba7a6a30f0fcc6da6cbcd65a603a1ea0",
       "urls": [
-        "bzzr://67a63ee7f29babfeeddaed7797043798f0e8c969ac23738a1655731509897451",
         "dweb:/ipfs/Qmev2by1jvcr8ukhu2NZYj3yCxyCGU276PQoRBAf2nxVZA"
       ]
     },
@@ -11914,7 +10993,6 @@
       "keccak256": "0x7dc96455c864b49abc7dd5f38ba6a47904709ad132ea36babbfce98d42e962e6",
       "sha256": "0x25f564cbecc5bfe95d6d358e0e7543c31ece0ab1332c555ff323ca163711bd2b",
       "urls": [
-        "bzzr://f61230aa01565c8c24aa2ed50eec7dfd26195be35f5bbe4445c6a3efceaa4b7d",
         "dweb:/ipfs/QmaLUM18c7ecA911ig5u2HY6fAu4AiUbhJpnZwwCMc9cWi"
       ]
     },
@@ -11927,7 +11005,6 @@
       "keccak256": "0xab25125b1b73862eb45a4d4e04cdd352c329e34c824338fc60c674b122cc1992",
       "sha256": "0xce0554b1cdf0140b1a7d62eeea9dc3d17eb18130e2e3e65bb6e59eec48c61660",
       "urls": [
-        "bzzr://5f49380682bb3ba63a0504a857cd075b89f70a522efa769fd7f3d379ec2b8a9a",
         "dweb:/ipfs/QmfLsmoR5iYUoLhwZkqMRpLxGtcs8iSNrkxyQNBDHFEP6f"
       ]
     },
@@ -11940,7 +11017,6 @@
       "keccak256": "0x4efca31e822f5b08ca9a53ed8bbdd4936fe8e555da4f00310e247e5c0f11a077",
       "sha256": "0x02c7d1c66b4d923dba59e4554cd03178a2efa33f6960c22cf6ff72feb388e911",
       "urls": [
-        "bzzr://ed119b6caf264a07ecf3accfc39ea289a7df5595ae55e935005658fd70ec4bf2",
         "dweb:/ipfs/QmdTjs6MXeUcx2bnYqCWKXFuiY6mSB6g1VeNVUm3P1dbae"
       ]
     },
@@ -11953,7 +11029,6 @@
       "keccak256": "0x6683831a9f0ad3fc96726e332462ed5e0755b452329e28abc4ecf66759dacad7",
       "sha256": "0x829e302a771607e2991226e747008500d7bf87bc9a43598762f3e088bbcaa163",
       "urls": [
-        "bzzr://bec1d2437a2a16fb9ebcffd1d79fe1b1ed4aa391086f32ddfcff0e8f79c27166",
         "dweb:/ipfs/QmcwpcZayDNtgeU1Pov7JBMYoHx46YFWdTUkThyxyyiH5g"
       ]
     },
@@ -11966,7 +11041,6 @@
       "keccak256": "0xc438477643bdaebdd35b2d203b0716885c05d703ae2f79717e74eb82066f41b8",
       "sha256": "0x0632c6c3fd3a5b8038493f90d12318b7089c777248a523b58bfc0e4b82ac8a48",
       "urls": [
-        "bzzr://486e2ffde29f54211fd36952a9030dcf9d2c7204064f9717773f5379f4997480",
         "dweb:/ipfs/Qmc7mxA6Ran8imJW8DnGCQGa61DjzaYA4V6fCBDnpgwjwV"
       ]
     },
@@ -11979,7 +11053,6 @@
       "keccak256": "0xe6eeaa95e8cf40a0217b6076fafaf5a7e56c192388af5a35e1ddf75aa93e10ca",
       "sha256": "0xf7d00e66937250b078ba6c54c7fef21b9231f70bcd88f5e8615c0b7c7e356223",
       "urls": [
-        "bzzr://24aa21dcc520b780389d517e0a5d10b0f7aeb94ed54fd0749e6702b0b8fb9a43",
         "dweb:/ipfs/QmQdPm82pgKwfdwd2nBaQSg5qcYo3HwFroAuKU4eroi8re"
       ]
     },
@@ -11992,7 +11065,6 @@
       "keccak256": "0x4b2519d899a346daa55fa10e947ceac6f745d0a38bfb0be9ae0be0968e343493",
       "sha256": "0x65fce9aed435ade3aacd64dfd4d6817f50462eed0f824a3417fe76a2a9960255",
       "urls": [
-        "bzzr://c8b41defea9e099d99d7dec9e709a3e7f4a7032b76f0bb17e608b4477f234d68",
         "dweb:/ipfs/QmPV5YTTDuYqdhGh9Kia3ee15pSxcyZeqBCVJxJhzfafJ2"
       ]
     },
@@ -12005,7 +11077,6 @@
       "keccak256": "0xecdede8aa267c6368889bc99d3926e0ea2a939edb39e4bf95cfa567d1f6c721c",
       "sha256": "0x87a60688a74923e5f4c58bee682ecfa85ceea859ba67e02437deae62ad0f8dea",
       "urls": [
-        "bzzr://40ad68224c83a7281e18a668d8517a675a71d942b8f4fd813b0c308d1b24824a",
         "dweb:/ipfs/QmUTVT7LRfGs78vwudPFHT9PX4a8PxwxoUX1Y4sUR6AtX1"
       ]
     },
@@ -12018,7 +11089,6 @@
       "keccak256": "0xb96573f17fe2983ba60120c9ec45a6cb02508347dacdea6489b0e980decf88cc",
       "sha256": "0x30f40b017dae49ba7ae2cc4d16f8fcb383534c7156a95923533e1f97330032b6",
       "urls": [
-        "bzzr://c02d91363d028bde4f327eb9a907f2e8a32a62af99e9ac8845a2da2f1a3b8d22",
         "dweb:/ipfs/QmXvZwQ9nPTApxWuoSHnWFXHbUzGyJLvKS7Cf7qXnaACCY"
       ]
     },
@@ -12031,7 +11101,6 @@
       "keccak256": "0x9d94df9b549c0ec5d1a1312f7bfcc081ca5f5cad379edec97ec2da2c47690fde",
       "sha256": "0xfdf4d98e89b1c57a98251a18bff7e4870503c95f5e005708d9a6bb5e2a471a6d",
       "urls": [
-        "bzzr://6261a5181d415fda6394bb0425548d8b2a24e3ae41f960c27476b671f6b6596c",
         "dweb:/ipfs/QmUnsEmePujFV5YF17VHo8N5RhM4qwKKMGiVnWCZgiNf8q"
       ]
     },
@@ -12044,7 +11113,6 @@
       "keccak256": "0x64c0caa579199acc942778a7230c426ab222a1b615b1301496a452beb4075c05",
       "sha256": "0x9a85a6fda11a1445540948065a7f480b1d0286fa887729381399c17dcd944ced",
       "urls": [
-        "bzzr://3b6e74d5befd6fa0b13cb88ccfffcd3af077172f3e9b1faa7e2435f44748e921",
         "dweb:/ipfs/QmaEqayBYUSsCFBdRSNZEn4FSTFHUU55higPQTkcupEqWF"
       ]
     },
@@ -12057,7 +11125,6 @@
       "keccak256": "0x878c468e8cb73a1a1e25c8bc9475bda5745698c2cd4e2597609af26f9f4772e6",
       "sha256": "0x22cd8accf386e07205e147271bb70bc870edf4fdd632fa218c0d959f97f7a17a",
       "urls": [
-        "bzzr://3f4d61bc50d3e331c94c04a88e4403b9eb13cb0f601f212ff911f25d0388122c",
         "dweb:/ipfs/Qmaw6Dz4badYrMrgnpezoz2SNg83wVKp3fKs3nnjypEeEL"
       ]
     },
@@ -12070,7 +11137,6 @@
       "keccak256": "0xda30f9ed9ed0f3ecbf3d0a21d7ad2f92f09e726f449005c92fa51ea309c85c82",
       "sha256": "0xd0c7c0e20c95747d2c9302cbabcfd6095b9bac7f969ef1e6400f2f8ebb5b1c99",
       "urls": [
-        "bzzr://2cc4a808b9d670c8f6f3d7e9b2ffb3c4fb0edd84e74ad4dce6b45371bb32ae29",
         "dweb:/ipfs/QmU8cvDH4fWYL3TLFCGkRxpLBFaXQQCLhyNzGzg815WpVr"
       ]
     },
@@ -12083,7 +11149,6 @@
       "keccak256": "0x1838b5583e3a3965df45cdd3306473d2314668330967c1800e174cea2f927966",
       "sha256": "0x0d38be0eacea0795cd71c3fa1771ef99e8ef1bc120f7521c34b41b51e205243c",
       "urls": [
-        "bzzr://3975de25bfe95242f3247d666f93875d1981c88c0a0965394c30761e1093fa6e",
         "dweb:/ipfs/QmYeFtgzDrwhZWTR2NdjAh4MwY4MKyA9XzWehnoaUxZN9c"
       ]
     },
@@ -12096,7 +11161,6 @@
       "keccak256": "0xedc0fed06419d15a47549af8069ace404e1934398da91e4180eabd62e030de44",
       "sha256": "0x2240e1fd97980403a28638c5a1566fe8e33d3c72e48acfb85c87e562a546fc60",
       "urls": [
-        "bzzr://f35862b9beea0d2e1e0be36ffea5e234c4aa6c34297b30a688db108d2c035d38",
         "dweb:/ipfs/QmRuhyhzxPNCmQADbCZrX4orMKzouUgQKCfQREp6NLUBeN"
       ]
     },
@@ -12109,7 +11173,6 @@
       "keccak256": "0x12672ada3c17f3e074913482f693b8fd4ccea71d38223b788525c0b75f1f5d12",
       "sha256": "0x6789992ee1cbf544f2559cda27be56c136a6a20bd0bef94636c2cf8700d4e2a6",
       "urls": [
-        "bzzr://9a0c88f6152bfaa0ee8bfc4860bdaa72606815afc8e9739db647aec8439fb3fb",
         "dweb:/ipfs/Qmd47pumVrKQa3Zer7DSqTSGKya7EoHJMbyaLKVHvh2Vbv"
       ]
     },
@@ -12122,7 +11185,6 @@
       "keccak256": "0x43a1cf9441815be354088eb0846f46f4327254b83e969939d8225b42d8e8fff4",
       "sha256": "0xdc972dbc8a1e617eb8732cdaf20a95570dd51f57ce542f9f452a2a7d31c0277b",
       "urls": [
-        "bzzr://4983589f46a3c1241e84bf6a86437518e81c0af6fcb6e324e379a335724f32d0",
         "dweb:/ipfs/QmXgsfmXxK3XjHgdSW1q26s1QeYwXGm7rw3ftfShhhDXfd"
       ]
     },
@@ -12135,7 +11197,6 @@
       "keccak256": "0x0cfaf670a0914daf17f188b673a9380bc8fe0258fd06b4497489a76363726064",
       "sha256": "0x40e2bb09ad5e5fd47e2c3eff2ca46f49a42ddbd597d24cc21d7e4193799f3c6e",
       "urls": [
-        "bzzr://93c4ed9dddfe75213e2f69d45bd4cfe85f1a054acad340195a85bb16dfe895ee",
         "dweb:/ipfs/QmRzUipdAmAuEDQEbTh4cRvBDTxN9kFV4AjQD6Bqo4JpAr"
       ]
     },
@@ -12147,7 +11208,6 @@
       "keccak256": "0x39ae8b2f3ba05ed7d4a7c16f0a9f4f5118180a209379cfc9bdd2d4fb5d015dff",
       "sha256": "0xf89514dedd8cfb3c4d351580ff80b8444acde702f8be0e5fad710fe6e906c687",
       "urls": [
-        "bzzr://1d6deff5623d883b8d0b3a3a5539e4604925ce4c1677defb86e0e37838ea70c5",
         "dweb:/ipfs/Qmd9JfFpUXsUQrJad1u2QDuMxBMeVrcG8mrpfJVV9jiBXB"
       ]
     },
@@ -12160,7 +11220,6 @@
       "keccak256": "0xab25df7aad329af7e6b031c3d24949774c9f6efe30816a764fa5b3899073d947",
       "sha256": "0xb6583e022b5ac66239023da4db2bf2cb27c1e4392aeb8a6692959040faf9f774",
       "urls": [
-        "bzzr://9c9b76a62e226885dcdea1afe826472d5ca5cb562d55081896e16cd1f140c4ff",
         "dweb:/ipfs/QmcDR1fBnmA6Maue4MQRXdE5yaur9oZJt7bGyFRJzkm5fq"
       ]
     },
@@ -12173,7 +11232,6 @@
       "keccak256": "0x9e5dc2815736eddad095f8d1f1687799e2f2b3b49d996fda9c8a91d9cf6506e5",
       "sha256": "0x4c7b69f76c35b20ab5f4a6580594e859db08d118c67b44aab8f2f78e3bfb2314",
       "urls": [
-        "bzzr://a017b99847a6927f7c0884b484c1780beed11029f0b74e7c8dc5423ba73e50a6",
         "dweb:/ipfs/Qmc9JDHjzF8QZvtcfnA3w2PmDdBStbK1F9z4nRDzrDXZNi"
       ]
     },
@@ -12186,7 +11244,6 @@
       "keccak256": "0x7967d606168d19e40ed75439cb894e27f5612513db61a96b91b82a6434d28348",
       "sha256": "0x4be3e9f7f8f37b3f42597a07c474e05cb93e02bd15ac0876838f09793a9267fa",
       "urls": [
-        "bzzr://1d0d501459046042d4b8ec04fc60efb48a54d75a5f584d54f6048f8efed2315a",
         "dweb:/ipfs/QmbxQcmWrxF2Sy9tuNb4LQWcpAvqKy1oaot6Ui5hUPcpvV"
       ]
     },
@@ -12199,7 +11256,6 @@
       "keccak256": "0xa5f23186e6a0c2981ee898f747e08c24e6e62e410fea5b082eaf2263487d4969",
       "sha256": "0x22bcf2adac4f201dce6ac7b7ddd1cfe788c868c49b6ee0d62fae04fe793b0b68",
       "urls": [
-        "bzzr://9af3e66820ad6f38e0760bc18291a7da394b2dea566e8e77ac378bb3590e382c",
         "dweb:/ipfs/QmPXnwuBRvRKxkp46uYQmapLXQLM4RhRCKqvqVyQBckFeQ"
       ]
     },
@@ -12212,7 +11268,6 @@
       "keccak256": "0x3f807f3204e8666252a7f25582346398d19140e5f60ebf02cd3868fb5f0b8672",
       "sha256": "0xe93160e52703ea86cdec96c51b817a3df951aa3ed21cfe0b3c736fcc71866d21",
       "urls": [
-        "bzzr://d4254b43282ed8dc85de0a28974a655738270381153939fb6a71264cbb778931",
         "dweb:/ipfs/QmZRpQATGG9AfCVbaNpVXLya71zrgLpZknuT9wt96JNSFj"
       ]
     },
@@ -12225,7 +11280,6 @@
       "keccak256": "0x853496154ae09ef36e221996ce8cd74aedef82afe69f4a6d5d365e3aad0e9bf4",
       "sha256": "0x6f8fe651dddaed6198942d24fbd6cc4c2462edb25156dcd1de68dd4c58ca5e9a",
       "urls": [
-        "bzzr://08e522f83f6dba1896bf8a5c61b9b9708e6e30a15d7d00eabb7ffacc648e3c11",
         "dweb:/ipfs/QmfSKqZRCdD3mRq9zYmWkgRPPv1xLs931qA5H8NgXbw9Tu"
       ]
     },
@@ -12238,7 +11292,6 @@
       "keccak256": "0x8c12309e06396ab78c120c10e51533a582d376a303353ce2913b3ddb3ce5bc09",
       "sha256": "0xec27311fbf319ef7be69e8fe21fe29afabd7ddc2adf2b8661c01c224a2d43fb1",
       "urls": [
-        "bzzr://8281361950f346179877d3f24a1c5e3e1e99c421e4b9d0a1d97051c6d24fd977",
         "dweb:/ipfs/QmS8v1FYxCe5dYV9jtpLJHqySPDaRojG26mtB2dvfXKx5y"
       ]
     },
@@ -12251,7 +11304,6 @@
       "keccak256": "0x0a61bd855afc453ccbe9ab0dd2c06cadbe2138f54602b5581c9bc1440da0a973",
       "sha256": "0x31f25254c368eb56b9b7ea5bfa5253fa8acd58494a14a67e39318c9496a7b578",
       "urls": [
-        "bzzr://bccbc243d6b2acd3f003ebc1e4fea270023f9c1afea5d17ca6a3be81aa1fec12",
         "dweb:/ipfs/QmNvAKDtDqsQLXFF5NDE2S65dCEoCNmA2rZrfGYzagJWVB"
       ]
     },
@@ -12264,7 +11316,6 @@
       "keccak256": "0xf7da87b48b2332777ed786baeb00598222ef80c30b44618daa9478f3db458a45",
       "sha256": "0x79f169656c56902c42698ff34b5ee195fce15493de118f145babf31b8f6e2b2e",
       "urls": [
-        "bzzr://c5c8f7fcee2ab8000508cede378c74c26a53217d60cad27513298065179924e3",
         "dweb:/ipfs/QmQuYfEyWvakm2sdM3FcHRCuL7vEu92ptn7LpSrGoJyqhz"
       ]
     },
@@ -12277,7 +11328,6 @@
       "keccak256": "0x31c01d21b7ea8154c1a45ee1ab1f213c67c49dbd76845b2f7764cf97ce1f3991",
       "sha256": "0xf9b08418b9245eef3a3590953ec716b6d6c2e945192c5a8005ff4a99a0d9689d",
       "urls": [
-        "bzzr://a91cedfc816f738794e93e9b4bedbfa5b3e7ebde36c928323b1926ccab7a6468",
         "dweb:/ipfs/QmRXPBsuTucPf6HDXB79PBYut7Zbhi6hxYoHonZVkCeNDY"
       ]
     },
@@ -12290,7 +11340,6 @@
       "keccak256": "0xfb768185e9822c333b995ff8e81203399a0a8871a5211da8c0f43bc9567ea5c7",
       "sha256": "0x22d9265b0660b2553fcc81ff4c8b4c35e04252672c86ed5c06127ba7de0f278d",
       "urls": [
-        "bzzr://350e0308e9cef2d4ffbe2bdef8b0db030048fed5de6d56fdfcc1d2ef3d4301d2",
         "dweb:/ipfs/Qmb7URbyeXbQc32w6rJ949QUC7DnQBJEWqrP4ADmiYSUov"
       ]
     },
@@ -12303,7 +11352,6 @@
       "keccak256": "0x2947927c0d8c3789d7248a84aca44f48c4162b56650c6f632164eca7c0b291ab",
       "sha256": "0x09b46eff28534de6f0ec78dfd506006ec8e301efe44f2d88931bb089d2405791",
       "urls": [
-        "bzzr://41c5b98f17c49ce26b1eae6c4c36d704239e2784504a6f598674a0c5d76fb9c8",
         "dweb:/ipfs/Qmd3SwG4ZZa3fXSz6dJ5oqsTwrpq65WAmfgmXNfugEhHdB"
       ]
     },
@@ -12316,7 +11364,6 @@
       "keccak256": "0xde935372ae7ba0c9f5f5b855052a855fb0fb607c3e52f0a86a6ac5587c82d34e",
       "sha256": "0xa46f055b82689a9a821fefd3811d6d3caecbfc167f4df025317d4b14de10312b",
       "urls": [
-        "bzzr://c4828e0e1751dc2f2c7540d5c890ee8aa56e1536d358673f1333e4d3a458991a",
         "dweb:/ipfs/QmUh1G9YtVmYLcNjDYpdPeQEdLDfNqhpHHr7cmN9YkbVK1"
       ]
     },
@@ -12328,7 +11375,6 @@
       "keccak256": "0x435820544c2598d4ffbfb6f11003364c883a0766c8ac2a03215dd73022b34679",
       "sha256": "0xa4fd5bb021259cdde001b03dac0e66353a3b066b47eb2476acb58b2610a224ca",
       "urls": [
-        "bzzr://62ef2a9bf7dbb8fd596b7c6ca6848d9b1a6c8562d10239659f0a56ee27c110ce",
         "dweb:/ipfs/QmTxzbPN4HwcK5YX7n3PNkb1BzKFiRwStsmBfgC9VwrtFt"
       ]
     },
@@ -12341,7 +11387,6 @@
       "keccak256": "0x74acdd6df18dec6f479e5b23bc7693e6e255666ef60da55cd87c8544e04af345",
       "sha256": "0xa72f44ab0126134cfd3e9e1bd890cb8714db1b582544c7cf3f2d6591136c7196",
       "urls": [
-        "bzzr://d782a14f988224495c2f1663f3e19d31ab25cd6822201480b7cb95bf451fb994",
         "dweb:/ipfs/QmXhrsCeTfiARfZ1sq2gWUiKCXARKub9P6ZxtZndpXYmjq"
       ]
     },
@@ -12354,7 +11399,6 @@
       "keccak256": "0x5d678dcb1ccdbb5877fbc3f4d1ed012debe92c7103216c5360c7af0a479389f3",
       "sha256": "0x4328405ff1e8d566f6900ef1d157cbf50968d18715cb3c0c303d3bf42f114608",
       "urls": [
-        "bzzr://dee303244571a5dfa50667918f4ec12149713ba59e7b577462ec2b37c42563c3",
         "dweb:/ipfs/QmPsasA9CY1TyDx4iuwKnC2i4bi7xb9vEMe9zcAdNgXBDB"
       ]
     },
@@ -12367,7 +11411,6 @@
       "keccak256": "0x4fc7c62d7466381a06978d318ffb324f9db7e7ab2f9802598d7362cda565300d",
       "sha256": "0x7199ef27c56dbd46f3e3357b0eae711f72ba9beab767298230e6d3c7e541e6f5",
       "urls": [
-        "bzzr://004854e59e0aa04b19dde6b4be297f87a5562871f835b73596d3dd4a7be48b78",
         "dweb:/ipfs/QmcWSmstcyaK4AgN8zZr27baPJhNjHtPYm4yycmjuYtWJ8"
       ]
     },
@@ -12380,7 +11423,6 @@
       "keccak256": "0x9759e7fd9c571210f85c50e0a9c83f22a5da437a600c8b0ef9afcd107a1fe3cd",
       "sha256": "0xd2d221210ccaa1891cc31bc86af5467dedfe3db45ed778f1ca09c401119c46f8",
       "urls": [
-        "bzzr://53988ec7013fbab5a4f5438a048c6c6daef6c03951a2ed00f2625fc23eb47a96",
         "dweb:/ipfs/QmZLbZ1qHZ71zfKb23X71eS88aMorbGV6aR4uTYAcY23d8"
       ]
     },
@@ -12393,7 +11435,6 @@
       "keccak256": "0x9fc610e68fd0eac467354e6ec1a020f86f9121575e46c348f93b6f222c286ea1",
       "sha256": "0x538d39457455eaaaad547e225413d3cd320790bf3abdcad77c15615b00ec2930",
       "urls": [
-        "bzzr://8c7ceb45096f7f3173865c48b00906de0ce842a977317ffa5225b2e96c5a9fc1",
         "dweb:/ipfs/QmXWQLHX15EEHEBCqWJrrD6kqvH5u8KRHeYwoqo4TCxnoX"
       ]
     },
@@ -12406,7 +11447,6 @@
       "keccak256": "0xeec559692b7d2c27be338d7b2cce6fb6ead42564a14f994385a1607a53368483",
       "sha256": "0x528c32e0da1c34f64792423a421830627f3045710d80917df8ef3fbd406fa29c",
       "urls": [
-        "bzzr://d561db91235f6a361ea5290ba0380283ab3774ff09105b8761b43609fb475165",
         "dweb:/ipfs/QmbEFtuP7XFmAXJQsU97SJEn92hKEpUdisRPX4TPKYMREa"
       ]
     },
@@ -12419,7 +11459,6 @@
       "keccak256": "0xc74ee33ef44c9d2de52a6f0e41fbbe39d5a41b8af040664cef27793a08a71322",
       "sha256": "0xf6b2fc77c8a38c56c15443ebb91a13dcd23babc71861e114726e50c7916b2f68",
       "urls": [
-        "bzzr://9478a3eaae9ea219c33910a827e6f712c13268df83d53eee94a1bc245885b105",
         "dweb:/ipfs/QmNvp9ZGawCS2KB3bXAAsgoizXQy2yaS87Kt6uAueSnMFy"
       ]
     },
@@ -12432,7 +11471,6 @@
       "keccak256": "0x88c5079ccdaea27094deeaa39faebfd74c3c310cc218738c8d34027abc850345",
       "sha256": "0x9f2a6a91d1155bfe46d3b08160f8054dede67f1f6e7597df9098808301141878",
       "urls": [
-        "bzzr://0b1a66a7fb27f65a6cb34db564fd2eaf7244192e2284bb39134932d0e85f0b63",
         "dweb:/ipfs/QmTa8XN8qoQPHETM5vfjJkJdKWuHRy8prFCFvWjGwMCkPm"
       ]
     },
@@ -12445,7 +11483,6 @@
       "keccak256": "0xa02c559886cc455faffb443108450f2c82811958bc605498401585d3dcd0cc07",
       "sha256": "0xe57a5a4d90af32c5c08f30cbbfe80cdc264bb59d275fa59cd8fbbe98f3da6f50",
       "urls": [
-        "bzzr://ab07840e1d1c52abded06e54b9d0d892e9e906aee1eaf113a94c8bea9dc82554",
         "dweb:/ipfs/QmPiqn9nSx3xG92SRJ4cDRGD77mUoGRwhNLjm5EFD8FYB2"
       ]
     },
@@ -12458,7 +11495,6 @@
       "keccak256": "0xaa9cc8864b8b0c1ab93d43dbfea45f79ca6a86445f67f8b6a9364f1a95c8dfca",
       "sha256": "0xe3606eb58b664bee2d80c79fe1c226dc0918d172107dc0057457696365339bb4",
       "urls": [
-        "bzzr://87928eb4c85db186a033c006b79259292a056ff193babfa409e11bbd4427ac66",
         "dweb:/ipfs/QmSQSX3cpbkUbYp11izawNLUZBXC3DJjdWa3EDNJySu9Bo"
       ]
     },
@@ -12471,7 +11507,6 @@
       "keccak256": "0x2b51474de211a0c0670cca7a9e0f767456edae2e3719215f92db0c768526d00a",
       "sha256": "0xb8b22ca9c14fce8c074d808c52717aab86a08a46f51b55e9d8b33e2d8f8d31fd",
       "urls": [
-        "bzzr://ac03c2a7929a7177c874d22af43a4e3f6511003bf6b5ed76215cad239e4b5cd4",
         "dweb:/ipfs/QmXcfmwaToR64dxYisiSTFpSydGfBrmJKm1HbwSSJ2w9oa"
       ]
     },
@@ -12484,7 +11519,6 @@
       "keccak256": "0xe7cc1a2c7ac9a9311cd85229942c6145218c324f00c050f68c0999f7d2116850",
       "sha256": "0xe1fccf43b5bfdb40babded1c2deeee8be1503c0a739e8f427375a8b00209ec76",
       "urls": [
-        "bzzr://3bb2a525a45840bfc71262d5a3dda2bf6fbaaf14405e9f8f5a12016717740896",
         "dweb:/ipfs/QmZ2PRJCdaS3BsueuV1d83zF6CVG7KhKynUgwo6XTkaxu1"
       ]
     },
@@ -12497,7 +11531,6 @@
       "keccak256": "0xe41fd04cec5d74eb41caa85991f3c4fde5aa873256cb0f5b2328ecbcd1c1afd1",
       "sha256": "0x15cf76b60b2a6d3bec56d96bb70ab8845d2686894475cf136aecb168032e2ad6",
       "urls": [
-        "bzzr://97a9c371412180f55f4f9df3293fb336b53a650ca46dfb965cd9e32fb1199329",
         "dweb:/ipfs/QmPSfGs4TThuG6bmkqxAp1dkg5fxMonDDGg9aL2M6NNWJW"
       ]
     },
@@ -12510,7 +11543,6 @@
       "keccak256": "0x46ac00b914f85edeb7cc255b605f11d37043fba953e43d7609bb7c2eef2f9e62",
       "sha256": "0xc2a5fc843959e8f29fd7dd2b39670c49efeaf552c2f9f4cf5f81d88fd07d698f",
       "urls": [
-        "bzzr://ced40f5a7baa270bdbce302e438fede82df1fc1f375c78d92c59304470f05817",
         "dweb:/ipfs/QmQk8j3U9cqESivhT2Ks32bbDrW4FUSRK2dAyj9wegVBwu"
       ]
     },
@@ -12523,7 +11555,6 @@
       "keccak256": "0xaea89892341fe59cf2c2860100c7ac4efd768633123e97cd04acea743a34eae7",
       "sha256": "0xf0622abaa11a47fbf56ff054ad1a789139ea934e052cf9cb34ff0bd3f605ca0d",
       "urls": [
-        "bzzr://9b643e72be6a889789af24da646c4c3acaafb2b4808a84c3d31dc25710b19acb",
         "dweb:/ipfs/QmdvkMuggo3TP9YHGCG5t3HxUW7XBjcPgmVbXXqmiRrdRJ"
       ]
     },
@@ -12536,7 +11567,6 @@
       "keccak256": "0xbae7832d317b2be47bae892d1f6de4b56587c6ee17e26924a44a432cc3efd80e",
       "sha256": "0x9bec709789395b8c2f03a0f7ee2d2b6df84ae75596092d8e2cc93dd49443b217",
       "urls": [
-        "bzzr://a29a025020631cbcb5c9ee57a83584510ac0b8968d249e666279c73ae52226ca",
         "dweb:/ipfs/Qmdv1Qv9Hc5juuVV4wNxSpeXaxi5ujiye2Ett1FdFr6b9r"
       ]
     },
@@ -12549,7 +11579,6 @@
       "keccak256": "0x244209cbb6289778383ac3a94d31ee77bb07741d6febe411ca6de450928ea464",
       "sha256": "0x4209d030bf7908c1ab0c21fe446753e420b6a970c2e62a4ade9d34c6e95d1e46",
       "urls": [
-        "bzzr://28ca6f3f5078413340fbe1dcdf760441bae84f363529c676f5a710fd4cc8313d",
         "dweb:/ipfs/QmPAHSb7VJ47fK5mwS8XHwcBCG1B9o8CCDiqgMBWetjQFp"
       ]
     },
@@ -12562,7 +11591,6 @@
       "keccak256": "0x2e47901e8fc02cf48b61e97fb0112cf34d9797bc6c09c17ee08b79c3c6926248",
       "sha256": "0xb89c402b4a600766a9bf882cf162884fc68f42522e1fb1b919b2fb068192f838",
       "urls": [
-        "bzzr://f7cc3d83f42ecec197ee24f4c4710586632e0e3b6779b74b4434bba38c5c81ee",
         "dweb:/ipfs/QmRYoeCJ6sRiodz1P4ef29hjZd65SDoA4i1MAsMaYQrjN8"
       ]
     },
@@ -12574,7 +11602,6 @@
       "keccak256": "0x6262768243c1ceaf91418e52dc6f52d2ce94d19c6e1065d54499b7bc4d6e14dc",
       "sha256": "0xf8f83757e73f33f44389d1fa72d013fb266454a8dd9bb6897c7776f8fc3b0231",
       "urls": [
-        "bzzr://ed91c1114615572c10a34f0ab28a3a159d2d433fabbcec9eae7253c25ecac8b4",
         "dweb:/ipfs/QmRUoBQeA5zpun1NK7BvBhQk6pTT4uZw7Jn2wZnWQETH9W"
       ]
     },
@@ -12587,7 +11614,6 @@
       "keccak256": "0xba5ab6a2d8295070b5da744573afacf1c944cdf4771d7887f280453a7281df0f",
       "sha256": "0x031b38740249dd9cf6aa890a9376d9a165fae857ced8903de07722e409f76de4",
       "urls": [
-        "bzzr://47fa2954c502bc89b089e0e1dac52905292f1c4789e9e4e95c88433a12884a57",
         "dweb:/ipfs/QmS2FD9ZwFzTFScbyKPhV9NSNYqcG9PF8Ga9kt1pXsNSfG"
       ]
     },
@@ -12600,7 +11626,6 @@
       "keccak256": "0xbc59141c7fb5cc3540f20d4d4e0967546b6ca7d859fecf7a91df2598b7a90058",
       "sha256": "0x8b75b91e88b2f3fd4253ae4210940de3aff970fba8f0bcd8c1b9ec7599680927",
       "urls": [
-        "bzzr://1e504357a73f2983e6d4a7601d05063388ed609e6a178f2793fad7ed271bcc28",
         "dweb:/ipfs/QmWRmSvhw8xQB3sGdGorvZ65q5qYGxtut5Xsb7UBxcj7fs"
       ]
     },
@@ -12613,7 +11638,6 @@
       "keccak256": "0x93d39f7683ee9d584d0c2ccc215dbe354a56a9ca00604dffd2cf6b1260be9570",
       "sha256": "0x14b87e69f5489808c8d9945966d6cd81540db7faa44568831eedf1306a05fc22",
       "urls": [
-        "bzzr://dddc0450e10bb3b289f597e38a65be014ae86715c1e7e6473ed374766739b5e8",
         "dweb:/ipfs/QmciCS7DySdpPFBW19mtwp5mwMqaR5jYhAVB4trTVpSXn4"
       ]
     },
@@ -12626,7 +11650,6 @@
       "keccak256": "0xa9cd0e0b2d4418292a3a977e879fbba69c101a5ff6e7ad383431543e4288f0cc",
       "sha256": "0x8b81ef835e34ff3c97bc02e443b4ea998d4a807e0e127d6f92c63fe0681a7eb6",
       "urls": [
-        "bzzr://cb85a3c47350633814b7c6bbb78e962bd6d55f65670cabe112097846d3448717",
         "dweb:/ipfs/QmeMEjF9mGKpG9RS6qHCT3uugy55dh2jzox8MRkMPHqgx6"
       ]
     },
@@ -12638,7 +11661,6 @@
       "keccak256": "0x3c9cfccc78bf352f4c7901d7af76757bd228f93af2634af4cd16b4916c13e44e",
       "sha256": "0x09f6098026622c5c334c7798c3ad2b8f7c0ebc62f87846c7d5e7e725c3d1cbc2",
       "urls": [
-        "bzzr://ab23bd0e01952ee485f0426c9c4e47fcf6a508bc4919e83be31c0f9ea6e396ca",
         "dweb:/ipfs/QmRj2pxXxvmJ96i57maVjLMfs4DUtCuptM8vSVvvDweJ74"
       ]
     },
@@ -12651,7 +11673,6 @@
       "keccak256": "0x19fbeafba343a0018108c8af7247c564a48a39dce05c7c738687ef214c7e7063",
       "sha256": "0x8b472165ccf506fbec23fefaa1c28d0f905116e2d1074dd819b9281e6e747089",
       "urls": [
-        "bzzr://9b97d4999835e41a48be3bb162f0efc0f1351b0aed92f0394830e56a17c3fe5e",
         "dweb:/ipfs/QmUna9GdTDeyNpDFZ6uXWTAuWytNRvZ6VmqVzBhDHrPkGg"
       ]
     },
@@ -12664,7 +11685,6 @@
       "keccak256": "0xc5e366cf172df63ef1f1bff9fee60bafd0df8dcdb98bc6f2619b5a0fe917dda1",
       "sha256": "0x5fe06ed4be5137808ae29b260eeca7aa040f5f62db53ddd1767a79344c9c16a2",
       "urls": [
-        "bzzr://70cc4360f92c1909efcabda1308e2f74e43213b111d53730c458990c26940fc2",
         "dweb:/ipfs/QmdyLgJ4C7mwsRV1RWBaHFCdjjxaP6tZwGnL6oP2MFBPC4"
       ]
     },
@@ -12677,7 +11697,6 @@
       "keccak256": "0x5a1d324a51cafd54068de279afc7602684c53dbb6f726aa1f73721792531694d",
       "sha256": "0xa9f53b38b7ad77c5bf287e35b9e49f7e60f0ba6e524941aec9b7aaf78f5d3b19",
       "urls": [
-        "bzzr://9d20a584a3787b6d8ae1d7537aaecfc048bb01f8a47b6b898be01b93d79a098f",
         "dweb:/ipfs/QmUYGDjfaJbFVwkoCdtCkfmYdf8KhoX11gjpAyGe63JDNm"
       ]
     },
@@ -12690,7 +11709,6 @@
       "keccak256": "0x120ee8a12f7d9ab285f9bf74915e3b28aef52714bdc02417b1794214bf3d6477",
       "sha256": "0xa0f956aed5c0023fd6a2efe12390f01294275135d40714c6efda3304f14fd836",
       "urls": [
-        "bzzr://55e8f3cd5449acd01944e2b95dd2c199aebfdcdc6fc15133f450e3b16b2d5217",
         "dweb:/ipfs/QmPmKCBz3Hw71DewzgkWjShnhboAPJ7y295rwDatwmYPbZ"
       ]
     },
@@ -12703,7 +11721,6 @@
       "keccak256": "0x792fd7829941a9ef6a5493cc41d3f76860be7ce66f59411d539f9f8f720c5012",
       "sha256": "0x3e1f45aa8dc0fa962e5f6f0017872eb441fc3dd0cda1e7c54317c75ed6d12113",
       "urls": [
-        "bzzr://9c7ac2507f78e06d9f54c0d464da8463320e251f2e86535dadcb74aa6d3a46a4",
         "dweb:/ipfs/QmZkDn2CN4SEPTbZCLCNDpSHRzEYPs24FJwtjuSgG1jzcM"
       ]
     },
@@ -12716,7 +11733,6 @@
       "keccak256": "0x7e11a240a01bcbe7b2bb3c6975a931969b935ea65438a22741d1f95818d8f481",
       "sha256": "0xbb3c611d4948527959b5d1352f504dd3cd5cf9c144e046b8cd670505ef81dc1a",
       "urls": [
-        "bzzr://fd635c6a895afa6f21615468150d020816f93892ef8a5d5f87abc8e96effda29",
         "dweb:/ipfs/QmQJzkojqkr6WqYvYFF6vKSSsaqKMwhBQEfMSKnkVU1yRE"
       ]
     },
@@ -12729,7 +11745,6 @@
       "keccak256": "0x1cde350fcc1893559355c23fccbfdb5c21810c05bcfb2581f1d8b87059b57504",
       "sha256": "0x4b2e7fad814ea17af6af2f727f28542daeb2863153d8c4c0a50bad842d45d883",
       "urls": [
-        "bzzr://68851f611407c0673efbbdea9fbde35601c5c34388308f10ecf0a46f4184ad64",
         "dweb:/ipfs/QmVURabrvsZUxYqa8FLgY4BjPJD7bEySrxhn8kZpg98yA7"
       ]
     },
@@ -12742,7 +11757,6 @@
       "keccak256": "0x64735da694a27ce3f3a3243e126748a4bb85a4eb4a12629dc24a1d707cf782b1",
       "sha256": "0xa6bd926a3a7dac9d636573896e5fc93f1fb35f7adc5577fe2e665f03bcd68883",
       "urls": [
-        "bzzr://d4cd436bb4de4402600c10392772f2ef646b0ba4d4ea0ad71fede17b5928fd1f",
         "dweb:/ipfs/QmYB1w9o2ULTeRB3SW8Dshbn79DYqqDGZ71SkYvisJpXT3"
       ]
     },
@@ -12755,7 +11769,6 @@
       "keccak256": "0x40c0d5ef3cec50a2a7a03ee5d706b773f3763adcdbd7a77b00fbed79e77f56f1",
       "sha256": "0x56aa67abf659221618b1b05b6f451c429a5d786006a9f01ce5d566bbfa8b49d6",
       "urls": [
-        "bzzr://ffe811967b00cba002c81d70f3d7ef5a1529edc86097a180cdfd660b2076c0af",
         "dweb:/ipfs/QmV4ktVa11PKpPvRPvYPoK5agXbNEXkmhFf3ufTC5LLfSH"
       ]
     },
@@ -12768,7 +11781,6 @@
       "keccak256": "0x7096b86953f032a2c9ecb96303234e25bf1e5c9dba3f7ee5936605b3068b6438",
       "sha256": "0xf95545cdc6b637911e9290b315367880d6ac456b03182d50e2038f522b382298",
       "urls": [
-        "bzzr://95ebd3e2bfb0e59aee833b4482dcf47d299b8a19fa2c6846754124adbc2b8d73",
         "dweb:/ipfs/QmQh5f3w9hmtXvFXqEMjW1ddiJHU1gN6gv57XedNJg7C9W"
       ]
     },
@@ -12781,7 +11793,6 @@
       "keccak256": "0x9d7f6c44a99f1a4807c81b1c75e672e9d8d1563d1975dc7b8a7165a56b2b0e4f",
       "sha256": "0xf5f7ac61c7e7239751578c815e023bc8a566ca7d1ac94f7457598a8afcebfc25",
       "urls": [
-        "bzzr://a42b252283c0275a162f2190db1d4ef0105a8a784d42500d6147a6239b94a8d2",
         "dweb:/ipfs/QmTKLZ2JJamMm61CnqPzhLnD1yJ2QNq7bhRMSRzuMmYX1e"
       ]
     },
@@ -12794,7 +11805,6 @@
       "keccak256": "0x857d67de4e34496949017f2b30c506ca890160dfd44ce0b25b0b32ee2a805d69",
       "sha256": "0x116b2291f3e84dda91f52fdff1641d57efae7f260830df5edad27cdcf0e64cd3",
       "urls": [
-        "bzzr://331ace49774b9a67eb4f4cf19fd966b86584d7c562fa0ff115182d3e5f937369",
         "dweb:/ipfs/QmQAjF9tnUzBkSyk5eufbL2ivq9ms6a5kbuPwfJLmLHfuW"
       ]
     },
@@ -12807,7 +11817,6 @@
       "keccak256": "0xd6360433fa58cd913cb3d3bb9e37d305289398acc338d6557a72fc2cc2ab7e34",
       "sha256": "0xfcd88194ea796a2ae0b1a9f8625c5ad9fb39931da150b843d5d4a55a6206d955",
       "urls": [
-        "bzzr://dd62fc029203a56873f475a8a812c935b602b0eb61df7926e6e681a9384acd23",
         "dweb:/ipfs/QmSfqCCzTCXtyX2FuBrDxBB4mZktAxgEhL6wQfaKjGBu2G"
       ]
     },
@@ -12820,7 +11829,6 @@
       "keccak256": "0x564eaa1bc426bd6fbd4a0d8b7d53d00ffb03efe6d221fb4aec2072ef2876e265",
       "sha256": "0x581082fb70f99f2277c8093220180aae83b59adc662a196b7a6b58dd37685463",
       "urls": [
-        "bzzr://ec7871163a6e7493cee89713ce708720a59d38031df71c4ae654371eaf41c7bf",
         "dweb:/ipfs/QmSxntRkfgDg1uMP6ewzCBWPuvXGimbiB8JfnTgfSqhfR7"
       ]
     },
@@ -12833,7 +11841,6 @@
       "keccak256": "0xfb65e186862d956a864ee54eb71715334891b30d913a8042af963e00b2e06a62",
       "sha256": "0xdec05c0dc0c04b7e003b881a010fec7f82af759eb19153073e4b48fd03faa3a7",
       "urls": [
-        "bzzr://4875df1d38ab410e050b4ecdb639fe4e18126d11f1b9049bdac2c3c4bb7ef1ca",
         "dweb:/ipfs/QmQgKXE7ZqmnpJHXgY5UT9qHRkyqjxD5Z6QT2MQKDUs2vz"
       ]
     },
@@ -12845,7 +11852,6 @@
       "keccak256": "0xb463b6a61fc027247655a32cbfd50bf543eafa3a6b42ceacdda7293e3ada8866",
       "sha256": "0xb795f1b20f065a0aee492c24071fc1efa1633c3caab77cff20278a9ae822f04e",
       "urls": [
-        "bzzr://c82fea785ae31fb4847f5640e6305edc05d1a5b0b47552f60325c25cce280f75",
         "dweb:/ipfs/QmShUrNZf1dZFjziorJYE8fMGNUSMFsbaR3ipSvsCMvExM"
       ]
     },
@@ -12858,7 +11864,6 @@
       "keccak256": "0x28da1c17071b4eac2a3a675223302bb774a9c2e0fe59ec2ce22c0efe38283e8c",
       "sha256": "0xfe62f4678724e283d433b85b3fd66c955a306903fbf25d8f7da436fd18ae657a",
       "urls": [
-        "bzzr://5b3cc8bde9102b0bf71a19c2c2aa83de80aa2934266f1ca07aebce65b7bb1168",
         "dweb:/ipfs/Qmd41FMuhDGBU6LDzcYJ9Z1pewh1MxnzX1qPNmEN5gH712"
       ]
     },
@@ -12871,7 +11876,6 @@
       "keccak256": "0x2eeaa9d4f332db4ac4340964adde23f1690248779369c5e6003ebd146c7d9c55",
       "sha256": "0xc85c124f8744caeb168fd0b7922745d0cedfa9f962fb7c3c3402fde0b644466c",
       "urls": [
-        "bzzr://4c4583422732f4a81b92811a38d9fa604809368a2bbad03609db12750ef11bb4",
         "dweb:/ipfs/QmaC2emJnoUijbdUAPwVndx9cehNpFPiTpyu5CzurTaoc2"
       ]
     },
@@ -12884,7 +11888,6 @@
       "keccak256": "0xcb21eb25cc01c9f3347981bd5dcc5d1118554ae1f050b37e3f3f0d4d4388e671",
       "sha256": "0x189bfabf4bc2588c6b505c121b0ca29b1d0516983e883d5eb9664aaad4c7749e",
       "urls": [
-        "bzzr://61bdc33a70d1b2bf8101a1beb2c945cb0a0716929ed6e9ccd5823e59052e9cc8",
         "dweb:/ipfs/QmXTKT89UFjG6arfDukVbR299JdXiE2kh1argi71Hx5btE"
       ]
     },
@@ -12897,7 +11900,6 @@
       "keccak256": "0x2b0d0a991a94b59ca18051cfdd74140f7536c274e79e76f032a69988aaaca7fc",
       "sha256": "0xc3f9e06e055a34ae5824852e6a9da02bcd8092607fd90b3630195719e8bfd5c3",
       "urls": [
-        "bzzr://27b3ef1bcd572e3f6d6149efa3ea616189c145f5a81bc1e292e6f353d1d96a1e",
         "dweb:/ipfs/QmNqdJTVTee554nthobhTPHJkfXgAz6gHn8pWXPvgNJvCr"
       ]
     },
@@ -12910,7 +11912,6 @@
       "keccak256": "0xf723bf586e943d5011d347e7369e0a90956e79e9d7f68ad097348a0d915dbb7c",
       "sha256": "0xfab017bed24278a847a6346e8498776f454a33bf34b65cb70f15e60a8cf1fe30",
       "urls": [
-        "bzzr://1b285970161ad94d74661021a74bad7ad0ace50d18b9f629f6cb5db3d19f2f36",
         "dweb:/ipfs/QmQCzX6Mruzj81kuha1N14g7NWm62UCrAbQZDwj67Btugb"
       ]
     },
@@ -12923,7 +11924,6 @@
       "keccak256": "0xa8dd43fbab06bc8d314d775e72297ebe8cf0a2c3f79ec03ee75dbde0129c4a1f",
       "sha256": "0x7ed6ba966f3dc18d195707b22e5d7f8fbbabf84750d2c1b1d66103e3c42d99ee",
       "urls": [
-        "bzzr://447739ce479133ae9adbe9bab111451d737bc5669aacb58ae139e73e6eea6bef",
         "dweb:/ipfs/QmaHokAfVMyzuhb73yKG32mfvjBV1tCeHhNTmz73QQSiQr"
       ]
     },
@@ -12936,7 +11936,6 @@
       "keccak256": "0xf09d30abaa34a5b5740e0035bf211e7509297713dc95f3b4fc9af8d9c8727d8c",
       "sha256": "0x80d26ab5c7850369f92f8b5685099c9a07176f134c701b8c31ee547d40c339fa",
       "urls": [
-        "bzzr://7bb9fd69bbf0c27793d5d9c2b48b4a3d028bb7df30fcaa63e015154b562f21c5",
         "dweb:/ipfs/QmbwGo7gditFqwsybPN5HCLUUMCWbjNGtCuVVsVnEzXbhN"
       ]
     },
@@ -12949,7 +11948,6 @@
       "keccak256": "0x891a2cfb76256a3d06f10f42d4e5eef7481092425ee8c91c6a55129d5986ecb2",
       "sha256": "0xfb5c95864c722210319db4e2f63f860e187bc4be4f5869fd56dd3c330945ea82",
       "urls": [
-        "bzzr://dda1b5759181aeb7b1afbbee4d8f4192d3dce322b67ec717699ce8faef989ade",
         "dweb:/ipfs/QmSvaeeRPsrw7n7nDCzWxf5BzRyysowVj8jUQx2CWxMHZ3"
       ]
     },
@@ -12962,7 +11960,6 @@
       "keccak256": "0x9aab2d12b8311829476e08cca4c7111bac97cc79168541895b5f18dc1fcb21b4",
       "sha256": "0x0866809f8f6d7098b12bc698e0b8b4395dbcf48416124b655521991d1b0aa375",
       "urls": [
-        "bzzr://4a4b8c6b21aed96964ef91a687697ba71b6142934595e35024ba3e43037bce2c",
         "dweb:/ipfs/QmUEZP24e8Frs8tkFyZGempyrtpXHHwiPAduksyw6gSv8R"
       ]
     },
@@ -12974,7 +11971,6 @@
       "keccak256": "0x537cefc0579dd9631ec952cae951b3df0a50a3e557b5638107a67275f7aacc07",
       "sha256": "0x3e8b01cbd194e40971b41017ada7c8b2fa941b0458cb701bdfb6a82257ca971b",
       "urls": [
-        "bzzr://130bff47eed9546c6a4d019c6281896186cf2368b766b16bc49b3d489b6cdb92",
         "dweb:/ipfs/Qmdq9AfwdmKfEGP8u7H9E4VYrKLVinRZPZD1EWRnXSn1oe"
       ]
     },
@@ -12987,7 +11983,6 @@
       "keccak256": "0x804042004c0ce1cea569cef85c2b99afbdc996e40bc348cfce181a274da15405",
       "sha256": "0x2430f6ed8973a704c3373346c1c6ab47799de0a9915b5e23593af2d2a1fa634c",
       "urls": [
-        "bzzr://31f9d5d199c3896d1ae1c1cced515edf80eb0a4d6f19af0e3762024d3f25a0aa",
         "dweb:/ipfs/QmYtz4TqKgq1Jit17W4oRGXGrnGVJYT9UcfwQPKCnRSUkn"
       ]
     },
@@ -13000,7 +11995,6 @@
       "keccak256": "0x6ba0ff7e6d68922d78f08a26db768146b3e14c923c8a5a9d641ffe73a25e18c2",
       "sha256": "0xf79675e431e1b3671da540ffe916f44a54cc922f2d7fbf3252deef0e2dcb06a1",
       "urls": [
-        "bzzr://fa13db5f38913bee1475458757e651eeb701d3fc69bf6c4f050aa7527ae95901",
         "dweb:/ipfs/QmcsCimkhWnjYY1eT4TRy3gmzdEguyWtSBqNXLcxDLZVjp"
       ]
     },
@@ -13013,7 +12007,6 @@
       "keccak256": "0x4948204fab7559aad90e269b073f13a199a401ec9f7a3b213f6c493e30034a52",
       "sha256": "0xd4c1f75c1671a6ccf38728eaceec81c29be7816563b98037dd4ecb64288bf382",
       "urls": [
-        "bzzr://8f4e1b68422ebd17c2945e056f69cd78f024f7701c9e44ca482558c8ec1b90c7",
         "dweb:/ipfs/QmbVJevP91jbNRDttTsif7SWbAP6CEBJ6xPApsryi4YNd8"
       ]
     },
@@ -13026,7 +12019,6 @@
       "keccak256": "0x33f252725a15d4cc5e80f32c0080cb8b52c1ca97d38eccddbbb09410010a0843",
       "sha256": "0xacd80236906c00f514cab42fbf040f201d0ba5c7715a40e4a28b04a03b0f5878",
       "urls": [
-        "bzzr://e1a46adb108ebf6daab58b1166a85482bf6cfd654f8cb8fa01324401de05aea3",
         "dweb:/ipfs/QmbCpu7Dg3MyBnucfttcb9Cx48aSUzh3wa6zLDAJPmhpi9"
       ]
     },
@@ -13039,7 +12031,6 @@
       "keccak256": "0x90d01cd2ae8a7dd0d5ffc047dade64fc56945a40ad673efb3a17bd263d4e332a",
       "sha256": "0xfffcfb5bda410edcaeb4cf79f9f46ea20a786fe16959f7c26c2166c93eb55560",
       "urls": [
-        "bzzr://0898ecb36eecde721133ad3d0c6dfd54ef60a4c6045e5851e0b608045f2bf8a2",
         "dweb:/ipfs/QmVKsevG4R1vC6H6g4pbienE9746cRcKP9aoc9kUT4rUhb"
       ]
     },
@@ -13052,7 +12043,6 @@
       "keccak256": "0x437eac6576ae67297144418d2dd1fff8c9bbaef775a68ea8c87981dcffa7b582",
       "sha256": "0x6b47799d984e52ea761a0bf05fdc6ff38318be964fa36c36593c9405024a0cf4",
       "urls": [
-        "bzzr://990f8db990b963cc8d2e1da7886999fff34210e68de2210791cd35bc33772157",
         "dweb:/ipfs/QmVrhBEp8a1dHEXYyZLfwWoPBfJWo4HLE4YwpswUMXH233"
       ]
     },
@@ -13065,7 +12055,6 @@
       "keccak256": "0x74a5f64693db9aa2c8813478538da45dbd18e233682a0b7cb4ff94d000443a6a",
       "sha256": "0x3ec23d906929f50f76abf1c7453524c9dc628ad981c0a0eae14ee9b1c5df0388",
       "urls": [
-        "bzzr://6b9c3342058d91c60a9a36dfc950d19aa8ff9d3d0cb26a857b835871cee62d4f",
         "dweb:/ipfs/QmetxP9mrnDa17EV9Uu5K7LFSBqCaosRYHJBFei9vpBmgo"
       ]
     },
@@ -13077,7 +12066,6 @@
       "keccak256": "0xa2d4d3ebe5d52bfa7ddf1a1fcd9bfed81eaa8678e6a1dd5a1c84954dd064422c",
       "sha256": "0xf1724fd46b7a353561b3f8d473b0dc8c855b6d84b5af559d7e3326ac79b9d758",
       "urls": [
-        "bzzr://2c5fff6b816edb78adb2220f175591c9f4f6d38cfd27a83afb1849191cf9a524",
         "dweb:/ipfs/Qmad6iesaR5FQ45RRtMrt2Fa1EYDuq1oGoMJJB6beMHESn"
       ]
     },
@@ -13090,7 +12078,6 @@
       "keccak256": "0xa53ea08e9a1b79f882ede910c03c1b42add38ee50d0fe6bc41a1dff024dae4ec",
       "sha256": "0x1dc2a3f7ef51c8afa628ebf04c45e8ae44158c2a3bdffd88873c8ca69917fa0e",
       "urls": [
-        "bzzr://02392f4dd6861789472e900b1d2356f5274132d67e450b1ddcdeb43e9c4fecdb",
         "dweb:/ipfs/QmapDK9S5wDLF84s1CR6PescxU66mrVMN2QfUnbJ68tZwm"
       ]
     },
@@ -13103,7 +12090,6 @@
       "keccak256": "0xe96dc60bf822c66e051442e22c395bf73f32d1a70168f8410b0cd066b789c1f3",
       "sha256": "0xb64bc67a90bded4971dc2613adc0984f058a4352ecd838c87462348acabdc52a",
       "urls": [
-        "bzzr://3f859a7bd461e30fffa815260e41775a6346fe3781f1fbc2eb49fb86b45ada24",
         "dweb:/ipfs/QmXUKauuHC5UKgaW8aSRB7nr7nwU1ViqZNU9ZEkgvX2K4H"
       ]
     },
@@ -13116,7 +12102,6 @@
       "keccak256": "0x26fa8a1217515b97ce42e0d1d6aa48ba23fd6b4ae5577351b50a3bc99a85580d",
       "sha256": "0xab1c5dc641b09e561ff1845acf6ca61b363cb0dca9d5620d932bf194fe35652b",
       "urls": [
-        "bzzr://d616f978e8bb4d31b012ecc8c9a5657baaa5330594c81683f83f4a6ae1f8c76b",
         "dweb:/ipfs/QmZbuqdaeSF5VepivAStG2Q7ELaqCpCg8ZbV4HGSvieJGX"
       ]
     },
@@ -13129,7 +12114,6 @@
       "keccak256": "0x8a713ace2dc546b57fb40af4623df5afa47b91298cb679de3cb22f9741be167e",
       "sha256": "0x8e9b68f364ebf3c7ac07a6cfd633e1564f06c8135b8c423c2994e93761ace3cf",
       "urls": [
-        "bzzr://1ff0c522ca11ffccc62d1936e9b205fc8556db2334cf6dc30ef9f224baeade76",
         "dweb:/ipfs/QmSPhLznnjdZBwzK6uXDngQJj3rs9qZAspmDThdbSsJi8N"
       ]
     },
@@ -13142,7 +12126,6 @@
       "keccak256": "0xe180b286ea1a1788efcb8c4ced2e2c72e00bdc0c090dd205b4d39ae3a2c95fdc",
       "sha256": "0x7531dbf6c26abc25323bbadcf68503c631a486f48b7dc63cb815ab66aa37748a",
       "urls": [
-        "bzzr://00c1402c4dedbe200b967eb8262e1cb78cc87a3e57d49131b2f251e74e4e1d2d",
         "dweb:/ipfs/QmaDvEVrD74AFLAj3jnYZ4SRxLJHfrbh6s7jyPPf9su99k"
       ]
     },
@@ -13154,7 +12137,6 @@
       "keccak256": "0x620163da7ee7b2622c9ee48b06110a52739f633189555148a3b5ecf767e60cfb",
       "sha256": "0xfa27ce9d23bddaa76a4aefbafa48e48affde9a1ee7c8a5e8784cf8d4c390f655",
       "urls": [
-        "bzzr://823b4efe3ca2964d660348214fd1a44579e13e1e8ce69a81f447372a11d60316",
         "dweb:/ipfs/QmUinsRZvs2zFNG6FMWy7ngTYUnZccXq7MRtgpj1dPfxu4"
       ]
     },
@@ -13167,7 +12149,6 @@
       "keccak256": "0x37ea3a5577336cd30069896ed6eded08a7518aca9b299240bfd5a7bceef4511f",
       "sha256": "0x9674b6ae7b90840178a36d965b91b877bb01d37bfa54428f1e5f1b8ef666f54b",
       "urls": [
-        "bzzr://042d845611822ef27c4e0cad0e2db619a62ea8834f30f6a1f370547cb2c4d8c6",
         "dweb:/ipfs/QmR2KRdx59jNsKC3tMminGi8kvdH258jeZu5r1ayUWvdUK"
       ]
     },
@@ -13179,7 +12160,6 @@
       "keccak256": "0xf0abd02c495a0b4c5c9a7ff20de8b932e11fc3066d0b754422035ecd96fcdbbc",
       "sha256": "0x9778e4a7667d5fd7632caf3ef3791d390a7cc217f94f96e919a31e3be332386a",
       "urls": [
-        "bzzr://9f9244a3605543a67f5ff35f21e3d6d3331a6e1361f09b271c37f396b5b89bd5",
         "dweb:/ipfs/QmXyjgFNMyFD4fdf8wt9uvUU92MGdDVGmcPdMZhNEo1g8N"
       ]
     },
@@ -13191,7 +12171,6 @@
       "keccak256": "0xe1412d909a0dae79b13c0066b9bf08831c522daec00b273bbc19a799af213d6a",
       "sha256": "0x3e1956c550ca48e289044c7c0bd892403081b4b5e17e77ce707c815ce6c4228f",
       "urls": [
-        "bzzr://b69ab6704a1e42fddb326e91f331e35fdf071b158e8754e2c887c0e607aee7b0",
         "dweb:/ipfs/QmTs8PnAGr1ijXtWvMjoWraefAtVv2Y5ZnwkArz6NqJ93w"
       ]
     },
@@ -13204,7 +12183,6 @@
       "keccak256": "0x3c9c3a45affee25485ee0fa6f934f189e1371bb7a2079bea98bf384f0cce0fc0",
       "sha256": "0xb9f9ca117a864f1e29bbefbf026feedd3a62566870a2830cd883264bae65552a",
       "urls": [
-        "bzzr://4f044405dff2a32ba43dd0a7143fa18388767362dda426d3138a84a6a7796808",
         "dweb:/ipfs/QmUrGLtKDizTRHaxgVouXpTehVK3qaymoAxdK7FESVogab"
       ]
     },
@@ -13217,7 +12195,6 @@
       "keccak256": "0xf987a5bd91b12d6c28aad40e4882e8558f00ea10c210431b659d3628fa183677",
       "sha256": "0xae646e07b0dea94b1914240b12c8852ac6a98846a1b6f03dc45134091d16ad69",
       "urls": [
-        "bzzr://f3820a973c660fdbfb3f9de8154b8a66ec5a145bd852bb8a0f7bde3f8817f5d0",
         "dweb:/ipfs/QmPz7zHS41FUaFEGD68thucuyqBbrWPwmUakD8NV4HBwZ4"
       ]
     },
@@ -13229,7 +12206,6 @@
       "keccak256": "0x0c7a4386781683c327fde95363535f377941e14feffad5bb1134c7aa7eba726f",
       "sha256": "0xe7e1be3d0a67469f6a37cd676a22314c4faa8a22ff9d5ebde11302db754453eb",
       "urls": [
-        "bzzr://65dc33e3d9ef94defff1b24e66f093d9d15a92c59778c8eb26e76fd8b64bd3da",
         "dweb:/ipfs/QmQFhTptWdDzhemjGpa7Q65HKWGphs4nKKS13nzkcVE8pM"
       ]
     },
@@ -13242,7 +12218,6 @@
       "keccak256": "0xf9ab4fe6129787eb18f21e50572da1f357501bfbd19ad20de83a009482468d56",
       "sha256": "0x6219e701b1e19ef08fbb3910e6ec5662e3f51924fea2036ec614f8b9a7a939d8",
       "urls": [
-        "bzzr://b24a2b37d4394f858e20fd6a16195f8e0a3a5bfaee1455cd838e178ff2540e3a",
         "dweb:/ipfs/QmNaj3e7pPGbJfyC6D4FjAJXH23GTkiH1WW5pPgHhXusDg"
       ]
     },
@@ -13255,7 +12230,6 @@
       "keccak256": "0x324b9cbc170664663f3ce3b1563dd72d121b2032c1187994c1f573b0001e9f05",
       "sha256": "0x37cd5e04ea4903993e7de129da3b9b523f138bd9c0b5307d165c53150847a3d0",
       "urls": [
-        "bzzr://2df7a5c09780289d3e4526942912d780ad9883e4973737600028c74d249f3d4a",
         "dweb:/ipfs/QmZRzKvdmcb473cSM3wdHc4YKZcZXz8kBzxGSGpNFfVuYq"
       ]
     },
@@ -13268,7 +12242,6 @@
       "keccak256": "0xc8ccfdc70765813d4529ec040ed68264d95412d65e56dc1be9c5e66a255fad77",
       "sha256": "0x9ed25de5b364fb07a7574703c10eb7eaa2f752ab9c6e75c7cb9d9397d2b6b341",
       "urls": [
-        "bzzr://c591fad5cb0141e9f18dcb4b608e663657cd0964dd7a1781ad8579b7df17b35c",
         "dweb:/ipfs/Qma61T26h4xYYvMK9YznTZvNrYwWt8f8VSiy4VPD7k7gtj"
       ]
     },
@@ -13281,7 +12254,6 @@
       "keccak256": "0x46ca049e2f5eab68a574a8ad8dde950e81b5fc1628b37ba7372a64070cfd3f16",
       "sha256": "0xc70856fcf2df2dc8e18d9f9b1af9879a9fafdcbb8c3483ff6bf080787678d402",
       "urls": [
-        "bzzr://804bc3cbd19477fbad334749c85927158911380ed8616e2d6055b55186308bc1",
         "dweb:/ipfs/Qmanaa4K5B56yFK6brzQwMysKjHriEZnE7dUYGjtD6n8zo"
       ]
     },
@@ -13294,7 +12266,6 @@
       "keccak256": "0x8abc64dd0e097c48411c46e77bd067aa0d8ad907690b57122f9bad4f3bba5e2d",
       "sha256": "0x5486ea871fe52ae68ad1090b87fd5033b73c2bceb6e94c1bad75bc47811fbfa7",
       "urls": [
-        "bzzr://d63ab40ca6913f9d3abf6b57de561da5939982bf1e4bf4540bf063803fc15967",
         "dweb:/ipfs/QmNR4nMk8yfKU1GLLroijpqdJD4VDvQUYri2B8J1tM6J1S"
       ]
     },
@@ -13307,7 +12278,6 @@
       "keccak256": "0x6a3c4df84e363232e65da0809408705579ef9f5bb63a96cdd65c26ddd1423780",
       "sha256": "0xde212e2bb2dacb24493928b86f58d193477f90c2f4435f8b39029c446c42359c",
       "urls": [
-        "bzzr://491b314b689fd643289293a9d1c1dbe48e1d8e43dc737f856f77473ad8d1657b",
         "dweb:/ipfs/QmP5G5cUHWMfHi5tEYX2bw3AycDEndqkppttej157srSww"
       ]
     },
@@ -13320,7 +12290,6 @@
       "keccak256": "0x97a3d6d42ef831aaa2956dd03fa95747933cf67acfddaa1c4529161a87e5145e",
       "sha256": "0x0704d59afdf8bf87e2273d14ce26b7121081550a05bd295835312866059f34a2",
       "urls": [
-        "bzzr://aadc43a59e9e73776c803f94d19987d40db187838d0c1fd4e1a9c28245360c0c",
         "dweb:/ipfs/QmRKqyvUQpH5ZxDbbjAjRAhU5fwZpXXmAduk7RYJv6C3n7"
       ]
     },
@@ -13333,7 +12302,6 @@
       "keccak256": "0xf8f736503c4e028878357c6263d484c7eed950f77e4196327782bf928a8db212",
       "sha256": "0x9996bccbcff7d7417799f4d8446af53681f5dcf24d6087f1d222f7a684ea96cf",
       "urls": [
-        "bzzr://b6d894ae2c51f85c957eef5c91d9a9f0674e6c39be5567cd1fd5a1a265bfb3ad",
         "dweb:/ipfs/QmSo47FpxGEYw8nZ1U4HzqxS1FEWbBqh1beNWzmTVzcif9"
       ]
     },
@@ -13346,7 +12314,6 @@
       "keccak256": "0x1fbca8a08782d9186e94583b1bad77f55110189ebad02ba21f5b9ffa36f72251",
       "sha256": "0x52c3cc695ee7aa7e838e7455364c04b4c0c728282e2d1b395528b2f5f8bd460d",
       "urls": [
-        "bzzr://f869d6fba77ea34d61988aafb3d5364e1f2a5b548b43445404103f0bc43b2b04",
         "dweb:/ipfs/QmXR4dWuWxm9x5Qng7iqWnfoZRDijkMZHbjy1KuMbwAYUR"
       ]
     },
@@ -13359,7 +12326,6 @@
       "keccak256": "0x7d4e9a984384852b1b2dabf91db7140d20bce7a316f8ba2320ee3391be1af38d",
       "sha256": "0x546bed241df35cb60a8bfac6ba02ea98686396c72e645cc6019bb743813ae76c",
       "urls": [
-        "bzzr://0620427034eec8faee39814f1701502d8f0d3c4e560824eeb0f41e9fedc6beb0",
         "dweb:/ipfs/QmU1bPoQQJSn5h9hrLFQ4T6pvKWveFWbFRwVKbUiRaTsQf"
       ]
     },
@@ -13372,7 +12338,6 @@
       "keccak256": "0x8bd6fafd2e5784b51b0d2db62fc8f1cda3f0ec87b91886130d06843340e7cec3",
       "sha256": "0xfe77719e10b907fa37dc0e7606a0dc4c114e60d0e053e7f147c80e4a21d640b0",
       "urls": [
-        "bzzr://8a2d67e5aec0c657be72e13d5d2134a15f0f8341074b85cf1d1bdf591beb237c",
         "dweb:/ipfs/Qmbp4tDiGSxy3MsTukhZ4BVdnjRNKLh6Rnv1SaQ6jiquqd"
       ]
     },
@@ -13385,7 +12350,6 @@
       "keccak256": "0x201daecec203c98d3ee6741508fcf62d5c36e689c7a45a362515a94182a765e8",
       "sha256": "0x25c8afe8a8851209646a0032314405a83cf96a7f83f6c18572cfdf96a4d864ca",
       "urls": [
-        "bzzr://f92451849a05df3bca4432ba2ecfd073679c981038f44d1b1ac064e3260ebf5b",
         "dweb:/ipfs/QmeViV9X8ai5xaX1XTzmxLGaWkXqbUA7BSsJoU8gFhkofd"
       ]
     },
@@ -13398,7 +12362,6 @@
       "keccak256": "0xaf535ffe9ab573245cc868005ad09c606d149a2f083a3cebdceeb30c2809c686",
       "sha256": "0x26ac73a9cce65e885c60c4384a7431c1de2db667dd7158a6129870ec455c42f5",
       "urls": [
-        "bzzr://e34a3c29ce1ec28361ab7e1388021b9191a1248cb05c30aca1e62a28b7ddc96c",
         "dweb:/ipfs/QmQVZ1v4pe5eA6Rx2D7AoS7nDfNzRmoyCgcqpukpYQms6D"
       ]
     },
@@ -13411,7 +12374,6 @@
       "keccak256": "0x7d3392b0150149eab7fdfef957359c7420a47fe65d58a9dcd773460daa0b6310",
       "sha256": "0x08e4672cd8797727ffd8e963eeaf53022534c5e806d25343c82b53e584f8e97e",
       "urls": [
-        "bzzr://fc38d11bcd365bf8ec87a20afe0413ac1229342b25331343f171c810da17c918",
         "dweb:/ipfs/QmWbDu7RLzguLWV5xws1GdcsgMdaPyetBGU1ohP22bnmfP"
       ]
     },
@@ -13424,7 +12386,6 @@
       "keccak256": "0x78594ba9226aa12aca810447977a7b6698de0c28b7d7fc6a3afc4516edaf6899",
       "sha256": "0xffe17201e76eb17e75e3a7dc7b51ce9846c562227f9f171d8ba4a63a36956f88",
       "urls": [
-        "bzzr://47fcdec0fb43b091c56c7992eccd89a45d58eccfda5a87668e084f20086074de",
         "dweb:/ipfs/QmUnju4dEW5V3ubk5Mn9rfxv3dM68WNdZs3BN4aPwhxLyo"
       ]
     },
@@ -13437,7 +12398,6 @@
       "keccak256": "0x8cec61d7914934517ba3e5c510c7d699ab498b7c42903b62aaca479833e51f04",
       "sha256": "0x0d2eb045800fd28ebf6109df6df24ca871460cabd6e1026ffcdbf84693de74ca",
       "urls": [
-        "bzzr://0180769413effd27ef4bf372a3c149f771f25f20329abb29548181d4cd8fbc35",
         "dweb:/ipfs/QmVt7FAK1Bhfuq82bVRNfBzEvRTqaHwFcsmeQQnW8ayr9y"
       ]
     },
@@ -13450,7 +12410,6 @@
       "keccak256": "0xd032339255b1c3b2f201719a09d216ac15b56889e58fa85e022cccdc52664c42",
       "sha256": "0xc20b7b86d775efb6f4defba159582f9432dc27bcaf7a24c590cc569b90918412",
       "urls": [
-        "bzzr://61a86d6ebba3d7792a07798de02a6273186f200f3a0a0c4f451fec29ca1ae96b",
         "dweb:/ipfs/QmUMshUy5N26gELJGhC2sKbaPN2tZf687acXJPQCSGVLwj"
       ]
     },
@@ -13463,7 +12422,6 @@
       "keccak256": "0xa46d8f60723e9466aeea5dd24520384bc3b8fa5dcccc6d167a2d249d05dacd14",
       "sha256": "0xca9a9266d5cc00de0b7c60090cdb17bf88aedfaa916b1dd33752b1d073b4f2e6",
       "urls": [
-        "bzzr://1b71ef5cfc04ecf0f387e80c7092971bf4f9634e1300bbbfe270265053b3b0a4",
         "dweb:/ipfs/Qmf5ThRPKYjmHaogW66GrPsuyT6J3qtzYL9m81ZuUQMhwG"
       ]
     },
@@ -13476,7 +12434,6 @@
       "keccak256": "0xb46d32d9197b5485bfa17755431c11692f86c82089b20736bb3f4bdf80c29654",
       "sha256": "0x18b9ed2ecce431e4b94e5717254decaffdcc15a16f8007af808e4a84003d129a",
       "urls": [
-        "bzzr://18a58ac454e5ac7f4af12a2ca377bf946fb02173bf612840eb4fd59c137cdb62",
         "dweb:/ipfs/QmdzmZwKb71TWcr4YqvYHXMiNKU8WVfB9A84g5V25pTCaT"
       ]
     },
@@ -13489,7 +12446,6 @@
       "keccak256": "0xdcc952ba09667b48f73289849fe529490848048124554691a56340566cbcf779",
       "sha256": "0x9ef78b8429cc82449c067ab3ca1241f5f1883c28a7ced25a57f8305576dafe36",
       "urls": [
-        "bzzr://77e24fc9748ae3e636d91f28caa8b6dc44520eee26c7cc0a7a52990ce5f01dc4",
         "dweb:/ipfs/QmbAFzcxMohqn6iYmUt7drgTuqLiRZbYkQSaKdF2t53XAx"
       ]
     },
@@ -13502,7 +12458,6 @@
       "keccak256": "0x12e2872c83af3f0ac9986b66982872469336066dca6b3279e86d11d5d91c8a9f",
       "sha256": "0xa463ae7b643df8ca1666c974e26233ad86b5dce306ba663760c336811dcd3981",
       "urls": [
-        "bzzr://c47937d3c93104c07e05e0f479210b1cdc6f2c1c62bbddaa780cfa788c0ad67e",
         "dweb:/ipfs/QmUT3s32iNtQorW3QAb1twSbPv4BxMKZmoEB1K52Fzsd5j"
       ]
     },
@@ -13515,7 +12470,6 @@
       "keccak256": "0x727b5f3c92bd87fb5a75c59a219e26f8cc76ce89aa9093b4e22110e2852be8fa",
       "sha256": "0x046d6dc40ba854dbb4d00cbeaf32e2b4ea8e1619fc92e50b8c7e5e731b8e2249",
       "urls": [
-        "bzzr://28e0d3e96c7b1e6c242f457e7f791515c0d3e81e183d65fdf6d102baa89561f5",
         "dweb:/ipfs/QmZrWriJ56MmSsvgiSe9hgXkKtk1vtmurmianF846Y4ed4"
       ]
     },
@@ -13528,7 +12482,6 @@
       "keccak256": "0x142a4da49fdef6ff4c2357c8c3ac103b9caaac81d88cbf571a44d2f287fb7c68",
       "sha256": "0x48f0ae898f1669bc040c36f2ef34361b8c2f92da3d6becdb324201ecdef9b253",
       "urls": [
-        "bzzr://ae18497cd5cf54bb046f430d52c331727ec9a02ee479e8aa2856ccc3d88600ad",
         "dweb:/ipfs/QmZWmgRjqFnU6jRAUCfZjYA9aCWbYFfThNdwQNuvU5YQNx"
       ]
     },
@@ -13541,7 +12494,6 @@
       "keccak256": "0x8bc6e08d958e7b7d3416951717735e7c3ace873eee632bff9213bca24ff6c9f8",
       "sha256": "0x38cdca0e2070afea095ff1d1d22f6d988eb7bf5fd72994df58e3aba7db0f3aef",
       "urls": [
-        "bzzr://37c9986253a0454c1ba2389f48e42d2484e767bade699e0f5f489cfdf2102d5f",
         "dweb:/ipfs/QmaJYvbUvTUV5MZuJkgXZLb66HQgRePKeYbAWtAzkHDeoD"
       ]
     },
@@ -13553,7 +12505,6 @@
       "keccak256": "0x3502cf7933fbce9f1fe1d87a83d5b9df12eee36c03997c3b9821493ce03fcf3e",
       "sha256": "0x7fcc983c5149840a47b946fc51fc14f1c21cda07c01d650e4a1f814319cb1423",
       "urls": [
-        "bzzr://617dff84fd7dc06b476f93a95c015a561662d9ff1d3356ac6a3e5f5b09a636f0",
         "dweb:/ipfs/Qmdw9c3usmqgdV2w4JoNWJqscHzscKNVWsWtos1engJa1o"
       ]
     },
@@ -13566,7 +12517,6 @@
       "keccak256": "0x3cbc03a5d1ac2c0b567a83a98b464cf87c49664aadd46aa8138fc54fa09d7233",
       "sha256": "0x14a0d50b054bbf0e651e56e5c437d01ac0e8b69db8e8ec01fcd3f6af5e2f6d15",
       "urls": [
-        "bzzr://cd4d17e1d3450ddd1324d3f4f35ffc9df052a322f737ba9f86d3d7ae76d451f3",
         "dweb:/ipfs/QmX4tqJJuRA6prb8EkYf9s5AoxR2GsCmbTYdyugESjLyXu"
       ]
     },
@@ -13579,7 +12529,6 @@
       "keccak256": "0x3329cb5c92faaee0bcaf606c676075945f2514a4c89d8390625a126fd59a9ba3",
       "sha256": "0x4efc72c6f9d1ae952b5289c3855d33bc30ee5f5b1af74530451052fc72b811af",
       "urls": [
-        "bzzr://583bbc172b5feebc0796105cb126d35783ed886fb7441584157c3200580815b7",
         "dweb:/ipfs/QmVzLmJHUdvRckHcRPfEuB7MqqaFtbWWjFwEyeXxbossqT"
       ]
     },
@@ -13592,7 +12541,6 @@
       "keccak256": "0x7a0c6265c30cead2e83b59c363f7a8d9f0d2c94350571d809824f0cd916d496c",
       "sha256": "0x4db55f8de38ed7f19d0efeacd615c51776e9cf7e51486496cb79d9b1510dbb89",
       "urls": [
-        "bzzr://d23dc588f1e87b5453df8384c30ca23ca8dddfe87fd0dcb4cc57f74c233b824f",
         "dweb:/ipfs/QmR8FZJ2WvN1WUCAFpySTcKiWniZNodWaY4y4habT7TNjb"
       ]
     },
@@ -13605,7 +12553,6 @@
       "keccak256": "0xdd97a8180ddf18afd2f41c72bc2d7f436bdc250d0e7c1790502be7d3b3b865bc",
       "sha256": "0x69e6d8acc289f19b5d42e6082645da660e7fd2f3126297ba44caf96b0a3127e6",
       "urls": [
-        "bzzr://29d98aa0eeaaf0efe948cd798c9a9b8934c22b22e2d95a3bb9be20e8f383e6bb",
         "dweb:/ipfs/QmWUMQBp23aSVHmMu9GfW3G83kEhiUDserzeoJryvq3GuA"
       ]
     },
@@ -13618,7 +12565,6 @@
       "keccak256": "0xe3324f9e8fa06d864611cd58014d188c8f02659e6f250d0286ab7ed30c9b74c1",
       "sha256": "0x4c35c97d406e16a0b056965f7ff9ad847a8c8069b08f84234031517d7efb3a72",
       "urls": [
-        "bzzr://7751238ecc5bc6126aab76a1bd94b751c77bc95b6a8cb5d4bcc3ba4a8c60a250",
         "dweb:/ipfs/QmequcBcpvZUvWKZgvhtMTj4JGywsWYjZL5gVvyb2jzWXz"
       ]
     },
@@ -13631,7 +12577,6 @@
       "keccak256": "0x11c97b23695232a1fea49b5f1d7124fcbfa99168ae09170dc85ce77e943ed7f5",
       "sha256": "0xdd4b04ea5cbf09eff105de45c0e6a5ab83fca7a94eb09814686c52d3ffbed6d6",
       "urls": [
-        "bzzr://a02b9cf5f7c20d2334064a9eefe76010892798df3a0e35381ba983fda3fb389d",
         "dweb:/ipfs/QmYkddu6NiSrkH8QdSnt3hxVgiJVSTc4EPBvmZ8mXe6PGM"
       ]
     },
@@ -13644,7 +12589,6 @@
       "keccak256": "0x5833a1bba2977e2141a332655357a7a2972a8925769ae69ae3a6946f525265fb",
       "sha256": "0x5cf495b42e8640df6246b361d6f1b191ccc60ea0040cb9d18d00b56963eb3f18",
       "urls": [
-        "bzzr://b12c9a44abf9dd3a4211b08a66272e9d1bb5dd9d41b8a4c91cdac72c9d06bcfc",
         "dweb:/ipfs/QmSu3fzZR1WHED1eET8CRpP8gZrTGuvjkr7RVrgbeNws7J"
       ]
     },
@@ -13657,7 +12601,6 @@
       "keccak256": "0xdb646e60d44981d8fe1347f3ad78d6e5110aa1ce13e56158b89e232290c02f46",
       "sha256": "0x3c5d2ad865d32584c9f3e1cbf13927fef77f8b9b7893da652014a14120f5805e",
       "urls": [
-        "bzzr://62ac97f5f6189f067260b03ddde412b088f12a5f50294f7e418242b0c84913c8",
         "dweb:/ipfs/QmUeycd6R9deuSPPeVWVYJAGe2x5DJe6Lc8UAKHvnmCcaU"
       ]
     },
@@ -13670,7 +12613,6 @@
       "keccak256": "0x95959ea15b358f8ab4f654d172ee03ba1aeef3fda6c8546795d16ca0cb148113",
       "sha256": "0xa6f232dc16248d1708cd824f53e7defcd55e98f8a4fd1498770257fd4b07129d",
       "urls": [
-        "bzzr://13fbfe4a3eaf45c4852234cda1ada87988a2234c8e435d91032d2549e8707757",
         "dweb:/ipfs/QmRDQAudHkTC1E7pFJEwWM4MhkSNsAD8FA2dTkDo9E8aHj"
       ]
     },
@@ -13683,7 +12625,6 @@
       "keccak256": "0x83f2c1dca5fa1246568140732e17c547333212b9ba3ae51ff34f74a7ea1ab533",
       "sha256": "0x5f2673e6de393e8eba1ba6699796b4b09cbf6a23f3355174d81e7926b00d97d3",
       "urls": [
-        "bzzr://0793a205a2f46d14e2fc2fd8320f2c5dfb769ac8fb30d083c1768b223ca0ff52",
         "dweb:/ipfs/QmYSvSRmxBGUh832ZgKnBYNmoETTEdjmr2pgRkPNFeX6FR"
       ]
     },
@@ -13696,7 +12637,6 @@
       "keccak256": "0x709eb2ce61e0f965b63b6b90d28e3b076ae98fd8d0d6bcfa52eeba5c63d24ae8",
       "sha256": "0x432659baba2707aae32c51c151270a40e9a0e008cac3d85cf63b0ca928d38abf",
       "urls": [
-        "bzzr://69688a48272bb82277e18fc3ed34af87ff7889d31ed1e05381d776570992f94b",
         "dweb:/ipfs/QmaXiopa7bHTjdiCMJCDLDAYEcHaKSVa4VYwLoKQdCYsXs"
       ]
     },
@@ -13709,7 +12649,6 @@
       "keccak256": "0x705bec6e6b1c2a03ccf3a5121cc0e640e153c2fdc37ce8707932b34927f0d7bd",
       "sha256": "0x766693dec8f9421bd58b674734a1e8d9a1ee1d21462c9c09d23a0b87a5e91e26",
       "urls": [
-        "bzzr://f1f0cec3473323958b0e4578f342681664761fefbf5ef05cdf20308df4baf4d7",
         "dweb:/ipfs/Qmbq65YCcc6U85dJY9BJW3uMzS89gUNNNh5RN37R6keYBA"
       ]
     },
@@ -13722,7 +12661,6 @@
       "keccak256": "0xdaf4d02428bc404e278a4993ddb24509f42e9dc849b77fa8e73c498ed0c40875",
       "sha256": "0xf57009bd32470a7ec4210522bbbba5921f0f0cc5194d4a9670e78dbc53110185",
       "urls": [
-        "bzzr://eb6a883754be00ac7ea59817213eb267935747de3c6ca43c42d3657e63d16e8c",
         "dweb:/ipfs/QmRXa3YQvfQTHSUQENDMMqjhWxZPG5eDq7bLvMWQ4BzJpc"
       ]
     },
@@ -13735,7 +12673,6 @@
       "keccak256": "0x58cb4dd3ca469ee572718ca97a68a402d62b4c09ebb3683f3cbe64ef253401d9",
       "sha256": "0xb4458e525bfca49b457535cefab70b5128edd6878927f94c2886114a0b5f27b1",
       "urls": [
-        "bzzr://ae7c6602c0e25ad61320fa0e1373a903012af4645504c2f68ba6e3bafd3aae3b",
         "dweb:/ipfs/Qmb8maSPCMVgucpJfoP68JzKuAC6Hw5iqVYGLy8rEJydAR"
       ]
     },
@@ -13748,7 +12685,6 @@
       "keccak256": "0x21827d07e58cf58ecc274942b4548262a4ed82bf9fa0ede241c81b0846eab5d1",
       "sha256": "0x37a65b9b03171bd544138fbda6d9be2824868342049697e50c314927d1ae6af0",
       "urls": [
-        "bzzr://30a50405bf6d4103d077bf015bf05b85b9427d67587be8abc42e959546aa0df7",
         "dweb:/ipfs/QmPoWyj14JcWcLxmmS8VvLWbxtrZKts8AMJoE8gSWES1bp"
       ]
     },
@@ -13761,7 +12697,6 @@
       "keccak256": "0x0e1248a203cb9bd968a8a9edf1a9e1e3960d0c6db752942dfcbf0ee6c496ec6f",
       "sha256": "0x0825d333e0842a125f73e39ba07d89ed58d36137e76dba27fdb3012252946563",
       "urls": [
-        "bzzr://19be93bbb631b596cdb62d2ec4eaf28407d5521be3e14132dc6e72815662b6bb",
         "dweb:/ipfs/QmXesvLrDr94bLX27M12ohSpJSCkTnX78fKTdgBgJEPjAp"
       ]
     },
@@ -13773,7 +12708,6 @@
       "keccak256": "0x0c80a0bf9e17700249a04a80d7729ccb012a55a82cb0f9e412fa32cc14b09c2b",
       "sha256": "0xdfa3f2bb4589bdc9c054292173c82ee70e65af8d1971598f6e13b9b79ba94185",
       "urls": [
-        "bzzr://a45264806fb74fd38c19704070c83053972270b63bf7b09ddff3c3e15cd1baa0",
         "dweb:/ipfs/QmTNWY4vkVLgtNdfGXyH6CY8URmzr33VzMJNN37z5dsAgu"
       ]
     },
@@ -13786,7 +12720,6 @@
       "keccak256": "0xd5cc4fba7ac0b97bc4b6b525eee1ab7f76cfe6a962b659f0b5e9f4bdf5354c65",
       "sha256": "0xb8d9128ddd754fb1316ca13d9a1715b1a82f9e94e77f32092e9ede22df0f2455",
       "urls": [
-        "bzzr://b27d59e13a706cda50dff3b5f2fec81a2ba0fe730987cf0c3f7b7522ef6d1afe",
         "dweb:/ipfs/QmZvsnwKHSFe9WuAPKLh9bYwBKgfZ1g8xsfqhEu4owm5Gx"
       ]
     },
@@ -13799,7 +12732,6 @@
       "keccak256": "0x4ecc291d6a0ac3fddf0882b67cf6f9d62ce296007c273bbd8ab709545c40e06c",
       "sha256": "0x1300e2dfc49ecee6c9f3de36a2aa2dc940b154e6cf54244104cdd1c6e6194bbb",
       "urls": [
-        "bzzr://4661ced8ce0df00461765e6e1930743f77b2d058de5df1a05e0cd792b56c05d9",
         "dweb:/ipfs/QmaeU74X6nMgy1LBNv1KLNrJpZPeR1PkvpRjZiMSndYVSK"
       ]
     },
@@ -13812,7 +12744,6 @@
       "keccak256": "0x3b72d54b6af0fb49ecaff56e465f0421f2a4c648c58920d8a75bfd7fee748225",
       "sha256": "0x5affeb4c018d99bb176d398706f3496e191f806272dedbbbbc83b6466d5d0080",
       "urls": [
-        "bzzr://6712bc949619d81962c074c26e3a63ae2864602f03b78c624498c50c67a515e3",
         "dweb:/ipfs/QmXjsuAATrJSNbFwVHsiPTHg3qxrUYJRVaMn1RaMAHfMuE"
       ]
     },
@@ -13825,7 +12756,6 @@
       "keccak256": "0xf1b0c62cdc7e96a22d5dcf5966b16bc5b0dcefaa6ce9e8a0628523ba6939185a",
       "sha256": "0xccb5272e7f5f8f747b5a77d6981b3814b8207b117c42e664234d39662505fb26",
       "urls": [
-        "bzzr://896597bb44d18eae4afc3f3d3a4138764bf1407bbef5d5b947cd900524bbb54a",
         "dweb:/ipfs/QmS2sjEJXmV8F4zZGfw9JdNJ8VHy4L2qHrFQWuLTJdDvBD"
       ]
     },
@@ -13838,7 +12768,6 @@
       "keccak256": "0xa17c811c3fc9b4b58f6484c0341442608bc87510b37331b47b1690e3cbb84025",
       "sha256": "0x90073a5037a2df0370b04bc3dadd3fda4c4a938971cfcaf1239a66864c9f3325",
       "urls": [
-        "bzzr://9f03cb0819b570f4cb6678922fcb5ff97a1640159385a09170f5e064954fe6fc",
         "dweb:/ipfs/QmRXnVcnHLGRcMZHJQ2o437o8V6FHkXezW8mm9fBPHu5Yk"
       ]
     },
@@ -13850,7 +12779,6 @@
       "keccak256": "0xcf099e7057d6c3d5acac1f4e349798ad5a581b6cb7ffcebdf5b37b86eac4872d",
       "sha256": "0xcaf4b1f3e01fcf946aad2d22bbe046b9dc4fd50049a05c3458ff239e2c93a785",
       "urls": [
-        "bzzr://2f8ec45d2d7298ab1fa49f3568ada6c6e030c7dd7f490a1505ed9d4713d86dc8",
         "dweb:/ipfs/QmQMH2o7Nz3DaQ31hNYyHVAgejqTyZouvA35Zzzwe2UBPt"
       ]
     },
@@ -13863,7 +12791,6 @@
       "keccak256": "0x9f1f3f0a1a495dd7e5d60dafcc1fdca829a702ed0a551d175a85775c8b202f6b",
       "sha256": "0x2b3a902c5082958b25cb9e5f50ac66e4daca70e88483524edfc8c78e944f8a4b",
       "urls": [
-        "bzzr://af23bbdffbd46e3a0e5878774018c0dff969f79152c46446c82cf1fe3de04bc2",
         "dweb:/ipfs/QmYburxTWAAXB29PRzreoEfZdUxdFtoedv63iocrGwbpgZ"
       ]
     },
@@ -13876,7 +12803,6 @@
       "keccak256": "0x3abd3f2e483a4f43240c219a038931b756f01168671af0f795495467d5c0dff9",
       "sha256": "0xeeaa75853c45fa7a30bf19405dfa261f8e95b4eb989e6bf4f494743f4cfa01e0",
       "urls": [
-        "bzzr://bf46b698243a883e069f96bd613838f1e64657974a40cb97d7a01cdad30c28fe",
         "dweb:/ipfs/QmRPh7XM92WynGLaL2stuDomx8YbXxTPeEvJYjXCMsZrK7"
       ]
     },
@@ -13889,7 +12815,6 @@
       "keccak256": "0x42865c45b34c30998a81bbfea2c4e66cedc1deadc4e22113ec29aab6efa356bd",
       "sha256": "0x60acb4d43be837943e1878796a2d95e3fd2647e3b6ea596897cf361944ca0a86",
       "urls": [
-        "bzzr://df12810e4ccb5fcc646b29da1fa21d1926bb19e68365bf1f6af9f15edc4706db",
         "dweb:/ipfs/QmQcodrUxvXeASGcJ7Jcsh1vV2cjyKqFJb4JM7bpjdH929"
       ]
     },
@@ -13902,7 +12827,6 @@
       "keccak256": "0xefbcd4f86eded44a3fa0eea6e44c154182f51781efbfe80b54d100b892a1c0eb",
       "sha256": "0x3c8a6a981f0abe94679e68f2d131e683783055fb309622cfc47636cf22973159",
       "urls": [
-        "bzzr://cb00c199290bbcb7ffec227a5806c782d67bc44bd4195f4c69100af5da5e14e7",
         "dweb:/ipfs/QmP7r9fUTU6NE56xy5q9Bu5WzZpbH3QvKyMPksogBwnq6M"
       ]
     },
@@ -13915,7 +12839,6 @@
       "keccak256": "0x7a0ccfa2a2ad2b0f3bf549f5f63bac63a395217f941b433d52390d7ee8d7e252",
       "sha256": "0x6790e9546e9c0cbead744873a07c41146cba023d0a858308edab5db51e802b74",
       "urls": [
-        "bzzr://3d769553abc992c95116bf0e70ae627139ae90a1fe0b4e12e414d46bd63ce5a8",
         "dweb:/ipfs/QmVMtjVRzEjjTrh423BkVkFzkFsMZ9YHLK9u7DJc8SrUjC"
       ]
     },
@@ -13928,7 +12851,6 @@
       "keccak256": "0x6fe6c6bbf10faa5826ef414b14d456a067203e4d8395c19d2a9875e61f3cd419",
       "sha256": "0x5f1a6b6c5a12e1da0b343e993f81cda86163f0ef0f100a6bb951dda03881c686",
       "urls": [
-        "bzzr://1d695149653e9c46e68bd3616f393a7f4aafc9542bb4b4bcd03e19307815d06a",
         "dweb:/ipfs/QmUXCmGSiTN1isqjDQ3nhRqiHY3k1goLurTNsa446aiaQR"
       ]
     },
@@ -13941,7 +12863,6 @@
       "keccak256": "0xbf63e26d2f117363b725b9da8c7e6373eba94a8dfd3bdebc4b7af4147eb0d18d",
       "sha256": "0x2004ab7c5d944874aff7bacf3434818c559af0e9a97526122dbadc4b0e732167",
       "urls": [
-        "bzzr://dbf9da029d34150ac1345c46bb1feff11913161661809643285511a357c62075",
         "dweb:/ipfs/QmZHaujs8xvih3jmxX7WZBdVoRDMK4zNUTmuSCmebBFq3p"
       ]
     },
@@ -13954,7 +12875,6 @@
       "keccak256": "0xdb33f938e413a7388842829c28d33b3126783a610b3e79df013865606db91ef8",
       "sha256": "0xb5bc16a161a6e2a3756af255a1a74bfe220a0277f938fde2268108eb5bc21471",
       "urls": [
-        "bzzr://2a86d0336606eeee571f25d7749b7f75293045f6bb77a8a0819ae3709a184821",
         "dweb:/ipfs/QmYgX5sGePF9FdEQciJi6WTgKNCLb7PF1VSgyaD6RQWuXs"
       ]
     },
@@ -13966,7 +12886,6 @@
       "keccak256": "0x300330ecd127756b824aa13e843cb1f43c473cb22eaf3750d5fb9c99279af8c3",
       "sha256": "0x2b55ed5fec4d9625b6c7b3ab1abd2b7fb7dd2a9c68543bf0323db2c7e2d55af2",
       "urls": [
-        "bzzr://16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1",
         "dweb:/ipfs/QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS"
       ]
     },
@@ -13979,7 +12898,6 @@
       "keccak256": "0x38afb7deebedcc001b774c6b132f944099838fd6f1ea013a81a568c64a50a0b7",
       "sha256": "0xb3be49c5b1007d931100e208635ea760057a714e5949cae7a71fa522d3a6ebf5",
       "urls": [
-        "bzzr://3f0e34fab98b48b304e98fb5c3315a2e791a7293f007d9550f58482225e1c012",
         "dweb:/ipfs/QmeCLasJ1V8SttkwZxpwffvrgJPBUoNBh8xc4EoirDPJ5v"
       ]
     },
@@ -13992,7 +12910,6 @@
       "keccak256": "0x8e9f011e85cb1638abeed9875a4d6bfb35a3f1b3804dcc9dc6991dae781214d8",
       "sha256": "0xe4dd9e777d80f261bfa104abcf2cef66e451ac5b8e90af8f8b41075c4961e49e",
       "urls": [
-        "bzzr://f2364ec8dcc11807adf29c39c4e13fbf7f42ec4f417d3429165b5886ebf173a1",
         "dweb:/ipfs/QmdGMzTb9iq1XgL47LVp1hxozPKzDBFwfjwtVAm7fGq61D"
       ]
     },
@@ -14005,7 +12922,6 @@
       "keccak256": "0x301fe3df3a4eee427c80eeca28ba7a213ccc1d2c549ea81a9f346dac5074575b",
       "sha256": "0x4d3c38333ab3b9ee6e724c2e1033647fa522a2f6a3cefcacff963c412fb74ad4",
       "urls": [
-        "bzzr://412e1c2df09984c24fcfab199c0151d3f711a1d9728a417b930e41d3081d1adb",
         "dweb:/ipfs/QmQCQyoYZcDDSJzQd2drPvqDmginFWaRc67hD6qzcTwLLv"
       ]
     },
@@ -14018,7 +12934,6 @@
       "keccak256": "0x24ded819527943bf0403135b47c30cce2e5f60d84291098184df256b18f413fa",
       "sha256": "0xc053c85e26f1198e51b24e9e4690aabae3809ecfda42e888e4866592f1c58148",
       "urls": [
-        "bzzr://e6edddd50aad828dec71a90853fecd6695d13a1f0833dcf42f8e2b55e611bef2",
         "dweb:/ipfs/QmaW2V8SxVRJ9yPj9DrVHDZS28giXvbYQMqwZXStQtdnkJ"
       ]
     },
@@ -14031,7 +12946,6 @@
       "keccak256": "0xd4c520b1ca811471d64a0ce4679e5c04bf3b1ec155d12af99ba0d6f01fff7353",
       "sha256": "0xfe96ea2d5142e000eef3aeeb3ac5f1b5b20bf90406caa814a7dd0f848cab5235",
       "urls": [
-        "bzzr://b72197032396cb84a4942980ae6de6dfce0b7439cd61edce5a8e0b7e587c7a1a",
         "dweb:/ipfs/QmVSMoykXmBpCn5LCTMFaJdhqPx9ekZBPuBy8UnuFeqodq"
       ]
     },
@@ -14044,7 +12958,6 @@
       "keccak256": "0x887bb464712e63a7f721db1b696ea533187f81facb792c6fc796c6adc5de2440",
       "sha256": "0xd77c985cafc66d1fa0dd703751468b809b220a9795e02b0033a790a54468174e",
       "urls": [
-        "bzzr://3550cb0675ae0032c562b47f03bfa0ace5d2c924abcdd173992ada830fa31c87",
         "dweb:/ipfs/QmVB8RSjGGtdi4o6p9Dth3yCFtNghvAn4H6eeeqYwNCcW2"
       ]
     },
@@ -14057,7 +12970,6 @@
       "keccak256": "0xccc72e0c12edcfa4088f757005afd73dd3c0175b2ffe556a08d40c6de4cd739c",
       "sha256": "0x9028d267a34a65e032eda6a7a546afb0cc0685c94f32955d5fa7e3f99af4c72b",
       "urls": [
-        "bzzr://22d74feb10e1527b598224588def67e0f022e8ef3335b218aad2391f938015cc",
         "dweb:/ipfs/QmV3AVwaAM49o3K3usUfBxe7skUjyKEyJrSoXrM3r4sA2y"
       ]
     },
@@ -14070,7 +12982,6 @@
       "keccak256": "0xbe4fa2012ecc289fd0839025d18c57bc4aaf36a92c67404edff69d9389064791",
       "sha256": "0x1392a6326e032b317f8b5f7397f1188cc014db72b6ba6499044f3ccd4f0a4e74",
       "urls": [
-        "bzzr://e7bdbf792374727978906b473be220b2098048bc7f36ddf2494b84e67a8741ed",
         "dweb:/ipfs/QmQu5VmbBVXXSfetZEoGaYynQ33WT2b2US8bFuybeXV5gK"
       ]
     },
@@ -14083,7 +12994,6 @@
       "keccak256": "0xb2c272dcbb210a868db74cf7a6aa0565f55420f9d2918ec142deebd65dab1d48",
       "sha256": "0x72a91ab716af4e3d24fa30a77c7c8d882916dee8b2bc8c86b79b107627c546fb",
       "urls": [
-        "bzzr://098c5dfd946e516ba3cba290224fff2e50e198f7347d352c97fb8daef2b99cae",
         "dweb:/ipfs/QmWaWTqKrDbTsrZF62bfFtKt6AJgjoZoMY6KCUvFaY5tso"
       ]
     },
@@ -14096,7 +13006,6 @@
       "keccak256": "0x66209d1e09df4369364f324535b36f389a7abb2abd4de987b843ff238e70cc27",
       "sha256": "0x098a8d1cc14c36a838febe72698fe7221dcce5e44304af701b5d0fc860ef5581",
       "urls": [
-        "bzzr://542eb91eece76cdea0a6237a6999e95c40c2c26bcfcb801044774de37e8c0b97",
         "dweb:/ipfs/QmYFeN18WdkC1etKR9UZFboSx3H8VrjsRAzi9nD4xKCSPt"
       ]
     },
@@ -14109,7 +13018,6 @@
       "keccak256": "0xc3562e8c24fb01d74ac281804f5c6f6327961dba81a295b7aa0bf206dfc1d6ed",
       "sha256": "0x82f9e973bb0b32a1458b848700f181d30e44ec8ed4e4e6f90b15b5d3a2afda28",
       "urls": [
-        "bzzr://7b039914937df0d3bd5b7b2ff583daec48c1046ae1feeb96b9f97b586b1d739d",
         "dweb:/ipfs/QmQjsAWgznsoBJc4gDqLfeFCDv1fYpMUd7ZrPYyCdHeUTM"
       ]
     },
@@ -14122,7 +13030,6 @@
       "keccak256": "0x468d15aec6cb7cee108df2256fa8c9260fa5310da1838327c2848e3181b98b83",
       "sha256": "0xd41bfe8d047c12097d21f3e7bf07ac7f3f00712157b9403fe82146ccc69f3b60",
       "urls": [
-        "bzzr://8e14c0cda650c0855bd050f188d93dd638ad43ac738980df76fd2a43d520b46a",
         "dweb:/ipfs/Qma31iw4xGJQcpAsof8GozqXCUfBfzS85B2MK68SRjZiD9"
       ]
     },
@@ -14135,7 +13042,6 @@
       "keccak256": "0xd81c88b9007ad38caa1ff11ee28eab3cddb7f80d8e488eb7f87167880d6d81c6",
       "sha256": "0xc50641df2e433f60c6cfd48dac43efe1a25704e1d79e5ce830b5a1fe224cbb7b",
       "urls": [
-        "bzzr://d52dfb873aa9658607714ade5ff1d965b6fdc697ac5bb932d00bc580a8bf96de",
         "dweb:/ipfs/QmPU5fj5kqpBiCoszqCkKGbKCawyfSRovjBsJFW4etYFbT"
       ]
     },
@@ -14148,7 +13054,6 @@
       "keccak256": "0x1e82486d8b13ecd9bf0fbb5274208c845e28485ae2f6fca852f47ece23e6c9db",
       "sha256": "0xa8d757bbd1dbeeb398fb8a0cd7e6ebef561e25e30302ea41a4c5b508ad474649",
       "urls": [
-        "bzzr://7a2e6725d66e5fcc36a65cdf425b8ba9a2f3d5c09f0f1ae5cde6117b85e52b36",
         "dweb:/ipfs/QmbtuTGW2qU1bADE4VbY5xgGPcVAK7nZCW4bi8S5RBz5b7"
       ]
     },
@@ -14161,7 +13066,6 @@
       "keccak256": "0x93d31cf50d07dccd4b00fb7e3c66b6ecda461bdbbb92236a7c401ab7c67b0097",
       "sha256": "0x48cd169d9f32b1102cfdf0eebfd94b16ebb84a85b32be3703a5c98f2608e8254",
       "urls": [
-        "bzzr://b8f63344ff3ed65b5c1249dca90e1689ff8505c7ee54d16529bc0010021e9872",
         "dweb:/ipfs/QmfYGhpq6LfiAajgQ5Gjpg9KuWkHDf92wLsa4ZHcsaU71R"
       ]
     },
@@ -14174,7 +13078,6 @@
       "keccak256": "0x1412f21486804b88da2e96a9ef5618a9593c01d197c5fc750c34ccc93ab35be8",
       "sha256": "0x0ccb6c3b4438a0394be0c683afdaa199d652b34d8714abea109a88aa8c804586",
       "urls": [
-        "bzzr://147fa1812adcd063bd556a64a1b8f5939cf25f5bbf8d5a9635553916a4ee306d",
         "dweb:/ipfs/QmceLUYFNSsZ8RUGRpdWTr2wrEuxY8W1pnhQyS47qF4CjN"
       ]
     },
@@ -14187,7 +13090,6 @@
       "keccak256": "0x034734f6083b3cc628e51548e2c8753f9554a20820e9fd2b791dba8d3a458ef9",
       "sha256": "0x7bed2b91f63ad4dbce069b56aab6e09f8512f582e2ab66a069b3f733c24a239d",
       "urls": [
-        "bzzr://3b2c55c5fb0845b28d8efe403491be3a518bbf52ae47d76d929201ecd6499a5c",
         "dweb:/ipfs/QmaRmbxcHJBe1tH3mkx8EwaPw3QAk89KD9GuiTwRUxpoXj"
       ]
     },
@@ -14200,7 +13102,6 @@
       "keccak256": "0x6752930470b96816dbd4fdb7bff49d2bb221104f23fd81aa6878686cc23a39ac",
       "sha256": "0x60bdb4d2d640e5dcc83e2ff43869384e8d4501ce4b7a8c30fca3d30d402098be",
       "urls": [
-        "bzzr://3ead8acf59f82cb330ebaabf862bf3b80a4d7188551b2f35863129ccbf06d3cb",
         "dweb:/ipfs/QmYUPSSfrmh1VnFU8BAENhKV2EM4NKRakiQEhP3HpQLjQ9"
       ]
     },
@@ -14213,7 +13114,6 @@
       "keccak256": "0x98051618382dd5fc78e38fa96cc73aaa8b878b2c29d4dbdef948e972ed2ed6a0",
       "sha256": "0xd4d4f3de070a18bc863bc4a0e833fbb57b80ca7916a231f0a0cb0eeb217db135",
       "urls": [
-        "bzzr://83660938d40a8da3013ee4e5c7c3e4d0471bebd9f5b5e1bce4d5bc16da33123e",
         "dweb:/ipfs/QmUcnU2sshG15en7XnimNC5jdLQQ2iT9k17gF7eTu318C3"
       ]
     },
@@ -14226,7 +13126,6 @@
       "keccak256": "0x182388d0b8c985986b3d707f57836dbf4b16114846587d231c5d44b396b82aba",
       "sha256": "0xe46f88b974e1aba31c8e310220eb29c7155859f219854d148622a4d548756f6b",
       "urls": [
-        "bzzr://24fc45fa9491a41d544051c87f8d962ed50fa8294cee678427fceae874de835c",
         "dweb:/ipfs/QmSHkrPwYgPJv4j2D2tLLuBwM3ZN86wzxgyjaPMUnAoX47"
       ]
     },
@@ -14239,7 +13138,6 @@
       "keccak256": "0x88972e607be4b9812909b501714f121e3b99eb7b91a64814cb6e9754bd168899",
       "sha256": "0xf731b44179de5c0a7b0e926e8f3516a61b7a4529d9a251e24bad25ff3a19ae58",
       "urls": [
-        "bzzr://a4bf829bf65247437ac6101d5d7cefa4af926de442a4e634831f3a2dbabd50bd",
         "dweb:/ipfs/QmY4iuJWHGbcSmy5kZ6fU5Zbg7C9DsLu2QGCVCQVkUKy1p"
       ]
     },
@@ -14251,7 +13149,6 @@
       "keccak256": "0xfe223dd264421f9b96c3dd3c835a3d0d4d9cfa4c61f75ca0761860c9ae8906ca",
       "sha256": "0x2ee1c6434a32a40b137ac28be12ceeba64701bfad5e80239690803d9c139908e",
       "urls": [
-        "bzzr://d67cf500345ceca523e9bbe55dab9399e27321fd9005704a5b16bab82185260c",
         "dweb:/ipfs/Qmf5fpJmeHdwgmSjQPqdu25XtA9akTotakkNmrh4axgo8N"
       ]
     },
@@ -14264,7 +13161,6 @@
       "keccak256": "0x93da221bc04182307953d6326f66e63d64662f661fbefad0b56a267e3782baf6",
       "sha256": "0xd4efb86b4c25db81975c9039bc8fceb14c0d89bbbc3caa6b08c4cf9b5e9d8d24",
       "urls": [
-        "bzzr://8600d0de4f40211acb49f358a1959f6ef6b9fe4afdb2b22cb2a3c75a861ba46f",
         "dweb:/ipfs/QmU3gYoWSiRmgeyNZEyQS2NqpwVgM51tEjiXyjDQEdz7Zs"
       ]
     },
@@ -14277,7 +13173,6 @@
       "keccak256": "0x3c3be0535ebce399fca6713019192f5d880c02da4b857dd166f1d18209f39512",
       "sha256": "0x2b09828cf0cfe61159bab6102be056d8f2efb6f84affbc99c398ad48a74d2b02",
       "urls": [
-        "bzzr://be6a83efa338e6c71605e19d5a7d59563da6c6c02bf23e96c522854bb4114f95",
         "dweb:/ipfs/QmXpcn692WM4gDUCKEXPokG1Le1mYGLTbBJfAgWTv9ywKB"
       ]
     },
@@ -14290,7 +13185,6 @@
       "keccak256": "0x6f4f069b0304e99a575f8c9a2177dce5efb50e5ef0cc11357c6981b2fb16dbe3",
       "sha256": "0x71453308e83eebe5f15972429db9940d30fb23bfa311165382b38188da553030",
       "urls": [
-        "bzzr://1ad9ac62704740194281284c392a583545e8e3c00f6a0ce30190fc6b6be70011",
         "dweb:/ipfs/QmUb46ktS6WNTsrFzMgP8aDJkEPBZExHgHoUEaKk1x5USK"
       ]
     },
@@ -14303,7 +13197,6 @@
       "keccak256": "0x1f876a903c4cfc651d8649c0ef99ad2d1dd7344273cf946b9a8515136910f51f",
       "sha256": "0xcceda83c29458ce97b18babf37a9710841338a2c5536a78e86a88d158cb653de",
       "urls": [
-        "bzzr://165769894a713a7a36d3d2d620bc9794254c85e764f66b5151392757b0b32d22",
         "dweb:/ipfs/QmP4zwkPgATp2GzyRdkdpyXaUTMhKFvjFVSjHnMxGwv4jK"
       ]
     },
@@ -14316,7 +13209,6 @@
       "keccak256": "0xa2af7227f97cb3b90fd521612695b4d0fc71579f4b66fadde3c48cd4916afa99",
       "sha256": "0x3f5bc8e9e2020e7649af06a224f4672b1642cd5edf045c23ef8924270c030bb0",
       "urls": [
-        "bzzr://ad96e29c0b4e553c24d2163750ea929333b60415fb88e229d68d83c6b5f26dbe",
         "dweb:/ipfs/Qmeuw8GSc6o2BQhP3aWiTLBocCneAAPEU1cL1X5bUfWHRn"
       ]
     },
@@ -14329,7 +13221,6 @@
       "keccak256": "0xee90fcceb27b0138b3d6e63977895fd1fa2fed9d28473e90040e62491a96deb4",
       "sha256": "0x843487f036bf768d671bf547db1df9fd882f1e179c5f850e1fc5dad2d208b802",
       "urls": [
-        "bzzr://54bd2228e4a2f5593d9051b22668ab061af9e6e9a8092502b6b7458206aad828",
         "dweb:/ipfs/QmZN35ebF4P2MUqwkNGHZEeGkA7BQjS2Esh1qwxiYX7foj"
       ]
     },
@@ -14342,7 +13233,6 @@
       "keccak256": "0x94692f36f73c1eeed6caa6c77f950e10747317a5e1dd8dac3242238f1a821b48",
       "sha256": "0x70fc531fcaeaba46cd684a11b8a8f7585ba46cf9a273f110e3a7dd18721acfd1",
       "urls": [
-        "bzzr://00610bf0cd870cd2e66818daa3e5fa4caa9ba7ef94f38f1ad09ecd5abb33efe0",
         "dweb:/ipfs/QmXhw2aMdRj6fdqcotiN7Ca2YRxe4ueRfMuNs84JVVujG2"
       ]
     },
@@ -14355,7 +13245,6 @@
       "keccak256": "0x8470f7ad9e49326c60373b646d518b9d5a19f9663974a94eb723b4f39797464f",
       "sha256": "0x82cb891d11b457f227dc6bce88bcdc30fe576981c900cf531281bfae5b5d9293",
       "urls": [
-        "bzzr://30f8f7855a242d854ab643ce9762ca380fbe92c01dd925749285296173b89363",
         "dweb:/ipfs/QmQoQMc2zJJkG5gX2fNdsvUu3yscCWdhsN4M2wkW4WXLXJ"
       ]
     },
@@ -14368,7 +13257,6 @@
       "keccak256": "0x853adc88f64108bde19bc803ed15a8a0e0ce32d00d9106b8002f41a1162d8308",
       "sha256": "0xc01f2d951878266fa685b6dfe15a8159281906c5da435719cb29dca8ccfb2ba7",
       "urls": [
-        "bzzr://06d9cf29d6d40a22795797d0574a3575696ad60766b08e5bdd2bdfbb1dc5ca3a",
         "dweb:/ipfs/QmPRDha2zadsqhXS83mpTQphfxg4xe223VyjGWvNfKKKrh"
       ]
     },
@@ -14381,7 +13269,6 @@
       "keccak256": "0xb4b130f28701f7b8ac4a437860884800dd354abcf377eceb89dbda87d018e173",
       "sha256": "0xd4e2c8b093a76d77597a194d2f0f5e862506d16adc7e87b254d022c34a7f2525",
       "urls": [
-        "bzzr://cfb44ccd8e3d049e01ffb1f34f75d7afa6079505c17c9aaf6229d884ec5aabdd",
         "dweb:/ipfs/QmZfgr9RmWGUN53MLjFPjPJbzxqicHQuFMgjWR491pEsP9"
       ]
     },
@@ -14394,7 +13281,6 @@
       "keccak256": "0x21cb57298f3bf4e3eed945509ccb5c3cd7fa0da1a12fd39821c9bb8187ff9247",
       "sha256": "0xbbc2914ebc7c5e3b808c723a135745873175c06acc488fba890bc501bd8d7614",
       "urls": [
-        "bzzr://de55bab041c1e431e86a878cab7cbea5ae0d966831093dc836a84010880466a3",
         "dweb:/ipfs/QmXjArQdma9CkfWgQctDQfzYrLKBn5CUb88iNXcaRPd96z"
       ]
     },
@@ -14407,7 +13293,6 @@
       "keccak256": "0x04c7bb4e86cf837d10f7b7dae5b44c2e5c0245b45d0918e8c642c20cf1052683",
       "sha256": "0x93d085031e8e18b9886a01149b48f85c8a173543eb27a4faf04a447367dbb0d5",
       "urls": [
-        "bzzr://6e8a424b79071dcba5f7289a633d7b459cddc90c8b8211cb6a8dd2fe7fe0e6c4",
         "dweb:/ipfs/QmPMcGWypjXqYFxMs5MqqExMYgXpoRc29Yd3h4be1TXEqi"
       ]
     },
@@ -14420,7 +13305,6 @@
       "keccak256": "0xc688916f4ac0bf0614379d26692f60bbd72d7fb391cc0a4baa2f6c7a95c18002",
       "sha256": "0x98d9a1511e1ced71a6af979706f0fa2bd32648f8082d3afbdb0fcdbf3772e462",
       "urls": [
-        "bzzr://c7d5b8152f01543f886dedd8b769f1a6feb950d6cc9a978c77120d23988254c3",
         "dweb:/ipfs/QmfNa6QP7v5xzUvDs3KpKzmYWY2hPZaQ4QXfS9zZ1TNBUL"
       ]
     },
@@ -14433,7 +13317,6 @@
       "keccak256": "0x78d4794e9612d109bf1861598fe9e57368168cf799a1b9a58c684a87440c32b7",
       "sha256": "0x7f5706778e5e45aa99c3343e0d7891a49ca83c0c3f77b01cb16934d9af7cc9b0",
       "urls": [
-        "bzzr://2a6dcec5305ffc0d83aa7d40ad1b5435fdb683ba52b5bc9913d0db3b84846ee6",
         "dweb:/ipfs/QmQeYnNXJVzzjiS52s1m4KEH8mq2KkWuJemWHZqoJ84C64"
       ]
     },
@@ -14446,7 +13329,6 @@
       "keccak256": "0x293dd3e5ac68e1d9a4e241c4b6efbda9c22cbf75927f9ca634324ed32557986d",
       "sha256": "0xd4de5e16a1f3848554e29e673eb94e1cbc2fd712c71e787163cf83373fa2a911",
       "urls": [
-        "bzzr://49939d9904f69a24d0bb10662936c017c246d795b3e0875f758d85c955dd14d5",
         "dweb:/ipfs/QmcnP3rfVgAxwvVPAgyShEB2kWaLBhAtTfagyMQ3HQD66B"
       ]
     },
@@ -14459,7 +13341,6 @@
       "keccak256": "0x5ef1f3822ceecaff7d6ca8475496bccb0386b461ccfba3c75dad41dd303d05ac",
       "sha256": "0x87e7f26c7f36db9d2c26e8d6e3b0ebbe9d0d7fb190bc394aeb78d9e91ecab3e7",
       "urls": [
-        "bzzr://7d20c1fd01562c3290a63a825225e9ed960eac7658275beae776ba60bc38ae7d",
         "dweb:/ipfs/QmbjthZL9kq63Ryrhoh3iM3dpeCYBCL2L2VhJaXW6k615Y"
       ]
     },
@@ -14472,7 +13353,6 @@
       "keccak256": "0xc6ee2d8f9157a8f20c222e31b104a470ca9f222ba9d7aa6e0a734e6cae8ae0b4",
       "sha256": "0x8c5b6a8d37f7be8ff65ed02960a99247a95f3f923aaa6965d23d43e9d34241fd",
       "urls": [
-        "bzzr://e77a67797ede90346f8b72d577e8b495767480fee85121baa3ff860f0e82c754",
         "dweb:/ipfs/QmV9t8XBRsjdecHszx2s6XUErfysEGwRMGizGagENDgLxE"
       ]
     },
@@ -14485,7 +13365,6 @@
       "keccak256": "0xfa5333e79c893eb39c3e61e23d2222806c2dacba4477bb043a21e7f81b973792",
       "sha256": "0xdd1d5e8b5aa0d0890462f30f4e4fb8a53298c91cc81592feae114283680b8569",
       "urls": [
-        "bzzr://9b2ac00a578e6298a640675b5a52a2e397694d0d803912305fd2a8db2b14e138",
         "dweb:/ipfs/QmQm7Q144FiC5BBV4RxS8QoCsZmVQdT8tB4NtzmauQVvay"
       ]
     },
@@ -14498,7 +13377,6 @@
       "keccak256": "0x40de1e4a0ee38aa8b2fb04387f8672b2c89bdc965cd7079942d5563c8a2ca332",
       "sha256": "0xb544e9c8aec6f84863f40fae4a5d4ae2595ed9d99b3f36c1d6c46c5826a575f0",
       "urls": [
-        "bzzr://267d9abaf7f183e6338cf2e2c59ca328d63c751099d64ffff6134576e4c715af",
         "dweb:/ipfs/QmdKYvgSzN7BQSjhLVB77KokYd2pe8mHLy91TM1P8zFKxJ"
       ]
     },
@@ -14511,7 +13389,6 @@
       "keccak256": "0xfb179918b65b911713e2e5102ca4f1b4e6f61db2afbb8bbf4ed795ed3c6d68ab",
       "sha256": "0x926b19ba4922384295e1d31ed8d9e81a2d5896e845a1105f4680d36938eb65b9",
       "urls": [
-        "bzzr://05f6ba579f4072ec77eff07b1cbac914cb5bf351cd6caac43e6d40a14b7aea74",
         "dweb:/ipfs/QmUWqWTQUhoMzB1cBiWBUfmS78NNZcSY9GgEMwAq9Hxa18"
       ]
     },
@@ -14524,7 +13401,6 @@
       "keccak256": "0x361788485f817c2dcd1258e2bda796c93eff16edd067513c68c5effaa34fee2c",
       "sha256": "0x3c6e84d5a4a74949f2eeaab7b57c8affaea31d6ce117719eec425cd25715d5f2",
       "urls": [
-        "bzzr://2ec27044def3d05c78397c4cc751cf9c6bb110bc05a8d82bf74002ab52a627e2",
         "dweb:/ipfs/QmSbn8b5v4yeVcotkHok188Ghqt4njxdzKULy9jbJSXMmb"
       ]
     },
@@ -14536,7 +13412,6 @@
       "keccak256": "0xc68517effed7163db0c7f4559931a4c5530fe6f2a8a20596361640d9d7eff655",
       "sha256": "0xb94e69dfb056b3e26080f805ab43b668afbc0ac70bf124bfb7391ecfc0172ad2",
       "urls": [
-        "bzzr://523852f3e01b02ce947771e0279ffb6154d12700f809ba3606d908ba6271431c",
         "dweb:/ipfs/QmWjG6PLzF5M6kxkHujhEMg5znQCgf2m1cM1UptKA719Hy"
       ]
     },
@@ -14548,7 +13423,6 @@
       "keccak256": "0x08dd57a5cf5fd59accbd5b601909ffa22d28da756b5367c29b523ff17bbc2f99",
       "sha256": "0xc596765f9b3dce486cf596ea35676f37124d54f3ada0fcbc02f094c392066a59",
       "urls": [
-        "bzzr://7047ade6879aab4c825594dab0914b8ec673bb907eecc6dfbd68f63086e5a36e",
         "dweb:/ipfs/QmYh5C2rgDAx452f7HyHA8soLhnoL1GeeNNEWEuw9jKY8w"
       ]
     },
@@ -14561,7 +13435,6 @@
       "keccak256": "0x70ceee6ccaa25d03ef593cdfb1ed1afb6e8ad414d80d2375b79608d798420a9e",
       "sha256": "0x1572c6226d01293ab30a66b24712b7879ce4e9911c687490ca4cb994c4ce0202",
       "urls": [
-        "bzzr://023996c3648cbd184530d51f4d8e2a51aff9fffd732e5c22c8b9135213f35c93",
         "dweb:/ipfs/QmRK8VrAdDpLBMSYh5as2VLTLKemmGFnTfzDaHczDtv5Af"
       ]
     },
@@ -14574,7 +13447,6 @@
       "keccak256": "0xd23d91912eeea1dc2585febbe5a2dc43506b10001466afd40cae75e8b34e0356",
       "sha256": "0x38dadbc7793c61ea3278d4a612ed23dde2ed0eee0b9cc7c54b66f4c53d09cd26",
       "urls": [
-        "bzzr://13a09ea778a916a00e7165849895c15edf6bed9783b09524796e2acd5e1d344b",
         "dweb:/ipfs/QmanNAFs888TS6cSX2jZcGocw7QXryfK5mdNFgYcUb5RLp"
       ]
     },
@@ -14587,7 +13459,6 @@
       "keccak256": "0x7a69e15ed4df24455c9cc3a2372587411bc4216cce3320bd9e5d85203f312fbe",
       "sha256": "0xbd06247bd73e5b6b3b1fdffad959149ea3cd79e0f24bb76fb680413ad900fca6",
       "urls": [
-        "bzzr://0dc04820914b9fffb373d0f78724ef3d3fa7cdb27fe979c73171a81a0d246032",
         "dweb:/ipfs/QmW18rF3MfGi9AvJgBeyNoPUk5YpEA8tAL8YqzppoUspCR"
       ]
     },
@@ -14600,7 +13471,6 @@
       "keccak256": "0x2c5a8b07099f0548264e983189a05ae89aa28b2c922750056fb40d44d295f8c1",
       "sha256": "0xd4390eef8df7644c6ccedf6263689ac231503c30b62d27927265e61715bdeb4e",
       "urls": [
-        "bzzr://a11d1462005056a55870f2fdb57a12be241c4295b1647d82598c14ef9588918c",
         "dweb:/ipfs/Qme3WLk9mzbuevQQ4gssP5QTarYPMfmYcu3ZCN7wGRKmDb"
       ]
     },
@@ -14613,7 +13483,6 @@
       "keccak256": "0xd0671ff67e876ae500f3fed78c966d70025c4ebe16b2b06361d0c76a29f3f5ab",
       "sha256": "0xe0b2f9f62d9e70b7167da31662a91115fafab137c7bb88adea56939deabb708e",
       "urls": [
-        "bzzr://f6400db776e10afa0963209380f33e60e860aa7920ee93f86c88b4a80752cc8f",
         "dweb:/ipfs/QmQa7V9wfuFXZLxP3jQLdgKAxetJBFaVbHwrdX8NRVV3EF"
       ]
     },
@@ -14626,7 +13495,6 @@
       "keccak256": "0x1a86189707b3cd291da6e189a6f917590c2724fe9f9036da764cc9270282ebc3",
       "sha256": "0x154727f1b0aa68459797effd51d8b953f5c8d8f7a5bf941332a422befd0536da",
       "urls": [
-        "bzzr://e9c2e72f4769c55273c42e8be05eb4df88467be323938e4f7ca5d0f78a84f575",
         "dweb:/ipfs/QmPaoRFYtgx4tJ5Qi4eZBfcfDAuhUYpP4Rhb1Fb2UFQivC"
       ]
     },
@@ -14639,7 +13507,6 @@
       "keccak256": "0x9cd5bbf8c2379122f0aa696e678309cfdf2cb1dc35d1e11608517680e2f52565",
       "sha256": "0x50eaf1ba143cf4e73ad09704d8eccae7faa004a5e80ec0968adb18da31da062d",
       "urls": [
-        "bzzr://9f3806387e50bd83ba1239c4b3669a9752ef3a74321c7d6dc495e47c85bd31a6",
         "dweb:/ipfs/Qmbf4Myd2q4389tWyXvPdjwfGdkp8o4Wc9vNqiV1uKqmFc"
       ]
     },
@@ -14652,7 +13519,6 @@
       "keccak256": "0x4ecc327bcbb4b0d4ac7c8bdec6745eff2916a5721a2642b89ad5b82cb02e7cbc",
       "sha256": "0x7542ce7c992028a2ba48ca9f8d376f32d7069d1bae4390d43e88aaa7640b60e1",
       "urls": [
-        "bzzr://5fcbdd2acd3e8f72244390c07ab5789354c1c0ed2819cf080e9d22cb72b9d91e",
         "dweb:/ipfs/QmUTzSnMNado2GCsUX9GPGgLteCbnA1Hsa1e9M49jhp1iZ"
       ]
     },
@@ -14665,7 +13531,6 @@
       "keccak256": "0xaced83ffba034311962a8207f1080d2a0196f9e1c1ea3b2a546eb24d5daaf2a6",
       "sha256": "0xb1491b3835a041f90c4d2b1e5cc9e79231626b85259e9043fb59a6386f178419",
       "urls": [
-        "bzzr://5227dcdd55fb172b782c562fca98bf3938a52e5a37cfb3ce10e5fe4829cb8316",
         "dweb:/ipfs/QmTQMyf4aWXSukGtSxqstbbi6AchzFTzZEPqhbujFDRNgb"
       ]
     },
@@ -14678,7 +13543,6 @@
       "keccak256": "0x39c8f0ab8581ddcbffce1127c17e315aff5217f677ee5ae570c9ac9b94b1e368",
       "sha256": "0x53f1d513bf88080a7554defb89128c0184e5b29f1859d728de8ea8fa48969a42",
       "urls": [
-        "bzzr://ea4778eeac6d3a2d5a05c893b6a7645c48470bb04f70e88eee900f662b049641",
         "dweb:/ipfs/QmVUnz7EDYG9dyrpmFCCpumf5PZR7aubDAB3KUAXNVqZyz"
       ]
     },
@@ -14691,7 +13555,6 @@
       "keccak256": "0x9b458742bfe89b73c8266acd870d41ef7ec31015e7fa277154ee750b0aca876b",
       "sha256": "0xfdde3d1261a3ee3aa3de421dd1ecf93644290eca31a3529470d5bb23920f7de8",
       "urls": [
-        "bzzr://51a8079d948c5fc00e429cda6cbecdfdea2062b800a6d0ac82c387f2b4efbc3e",
         "dweb:/ipfs/Qmemt4oRPo7mmv2QeQC9YTNj49XkhZQbqD6X8iX9LdpUXn"
       ]
     },
@@ -14704,7 +13567,6 @@
       "keccak256": "0x9468048243871673a4f1f14dcebb7801b008c5d0b0d8afca70c6f672be18aa0f",
       "sha256": "0x0eff232fd6b62547dbab53f0822a638cde4f0088cc84e04f1bb6f3fadbde67db",
       "urls": [
-        "bzzr://0a0bd5b76531966993f00877d828dd10e1323a8a1e261a614e4098cb4feb2a42",
         "dweb:/ipfs/QmRNJNqkF5TKNj84Uj8uWNRpDKAaudDR9kdTMdmbvvMXXf"
       ]
     },
@@ -14717,7 +13579,6 @@
       "keccak256": "0x33c709821c7179e302eb3852675f77f658035f376006d8bb89446e6095d3a85f",
       "sha256": "0x67c291a511475b648ff6690b2bf5f0c4d5fb753afbe0dbf7b25e8c6167fb43f0",
       "urls": [
-        "bzzr://bee9baacddf60a2750d8df7df3f986274c9fe40cd2997b9488812499c3c5a4e8",
         "dweb:/ipfs/QmVgvxaJdtR4VyqFr4Bir9NNakxWPw6QtbwNzaDK8Lnvqk"
       ]
     },
@@ -14730,7 +13591,6 @@
       "keccak256": "0x1a109a95d318d66b3a94b8e6862ea6d8c2bc328fd3caeabb84ade02d7baa8cda",
       "sha256": "0xf23dc4f82c9bb25402af85d76a64e024bbf821b711ce3355f7988ce11a6b5bff",
       "urls": [
-        "bzzr://84de46dca6383d2351c099caa597cd4e6ec86706b1a5c37bdebacb1d50fea9dc",
         "dweb:/ipfs/QmNgAqjWFLnB6m9XD5eiNNpSBaZ7rcuW4qYVcJJhM6kVrA"
       ]
     },
@@ -14743,7 +13603,6 @@
       "keccak256": "0xce0eb9d31b71c4a3e813a8f16f64c6800a8726da0d2cceab3441f469289cc391",
       "sha256": "0x39fbcceaae51ad340f176de8b8c0df307c33eeb0b44c90606df3382e90b4f557",
       "urls": [
-        "bzzr://81bac30739dfbd78f5f655aae54f22a9c2769d1417d6508bc059d2c589dd891f",
         "dweb:/ipfs/Qmah5QQBR9Etsoxf3grb6M9EBjpLZbKP6eMcjbqUAbRcfd"
       ]
     },
@@ -14756,7 +13615,6 @@
       "keccak256": "0xfdb3cad26266a3363041cdaa3da618d6a50fbf6c471d009af193ebad7676f214",
       "sha256": "0xe464033385c2f112bee182d73406aea7e4bbf6d8ca4e5c45305146ae6bd26b55",
       "urls": [
-        "bzzr://ac8e9be91295edcc27f95d4e0742e3619075eb8af77facd5b54e0ed824a603f3",
         "dweb:/ipfs/QmPxv2qtoyfShD7PZNKo8Ktsebbt1DE2w3VqGbwax4YfPZ"
       ]
     },
@@ -14769,7 +13627,6 @@
       "keccak256": "0x619c6c9f1e15e7002b1659df0f6b8f7c662201d0577fc9d7f47f2e869b1c96a6",
       "sha256": "0xd9a6dabe5d94ade9bb17219f4027caa0d37545339b75e0f1dd322b4678cacd2c",
       "urls": [
-        "bzzr://db308a6a36ed86b1dbe0e983683356ef1fb5634be0d7b2830724739be887128a",
         "dweb:/ipfs/Qmdox4sPh3jtM748SUHK8zTATDYgnicyZvsdmXrq5eTmWz"
       ]
     },
@@ -14782,7 +13639,6 @@
       "keccak256": "0x65565109d6bca3f4d84f558f4fe8b8222a30585aca5f44d2e188c366a6149a14",
       "sha256": "0xc57d016d163aedc1f621f14a9214a81c593f06ac048c4522846a9b630d724ca4",
       "urls": [
-        "bzzr://66066b4140bd370cc1a9e035fecb92feea1eba0a6885848274133a50eb728dde",
         "dweb:/ipfs/QmRz4cpWWAZyFY53UFL1GMWSmPBRSmqNivasGV38RGu83P"
       ]
     },
@@ -14795,7 +13651,6 @@
       "keccak256": "0x5d37fc8aa3218867a00f508a2f23e974c8bdaf0e3afb2caa3cbd6e241781357c",
       "sha256": "0x4ee86b327eed351b6c16b0f41b732e2ded3b395d7ac8d39fd5a6230aa172502c",
       "urls": [
-        "bzzr://72494d0eada60f5141bfbe481b13cdfc1dea04fe469787150b9bd09bcc55bb70",
         "dweb:/ipfs/QmQDwCSdEMKH8NXvb59uWnJiRquuLabmGcuzhpiZ4kufhn"
       ]
     },
@@ -14808,7 +13663,6 @@
       "keccak256": "0xaba9da05a6367d3b7684bd833364a529fce32116f1d66911a2f8aae6218278fd",
       "sha256": "0xd6b2595fdfc48fd2b4ebd1a131f7a6ca89737800b94a6ff15a5be5052bf43d95",
       "urls": [
-        "bzzr://fdc377e9e5cdbc3907a0e99be0f425c7f4ac2232dd71518c767d914aa75167ce",
         "dweb:/ipfs/QmRvFeh28VQ35vG6JK2jKUSsfQkLj6qxJ8Lycq97dDDr98"
       ]
     },
@@ -14821,7 +13675,6 @@
       "keccak256": "0xb345314abc628e5974d81eaef6c95191412407825066940b6a69ed10e3aa9136",
       "sha256": "0x71703fba5d77a9684b5dbdd1e46e9a74ff4c393905dea96de27acea6aa4fe2ab",
       "urls": [
-        "bzzr://37828ccdf73f308a7cd82a38b136e1fe35d49ff5c9176e86bae749da092979e5",
         "dweb:/ipfs/QmRGJaH6vJxPuvcmDrtna1acWmfFZJgT2kqYzd7WNVnArH"
       ]
     },
@@ -14834,7 +13687,6 @@
       "keccak256": "0x6d5355f30911dddf7db98cfcc0a5fb250212fd4921ed8bd66aa5bd598d83e7ed",
       "sha256": "0x0b928c9325ba1737aeaa921eee88ed7e2a655c888e7bc8809f07109e30f5b8fb",
       "urls": [
-        "bzzr://039fb575016abed8ed75fefa0298a88fa98a372a313a60af3c019cfde1dca8b9",
         "dweb:/ipfs/QmT8jnt3hZN5vhdkuFKeSQw7VQNevXtiXmXMooGdWwgo1E"
       ]
     },
@@ -14847,7 +13699,6 @@
       "keccak256": "0x56b598fad3189508235538759b9dff762b5d7f69c2b50df7dca4b2ee8fefc8fd",
       "sha256": "0x585101f0ec518e79dd31d580bda799ead0035d7fe2407d85e7bbc9e08886c814",
       "urls": [
-        "bzzr://35db4cd2df9d4ff6bc1a00fb208829f19441cef5505adb557663cb6afd98108c",
         "dweb:/ipfs/QmdgqbWwLGvUdEUgzJDNUjCSBHBoi34gwdbqx6iKmXvgTP"
       ]
     },
@@ -14860,7 +13711,6 @@
       "keccak256": "0x0dddf74964327a2707f3be5b549800399470959eb8bfc9db42c90721045ec1a1",
       "sha256": "0xa078f03c9467d7d910653a2e88c7116c6ba9edc23635a7629531b12e277ef621",
       "urls": [
-        "bzzr://d68e2bc8fcf21d3041583dcd0934acb9307147b1f6286c783b2a86edc33fecde",
         "dweb:/ipfs/QmbBLFSzwkfSUVQ1jHHpBYNrUeqEDJMj7CBTtyiR5RfLmX"
       ]
     },
@@ -14873,7 +13723,6 @@
       "keccak256": "0xb40b0f08285513bc1281fba3b01a9f4c2c491131c823c52b79af1457282e536d",
       "sha256": "0x7c9cf4847c4847de40ad7a4bdb30722fcb5caf0fc129c44b7eea284c221ed5ff",
       "urls": [
-        "bzzr://eeb2ec519634ffca9273065a51bf4c6cfdea80e046c3b38b2f420aa03d8aac63",
         "dweb:/ipfs/QmQMgFGCCT9YzrgXgKdqrC3AgtP7sYnuA3shHCoN25BybC"
       ]
     },
@@ -14885,7 +13734,6 @@
       "keccak256": "0x84a0e9282047512eeec499d55c83dbb6981430b08692d81d6c09730bb18e6cd8",
       "sha256": "0xf77f141e5fed9594b28342e2c630ac6d48f2a724e4383a457881acd7fa62b1cf",
       "urls": [
-        "bzzr://da8c5ea3f2ecd33d3f83ac2c276871f4ee41370fb55ae62c6c29835c9376bdec",
         "dweb:/ipfs/QmQ6W5VedQpZAwuGTtp1BhmNkvVheLnJq4xwN9Qmt9bAbH"
       ]
     },
@@ -14898,7 +13746,6 @@
       "keccak256": "0xdb4babcdd1ab9aee67f25b5131173ac3eeef5348a7f98b4b29d04e4708e12b18",
       "sha256": "0xc4713a920a053a1071b09443445de6c1f21ed001391c65210ce5a4d9e1d365a9",
       "urls": [
-        "bzzr://4fc02782efad80edc8391bb609c040fbb8407f60ff3d201c4f9fd2572739f111",
         "dweb:/ipfs/QmemiCtQbk4yW5u82gC1J11Hwip5nM5LGsWpbaztyJoTMj"
       ]
     },
@@ -14911,7 +13758,6 @@
       "keccak256": "0x8af93b2b1cdf1a70a5b0a1d95aae4243bfa73266bb3344d71f85a9d4cc5d0012",
       "sha256": "0x3b6cc04db183199d04c86d1452c19811b29a9f9ba300980d95c3d34eb23d3e42",
       "urls": [
-        "bzzr://96f485dee27e87180b9ad4b0d3853e2ef20b8f0c1dd5052a9157f0b78824762a",
         "dweb:/ipfs/QmeWH3gMLANFWi4GL7NpRcqWrwkjT7bNGMM976Ho2cZaxm"
       ]
     },
@@ -14924,7 +13770,6 @@
       "keccak256": "0xaabee60ec190b2afb3f85760cf9339e05d470988812a21e1a38937e39802ba43",
       "sha256": "0x5de715bf9208ead746d765ebee6e179af374521e19d1bcd3f71dc88acb6c86f7",
       "urls": [
-        "bzzr://f73dbfce3c101a8318523818f382395fa51209def59a25384325ce7803d99ae8",
         "dweb:/ipfs/QmezwLqqCw1rKDe3EpWwK4gfqrzdC7Q8d8uBi5Cdujfuii"
       ]
     },
@@ -14937,7 +13782,6 @@
       "keccak256": "0x6cebc9bccfadcebc24c0eb72d30d8325f37e544175d8a70a5ca7ca5f4dbb8f5b",
       "sha256": "0xf912b8cb0285ae75a6ff10672a73727f9c291acf74d1e47b804edd072796016f",
       "urls": [
-        "bzzr://b460c28306dc1fae66b0c4f64cb00a244e18a42a7c0c5aa4656a92708d4bee0d",
         "dweb:/ipfs/QmaL7k7QTDbFdzTf4ikQ4itP71gYXTk3sUNVXEwHdJvqus"
       ]
     },
@@ -14950,7 +13794,6 @@
       "keccak256": "0xf147e0f7a54b46bdf0bd21af35d0ed8a6387edc7cc024270770509556f83cced",
       "sha256": "0xe22d1d50013d3675ab35bd5fdb7b61e76f33c5936247a44037db82297a0f1703",
       "urls": [
-        "bzzr://c55cb959cd70233cde34b09da913ce408c1b3b6b661938ceb58417001e4339ad",
         "dweb:/ipfs/QmWPRhBLzmkCgWbsSwLumnnXwec16WkHnzp1d3RcWJr8yT"
       ]
     },
@@ -14963,7 +13806,6 @@
       "keccak256": "0x835d288ae6949349a68098116cd5ba7cf9f99385ba89006b569f8f044600be2e",
       "sha256": "0x35e5fcfba2d8a54da4384d1606830d72588e5d46d69f77f8a17e187549396f1c",
       "urls": [
-        "bzzr://ac64537d392db4a08811c55999d2d5049b9fa43b1dc48823609d5c106cc817d4",
         "dweb:/ipfs/Qmf82LyKuS4DaWGxW69MYX2bmGxGQ8KiGB2r7Cg136Dx76"
       ]
     },
@@ -14976,7 +13818,6 @@
       "keccak256": "0x72fb2d3793e0327ffba901701364571218a0569dc37466af686fe8456ac3955e",
       "sha256": "0xeba42283055d4af946ef3b0425ee6977a590845660cea25864c7a3e75c8826bd",
       "urls": [
-        "bzzr://08439437e3a07af29295c2b4a69915cb222ea307e3a28553b4144b41ca92dca2",
         "dweb:/ipfs/QmViSJWoxs9qYqFWE6oRpDFwACLfon9s9e5pM18zMXZ4L7"
       ]
     },
@@ -14989,7 +13830,6 @@
       "keccak256": "0xff0e1455e5c55ce42c0dcca06d71487738262baf311880c702ffb6194fd21d43",
       "sha256": "0x6e1741e1b9817a5180a06d3500d2bbbaadcc86168cb678f4dadbb7cff44a0fa3",
       "urls": [
-        "bzzr://ff8aea1515410668c6732cf86cefff6ce1d8cae3922f041677abae98cfbebc40",
         "dweb:/ipfs/QmPiEAamzXxX8Eu5NbxhzRWPjdAxsmjtJaJsM2aHhyfw8q"
       ]
     },
@@ -15002,7 +13842,6 @@
       "keccak256": "0x6d4950176dfeb8e610d5e1c254bfc90dacee17ab4d6fe1fec75e1f82308f7bfe",
       "sha256": "0xc10b9612ca1e8a9faaa1ff1a024ce84716bb39ffb372cc680657dd7edc352a7a",
       "urls": [
-        "bzzr://f240e4cc03f78f61551aeb1304975007c5e623aa4a6e20736bd3585688b63b6f",
         "dweb:/ipfs/QmVB5VAm4ti8FMbAnsRr1krM3xjdbsM54sVhv5WW9NXb7H"
       ]
     },
@@ -15015,7 +13854,6 @@
       "keccak256": "0x812557544d6f3182f0129526fe850dd7730a34ed907f1d617582384c6cba1768",
       "sha256": "0x05569271c11cc1469a8cfd60fdd447afeffccc824bffdd90eab31f13e9b4a20a",
       "urls": [
-        "bzzr://1528c6ecc12408fee306b427842f234183942dacecb6a4c413ed1d9409cd97bf",
         "dweb:/ipfs/QmSACBzUqDUFB4Tdua9a5XUB2Vsv2c5BhB3Jbk7RN2QNVB"
       ]
     },
@@ -15028,7 +13866,6 @@
       "keccak256": "0xcc7bde32fcfe5ef94e3943a92d5d727791efab2f4d1da228f0abcc72f04ac4d7",
       "sha256": "0xb72470718b0832e01b725f137b890ce72df204e58d17db3f20cda032d109661e",
       "urls": [
-        "bzzr://32e08343a47d12362182ed3c00f15c9162cf1d87fbfa02d28397ba8c00d38e10",
         "dweb:/ipfs/QmZupwbDR9ZQZ3gZUbGbG6QXCSuYgvF65wEUdygAZg4Vdr"
       ]
     },
@@ -15041,7 +13878,6 @@
       "keccak256": "0x338197f498e020c26c0f6ea7d35bfdaa14efd818ada76d4f026c2871e7c0cdc0",
       "sha256": "0x13dfa1ffc3ef6dcf4aa8507d10d25d260d9a1ac5799de599e445b9fb64ab3ee9",
       "urls": [
-        "bzzr://87b5b01f6b9ab91abdadc5669dc0e4b2262cddf048d09fd269b0fa07265691ed",
         "dweb:/ipfs/QmS2ZHuXE7Qrn21i7siwAQc7rKa1Txad8nWVyL8qTTdy6S"
       ]
     },
@@ -15054,7 +13890,6 @@
       "keccak256": "0xa832f842a843a2e896e985f01ca088c6b39ea9a8d56a460e5aa25c429034d829",
       "sha256": "0x6ba8e04a5d1827cff4d8ecb72f1a6e490ceaa1d3fb683da15d0b8dc2db9abc70",
       "urls": [
-        "bzzr://1f062cfdb574ce6b590fbd1c6fd0f2c9af05bd290cf4a66abbccabafc4a45e6c",
         "dweb:/ipfs/QmUkfiivYLGfSWzZrjHDWnm5tgvUyG7cTdc3bioPDSSrUt"
       ]
     },
@@ -15067,7 +13902,6 @@
       "keccak256": "0x89e3aae91edd6c888aab05b35230432e33ff9dd51ec9ee56a7a1049a80d06637",
       "sha256": "0x1af94fc436400f4392cca7bb23e22507c7847710d0737c5c6a3cc8bc2689321e",
       "urls": [
-        "bzzr://ebda984e825fa497477049407f14ed2791cff26a60ca941b75aba8eaaf9108fe",
         "dweb:/ipfs/QmcworY6nD9k1i9NCF9vgenumqBiHpLz1cGiBTqjmt9fXy"
       ]
     },
@@ -15080,7 +13914,6 @@
       "keccak256": "0x61402e62e2a65bf70d576ccf501408ac85ebaff2ca4677c19025e14868eb4f22",
       "sha256": "0x8eb7b2b211a298125cb9869209a954be47450a503c6efbdd64246db27cb56d30",
       "urls": [
-        "bzzr://77f44350423b658c3925c7301ed1fe96b5ffbccef8d18d2829832ef1ba2de787",
         "dweb:/ipfs/QmXdvHTA47kZkUVvzcZLMUBTvdWoscLkr6AiTUvD9mRKC9"
       ]
     },
@@ -15093,7 +13926,6 @@
       "keccak256": "0x04d3c482b0129798ad2656560f3f794f57f83db77ef72f296e9614ae4c676c2d",
       "sha256": "0xd329a60c3be6faa6de5536e10d89d58717f176662255231ac02b66542b48b37f",
       "urls": [
-        "bzzr://d2d6533605648047a3b0063e456e43b5f40654f3b8062f160aa45bb9ee1a8a0d",
         "dweb:/ipfs/QmbQKWJTSA2KuE4AXzDEob1p9VbkAsLnQjf9HUAoAebife"
       ]
     },
@@ -15106,7 +13938,6 @@
       "keccak256": "0x63e14f38181a4d7798945f48b0e4558f31800f1e1b22b4e46ef7899d1d2376c9",
       "sha256": "0xd2c6d2e2e973ff261560918d5ed2ebc2fc56c373bcff6ac7344303e354261ef1",
       "urls": [
-        "bzzr://309233f67b2bafcaf6ac20ac4402a39241c91a309d6eac3b9d7c2da55c6531a6",
         "dweb:/ipfs/QmetymiZQze9BfYPaBmQ7JEADwN6gGFDEktoJw1qaUvH2U"
       ]
     },
@@ -15119,7 +13950,6 @@
       "keccak256": "0x7a3ecf926e850b22367ee0f01d15ca95b4708df20c6726fd356dbdcfd4866c44",
       "sha256": "0xed3813f876cef5ecd311f5a096c782a570300f2f167fc186a4496cbcc85a2b6d",
       "urls": [
-        "bzzr://0ee8cb22e37dae65fc624c704de97071866ae839a5c7eed73f91468a04416e58",
         "dweb:/ipfs/QmR6kUEnDsiMcteHDA3mKz7vMP2qv4pkfQDTSxz1rpTvNn"
       ]
     },
@@ -15132,7 +13962,6 @@
       "keccak256": "0xbb0a0d54e384ef1565b2ffb23468056c833c0f33d793e98c6d6c41a20eba1502",
       "sha256": "0x3e2007f4f9453c58b3eec0e1af4db19a4ee47d8336ad2ac18301c8e9db5cd7c2",
       "urls": [
-        "bzzr://24619759385b2f2437e64a3ed66e7567b35c76c8cc76e9ce0dabc5fc580e728c",
         "dweb:/ipfs/QmXk52Y7SWWHNKgGfSde3Sdk7VDeTNZnb1trTUbZeuNKC7"
       ]
     },
@@ -15144,7 +13973,6 @@
       "keccak256": "0xd0c15275c5b0d03871332719def9b0f17e8860c7db60e0e71f18b971458a7391",
       "sha256": "0x015e83fb0b72ccdafb0c217961b21a0321adb2d3f2ad992f5e79635c2086e6dd",
       "urls": [
-        "bzzr://629ae5ad84c45c248144b5eec7827a9cd5b2f2779ef84ab251c8cd876347a098",
         "dweb:/ipfs/QmdfVfa2mhyosaJVeV7rbfnvQ95GTHPeRPzmvxcds7RYej"
       ]
     },
@@ -15157,7 +13985,6 @@
       "keccak256": "0x1756f4ac574102e819c515381494d3dae92e3cbe755575dea6e732e2be882c7d",
       "sha256": "0xa204e1c3d457e664e966023f66912c9f29df9f191b5e7a71010f6890d9ed1130",
       "urls": [
-        "bzzr://90235e6ae95882af33de965dc75e35e6b33285e94c700578928921551ee15d10",
         "dweb:/ipfs/QmYsgowyLTweSj3zyNfHW4MQEKxG4kV1U5yUswwm2KZx1f"
       ]
     },
@@ -15170,7 +13997,6 @@
       "keccak256": "0x8c1a3464df1dbad1d2fcfe0983ddf97b81ddf14ebe18c97000d87e501039769e",
       "sha256": "0x2604149b4ce94d79e7d64bfda690d8f2c237b9433b3319841df4e77249805518",
       "urls": [
-        "bzzr://b0437b90c90dbcdafd7a760f2717d2f7fde4854c9d7384ee1897845bdb6299d1",
         "dweb:/ipfs/QmVnR1ya9DgqjWFdnij7GNQdm1th8zsQe9rKHHmEbD3XZA"
       ]
     },
@@ -15183,7 +14009,6 @@
       "keccak256": "0x0d0427e9f23df17aecd8f093a85ba3628013c94540acd5d5b70e2957d672d693",
       "sha256": "0xa6ee3e4d735f665b7eefb46d5645edd22ee91ee51b74b2a8c23438feca41d709",
       "urls": [
-        "bzzr://82a6f35139c920678c72f883188adbd5dc6cd35556f683942dfd642a336f7580",
         "dweb:/ipfs/QmdByR1HL5oxLBoABk7y3E6Ge2bt8QEuTpVN4M2KDktNUN"
       ]
     },
@@ -15196,7 +14021,6 @@
       "keccak256": "0x9c7a7db38a46a0d9c16000569db064b8758966feed7dfe175352cd94fc0b3411",
       "sha256": "0x6174d5939034f5c8a1ba8d843a957e56c2acc54f5cc6f20539b576db2880ed5c",
       "urls": [
-        "bzzr://88885af7123ecf985cb185ae4bdec92c8ebf4a3e12eab993b3b471fc1993b570",
         "dweb:/ipfs/Qmf16BVtpLoVwc5WG97dZWs5873v2Npyw7WyCBPP8b4d2M"
       ]
     },
@@ -15209,7 +14033,6 @@
       "keccak256": "0xc80718b0e0cb26a978c0eb0e0a3685d00efdb8517e531c97b5e286df8207d9cd",
       "sha256": "0x09dfdc842940c31fbb87d512d48fb36cbec374a3aaddc1f527e05e29288838a7",
       "urls": [
-        "bzzr://4011a6d13b2502f5303d022c8e398a03467579ad6388ac745d4dca89d30627c0",
         "dweb:/ipfs/QmXP8jyNcXqK5hYwkNo8Nvk3pxfCrPkrs7hqydH3qppZWF"
       ]
     },
@@ -15222,7 +14045,6 @@
       "keccak256": "0x9d422954e49d0523c6403592fae5f81cc8c42c6e0aa00d22b27e6a981e5f17a5",
       "sha256": "0xc668187419edda1bf0debd1c328a0b535611e627109397e48f49fb0ddfe028b5",
       "urls": [
-        "bzzr://64d18cd0fb8bf0faa31808305ec5feb716f1f0d5602032f7e0f45fe4511b3e2d",
         "dweb:/ipfs/QmXnYgrJSFPQrUPd9eWimxWDp21AYcyKGCnAG5Q3AjXsdX"
       ]
     },
@@ -15235,7 +14057,6 @@
       "keccak256": "0x5d7be3b2ca09f235e7db92bff22edd4e4127e135b69aeac8afa43add8c70d820",
       "sha256": "0x7f982b06bcc3f79e8548db11dd62dba03806b7a9f743bc076846944d38844357",
       "urls": [
-        "bzzr://5a32b7e6e52aff66226e3ebb4a9a4e5f0b68c09f5a118b05e5a3fd3eb232077e",
         "dweb:/ipfs/QmXQqP3Csxu2SWFejrJEHAc7GobXBgKokhSapw8y6CFd4V"
       ]
     },
@@ -15248,7 +14069,6 @@
       "keccak256": "0xc635c2a60f8e57017d0ee7ca0e1d17a7c823792d2d8862e8d6d974c3f22da4a0",
       "sha256": "0x401c758c0c09624c7cd89dbd27180ef20814a24c2f3a2f055e232e402aabebd5",
       "urls": [
-        "bzzr://483b33c81c8bb4eeeb78275a8fed9330b43656490749a21d084fcd11ab37f9ca",
         "dweb:/ipfs/QmPvoFnzC54Sm6Rud18PJezkK61PtXFPYwZCTYD9NCYjc1"
       ]
     },
@@ -15261,7 +14081,6 @@
       "keccak256": "0x2f2e0849b6d7aa05f43f4cb3188971fca2d2297c56e195fc441eca8c7c961c42",
       "sha256": "0xde8ef4500a9f8fee34d3d76113cfb9b1cd43a278bae1ec0b75a1c16e752e43c0",
       "urls": [
-        "bzzr://525a81cea60033f3f4ae7bad1ca01475da653c994c9fc168ee47d58cde958ccf",
         "dweb:/ipfs/QmWwMutZzPwrUJ1KMDr2yrxeE7amRT7X6WFARoK5xR5zZH"
       ]
     },
@@ -15274,7 +14093,6 @@
       "keccak256": "0x6fd5679a082c8ce7b12de084e51e3659b534a05f79684ee70c200a885776842f",
       "sha256": "0x29d0bd45994f99b031d9c565108f7a4bda0e2601e72c8bed707a2007432cbe14",
       "urls": [
-        "bzzr://4c68494d65c3862b818d48cec1e74ab82adde25097fc35c4b13a987b08c19efd",
         "dweb:/ipfs/QmbqPkbPh9BtYbgp2fnntZHW9fmE1dZ6ZefcbyQm4ZZMay"
       ]
     },
@@ -15287,7 +14105,6 @@
       "keccak256": "0x3d8680bae12b8c196424d917e26c7c4b059c6d4505f66e2f3589730edbd0e1f1",
       "sha256": "0x973b2542ac42f1a34e5028198cfe6695687e92d280b027dda2a9635b392f6f11",
       "urls": [
-        "bzzr://56911ca47c26f38b8e3768442f58e59110a672a28169eaba04b218378bc6c4f7",
         "dweb:/ipfs/QmNagRdFNdB3KTL42u6FZuGc7hZxpasrKCUs4fJh3Hw6vX"
       ]
     },
@@ -15299,7 +14116,6 @@
       "keccak256": "0x51777116af58223a41aa3016d0bf733bbb0f78ad9ba4bcc36487eba175f65015",
       "sha256": "0xb5cedfa8de5f9421fbdaccf9fd5038652c2632344b3b68e5278de81e9aeac210",
       "urls": [
-        "bzzr://c7d43da1bc5529d2cc311e00579c36dcff258c42b8ed240b6c4e97bd85492a64",
         "dweb:/ipfs/QmWbNMzJryhiZmyifLDQteGPwN4aTgXQB6barBvXYVw975"
       ]
     },
@@ -15312,7 +14128,6 @@
       "keccak256": "0xf6cf9ea56f89794a2068113bb7346f9d8e2f17f673d6f106460925ad2a2d1104",
       "sha256": "0x2651c1f52344980e359ab8cae8e5dd7c2e326ae125736eaab0a955f29080dff4",
       "urls": [
-        "bzzr://1f263c015ffb81a41d71a1708061cf72f343262b4a0997decdbb8a4c1182ac71",
         "dweb:/ipfs/QmRhMyy5qRcGYzSJV5CTnJDUhdLoA6tHDFbPFDUcSsnGA3"
       ]
     },
@@ -15325,7 +14140,6 @@
       "keccak256": "0x4557c6939ad9978c713dfc9a8ec0d830871ec1c6f894b7d6e22c14f2a9038bc5",
       "sha256": "0xeb398188f7964943a184cff20f3ede305c6014624170dd484c2af666325e3866",
       "urls": [
-        "bzzr://342eec265ca1dfefd42a59c5cd7a41686b63d124232c278b019e82da111c87a8",
         "dweb:/ipfs/QmWWmu2pSXRZWGbyN3aMaSe9L1oZEFVbT4LrgVKukuJ9ae"
       ]
     },
@@ -15338,7 +14152,6 @@
       "keccak256": "0xe27b1e15a244d18042900182d758d0fd7b210b24f6b8212a584eea42a0249112",
       "sha256": "0x32962f332495c7137a2b5b208e97640194dbb5a9e8c7625fc6bf50e196cd1da3",
       "urls": [
-        "bzzr://9a8391015bbc88f30cc60cb412dbe8681518ab1b22714d90fe547131577cb572",
         "dweb:/ipfs/Qmcoa7gU68cBVK3WA5JTbZLix9sHwYTA7VqcZXUoMXoBgK"
       ]
     },
@@ -15351,7 +14164,6 @@
       "keccak256": "0xc0e1141aaad2714b8a06ce3f278e67317b5e3106c4a2f1795b4b6169588e6eb6",
       "sha256": "0x76dbf64c2399d23bf9e2ff39d228156f9eb8ba78ae7c4c618558db80196ac8a2",
       "urls": [
-        "bzzr://03d775c4c0648463529e47078edbdbcafd9fe7e56c18be36d04aa05484216752",
         "dweb:/ipfs/QmQG2ZcT54mNhHcXYoBtNWD7g61LTbLzhx5f8qPxNe2NY2"
       ]
     },
@@ -15364,7 +14176,6 @@
       "keccak256": "0xdd08bb1e140a2260b64d3e38e0cef0f7e306ae6ea6caf1c2d8ece613773dd200",
       "sha256": "0x3e4c8662a38767cba15555bff326899eed197c8000d616082968a43e9829fad6",
       "urls": [
-        "bzzr://1aa79ce3900611d7f28999713c9f9392e4099b69f9cf0fd9ec59c4413440549e",
         "dweb:/ipfs/QmXKhKhyB2DQVfYrNuNkHF5Ci571wze8KJSN3VMpbLy2VB"
       ]
     },
@@ -15377,7 +14188,6 @@
       "keccak256": "0x6244b189110fd55587ae8386fe83c67695cfa57991d7b33fe5c6cacd3ea46632",
       "sha256": "0x3fb7f3d1dc71ee86fcdadb03797ae79daf064a2efe321ff064524a7587fd01d5",
       "urls": [
-        "bzzr://3594b937b6f1e0c5e771a4e0c895752759b6a4a94639062ebb776eab49a02900",
         "dweb:/ipfs/QmXaa5wgiqSdpFScbXAtSWssJEbSQLiioyjmsx72FNiwrs"
       ]
     },
@@ -15390,7 +14200,6 @@
       "keccak256": "0x6691e13020527719f8ed9c0f198fb3fe5d3b75d4730b51178308780b3b1106bc",
       "sha256": "0x82e20b97cfdb62338d4ce7d0ca3242c818ac5450a660d52b0c0d80aeb0447580",
       "urls": [
-        "bzzr://de54f60110259f82484e0232c57e9b4b0cb27fbf2a201ce75bb7fec292282229",
         "dweb:/ipfs/QmcxcUQGKJbBUwVTENVLhV8CnYJBLdYqzeJQRNzDqoF2n1"
       ]
     },
@@ -15403,7 +14212,6 @@
       "keccak256": "0x8cad3125db54c9096845a8d4a629b9e010eb4baba537f5bfe4970a5127cac426",
       "sha256": "0x1752dae94621f8f3977d2461eead9d0c009e63e3215b8ee975782a7ccb44298d",
       "urls": [
-        "bzzr://ed83995456ab1306189dc5b787f710545dc635615ebedcb328bffd36c8a6aec3",
         "dweb:/ipfs/QmWcYiJCiv99f5d4jFWQDVkYQbQZAFvpNUjD9Mn6KL3DYr"
       ]
     },
@@ -15416,7 +14224,6 @@
       "keccak256": "0xc111e452242404f40394055ae96a00a590b30ffb224434fd80a60543114df850",
       "sha256": "0x1ea13152e79b21986f99471103905ef54f93dae2a64ceaffe6847ccfe9b2398b",
       "urls": [
-        "bzzr://60a25a588eb4464211f0cedf9b16e8298bf218514ef338c8e45aad97aeb3faea",
         "dweb:/ipfs/QmQEJ1dsHr81FxxZpZogeJLTqVPkSbuVAwk7nYaNwjQQzg"
       ]
     },
@@ -15429,7 +14236,6 @@
       "keccak256": "0x719e9d6ea8d77dd82c8cbf9a4d68e543e4d12395c536946b65793b7205fdd6aa",
       "sha256": "0xc913f11127f168264e1349912123f0ee38e4c268ce241cb89b53536cf0728806",
       "urls": [
-        "bzzr://670b43896fa1841c72e292ec74a33a20aba4294986b29c88e3ac5826a0332e92",
         "dweb:/ipfs/QmUC8jVSaU3g5DaKoxtMXf4SJfTrqdniGXDUc8y66o9Nib"
       ]
     },
@@ -15442,7 +14248,6 @@
       "keccak256": "0x16fca9b9e10bdbb5fa5fbbb7a8925bc0f8ade91fb9ac4c3fc733b54c35f8ffdb",
       "sha256": "0xfff7c1692dbefc4c9cd72fe8b9396876ba00af926f5c717f23cd93dcdaa7e7a4",
       "urls": [
-        "bzzr://9eb1b6b0e5be45befe8bfe083b37f3a4c7f28f1ec09e50aa6b1b3d7469c439c5",
         "dweb:/ipfs/QmeJ1QivuBgYMUyutt4tFDne1XSkVXcLqGTRYLg7Xyyioz"
       ]
     },
@@ -15455,7 +14260,6 @@
       "keccak256": "0x18252617dc5164950e9b09b5aec22b4ffd5dfa54735c563ecfe33fa6ce0b3e44",
       "sha256": "0x411698d18e4af6ff02b79053f5fba07a8f76855b74be98018da83f78bd16f693",
       "urls": [
-        "bzzr://1debc4b9a35ee1917ebe9452468c1eb74c998f3058298b5a0af5b0501b11a475",
         "dweb:/ipfs/QmUATC4nGK27HvAPWgRyeWgcQxpQBioVRHqyhVKtnuzWcR"
       ]
     },
@@ -15468,7 +14272,6 @@
       "keccak256": "0xb8ab065dbbe9e9f2745d5e01e73e48987d7ce76db6f32f0b86f665d51cf518d3",
       "sha256": "0x3e5c33449ffe115a0891ce1a6642f985cfde7f53da0f163663a4f6854d76408f",
       "urls": [
-        "bzzr://004838709feeda9ef22ad19d9ea3686841b7a928490afbf04a312ad747773983",
         "dweb:/ipfs/QmVK2EkE8HZRMTMrKQ5Kt26nCrSMaqK35F3gMck9NMqws4"
       ]
     },
@@ -15481,7 +14284,6 @@
       "keccak256": "0x431d502c446c261139fda1e0ac7dd95771ce93189ec62d4ce818ffe0b1993d93",
       "sha256": "0x02074b56e38f423970a51373771e95af1681a194640a4c96de9ccadacbdd84c0",
       "urls": [
-        "bzzr://b6b62dcf430652b3d5ac00a8a26d78463ee8c4bc5978be75754fe96b76537df6",
         "dweb:/ipfs/QmT85sg3Rr17FotmwJVyuRbx6PTEAVB9qEyjv3D5zLV9NP"
       ]
     },
@@ -15494,7 +14296,6 @@
       "keccak256": "0xe84b229dfa89a53fb5715975ebe4c83225af6787379eaaf960d938d8b746f1c0",
       "sha256": "0xba0bcfb9178ca85c7607a28cb10eeb100f31bc7dfaafa7d3f69c6d617272128b",
       "urls": [
-        "bzzr://0b9bdebd7243746c0a840cae3756a84c4783e9674c7d7644fa4f9d6b0c22fa31",
         "dweb:/ipfs/QmTag817J3bHP28duKG1hYBTARp9r13SbyF5TzwsfEjy9r"
       ]
     },
@@ -15506,7 +14307,6 @@
       "keccak256": "0x7e0bca960d11fb095798ff65d029436f23358ac060b25a0938acfcb4652da2ec",
       "sha256": "0x4a14c7bcaf0d988a829db2174b8f7731898aa8633216490603ad74bff64eca3c",
       "urls": [
-        "bzzr://7f33fe204160253c7ec23cb0ac83224bde3aca9f91a7a686cb67d99248c5fbb6",
         "dweb:/ipfs/QmPYDf4qYtZLNEAicW7hcvpUJ69FoHiXmUypipDpTKo9hU"
       ]
     },
@@ -15519,7 +14319,6 @@
       "keccak256": "0x2299d629a966986186ede41a48d15de1701380560b9fd4d4a83feef10973665f",
       "sha256": "0xfada547a1ddc9f64c3d72c3bdd7d971e40cd53350e0a56bb8dfff096ff2735c4",
       "urls": [
-        "bzzr://459fe00ed0398cbeeff491f6e8d3279e1d68ed696c173bbc21484d1916029d7f",
         "dweb:/ipfs/Qma2ZaLxvUhZKrAFieoWGaNeprXsJgf2gAh7EHxU6doAzh"
       ]
     },
@@ -15532,7 +14331,6 @@
       "keccak256": "0x744ea6053b6c526def51e31761c49272db62e88e332170aa733c67b7772f1c22",
       "sha256": "0xde026387f1305afb3871a2b36856d634fb3bded8746b65c3e7f86aece5bf8d3f",
       "urls": [
-        "bzzr://a743cc37d24b6d4ddafcbec5ad9f9f4c07972afddf84e7a3626956467799843f",
         "dweb:/ipfs/QmNVumJS1i8taq2i7wfTEPWw3Zf2Ev5rPtb1QDEBaQTVMe"
       ]
     },
@@ -15545,7 +14343,6 @@
       "keccak256": "0x6a0e0f1aa3516877ae119d3c1333e98dc8939618f3871497b06ac79fca6c8d11",
       "sha256": "0x20ebdee320bb57abb9c9ffc9bf83b895ad2b9be3ce6758d68d8f343cfc5f8c53",
       "urls": [
-        "bzzr://93628ef0a32459bee7478b286a4bb7a436750050cf66fc04b58ffb281c531cd1",
         "dweb:/ipfs/QmS3WEjaTpcpy6XcsXHAQyXcHn98jmAsxaeaXc6AgcUASR"
       ]
     },
@@ -15558,7 +14355,6 @@
       "keccak256": "0x3efd981523b0e9e24349d7eb664214603e4d9143eaaaa092803590b64b065ec8",
       "sha256": "0x748b07980723a4af63cd79ab8863ae26471b4aa9177e586b4d0513b2165b35ba",
       "urls": [
-        "bzzr://dc441a1e18d65fde67ec6bbbab6089a3bdb9249d9dab9d3f9416ea5dd191c206",
         "dweb:/ipfs/QmX1X6D5KDV3GSjdEJ3xjHiX7oNaWok6eDoSkCiDn3WPbY"
       ]
     },
@@ -15571,7 +14367,6 @@
       "keccak256": "0x65fb2434d8fafc6bb95f165e09b448a87a308eac91ecbd372f2e2261887a4398",
       "sha256": "0x5437a98e7d180d51b44dc1126afd7472812f7ec7f2934632d837f0caad8c54cd",
       "urls": [
-        "bzzr://4d9f3edfdd5d05555b74778ae85bc1807f9b50bdc03dfd7e2ad5558e702e310e",
         "dweb:/ipfs/QmatwgkARMmiGpvT8pvvqPoPQUEwE8mFmLJxLsjDNRX1rk"
       ]
     },
@@ -15584,7 +14379,6 @@
       "keccak256": "0x2892aa81d1e795b1d05a50db3bc4e5a91031d0b69a3d8add893c8c29d43ab594",
       "sha256": "0xe3624e8d41ba20792691cbf8620789e251c53a1f1d9b69db99fd5338d97c5e0e",
       "urls": [
-        "bzzr://1b2d2920a7018e0e4ca20efd8c248aae78208a34b1dd53bf1712e68ebe91578c",
         "dweb:/ipfs/QmdBAPy6gFtSC2ZaV3xf2kx2PmBgZKarTaeQbbncTmUV28"
       ]
     },
@@ -15597,7 +14391,6 @@
       "keccak256": "0x8bbede675ae4dde6aace0efe1f03ed7776999bd1d26ad879ba120c84a1fbf5c8",
       "sha256": "0xaa16f096dc98383a80baa3fa88f992e9add57db205cae29ce09057a12d72a57f",
       "urls": [
-        "bzzr://7f82ee1a5e28f6a34fee7891ef7ba51f7974c8de5d81fc4d16f547fbc245657e",
         "dweb:/ipfs/QmXnidpdXmqD3p27zrzewKqcwpu4XbxcDzHkf5QfmpiQjN"
       ]
     },
@@ -15610,7 +14403,6 @@
       "keccak256": "0x36ba0b76b14da4dc7cb9d0bb0daef02ff8cbecc4bd5dab80a5e7c698da982075",
       "sha256": "0x14e1528f1d9016eb692e7f2fc7da6fc79768ca7906f3c9a816d91fdc679b3103",
       "urls": [
-        "bzzr://33d306d44632de26043b4361e239777fc6c5352906107855e286ef30a311d3ef",
         "dweb:/ipfs/QmdoPUhzF1wisV2smwpUxj5pbEcLpnt1doSty5dKEsuvWx"
       ]
     },
@@ -15623,7 +14415,6 @@
       "keccak256": "0xad326c81da3a33e94d1d3fb515b46f3f81d167b6921a011dfb204cbc57e91406",
       "sha256": "0x166c5b377c7b20905d33af31528c9d33ad6e16759a510b2d37a5afc37b984fff",
       "urls": [
-        "bzzr://a3c91a67ad9f79ccc568b883a98e7e9461c3128942b57ba5f07251fc4ca1f30d",
         "dweb:/ipfs/QmcUHAoSAiKz8AtwBYR9Kuz4jTehq1d57NhH9G4c2mZLZq"
       ]
     },
@@ -15636,7 +14427,6 @@
       "keccak256": "0x6986121f8902a09d41ca953f7d477b87527180fc0c3625e936a67207e590c315",
       "sha256": "0x3a01f526f31a62e6242cbf8adf3814833da82b8fcc4fe6d767d489ea1fead12e",
       "urls": [
-        "bzzr://96fd0778a892bca83ec7bae470688ce8bf59b9e27f9a4e43f813f00a0f3c1e42",
         "dweb:/ipfs/QmViR7oUvggJqaUHBqySUWDU6PLVemoY4Pjv48oLt53kCL"
       ]
     },
@@ -15649,7 +14439,6 @@
       "keccak256": "0xfc0ff5985f7c2a766b4280a6659a5051bdbad755b75da942aed484f936254495",
       "sha256": "0x09b782dec05908ceb112676413662470487dea450c472f57a8520f28b296446d",
       "urls": [
-        "bzzr://d62ccf97289562ce4c43ed4ec880aefd9f1cd23f8678564bf42624d9af98bc95",
         "dweb:/ipfs/QmY3zYMoKN9xtfabhJ7CThkBsgUJMMmjHowY9CK83gdK1U"
       ]
     },
@@ -15662,7 +14451,6 @@
       "keccak256": "0x0f800ddb7f268f9174745ab26102c980b875181c9d2bd8b2f4c594611744f938",
       "sha256": "0xf5a8aad8d6e2e3d5149f432d3f9c550d48da6980dcce3322227cd879b6a89a2d",
       "urls": [
-        "bzzr://c5a4bc35fc56453b2c669169dae433e788f0f83a046c488d818fabf6f33dc107",
         "dweb:/ipfs/QmcDwmDeshVzsdETXuKLpZ982PCfBAow7tUjbobeQNpXx9"
       ]
     },
@@ -15675,7 +14463,6 @@
       "keccak256": "0xfcaa64a2950e5bea8c49b0938cb4605dd1b72976b1b9e7b0a5b6a53702ec9ca3",
       "sha256": "0x2051e9b76a523aba85f154005d12b807865aecc4be6c3e87a8891dd2f9b5e271",
       "urls": [
-        "bzzr://6a385fb3f0abc70fcf50f3e901781c2dd0911a950ee03cdc25218fcd68674bcb",
         "dweb:/ipfs/QmcTocseN2tbpcycniUfkbpEej9QMd4U9XMtGH21qR2wNB"
       ]
     },
@@ -15688,7 +14475,6 @@
       "keccak256": "0x6c3533a2b12eb5baed3c8f5c8caf37791e20fecab76a3e377ce665ea35722fa6",
       "sha256": "0x49cf2be9563d78fd9fe3681328540e88992f9d84da85e0f64fc8f5075b74a34c",
       "urls": [
-        "bzzr://1a57e8c0ee5a9f32e8db437adbbec55df4e5c209b4c35d719a7f24c15d713710",
         "dweb:/ipfs/QmXcVmjzd4FEwjYttKXDqAjHKFK24USPBKfbSvEK3954Ag"
       ]
     },
@@ -15701,7 +14487,6 @@
       "keccak256": "0x354042d885c62f32be484faa638bec28b70e69be43f0ae5734867e9c3ec64a9f",
       "sha256": "0xd7aa14b13552772dbcf928707053f140238fc01420872d6d17493c8ecc5ee2d8",
       "urls": [
-        "bzzr://122afbf392c5971dd47d855d67b7604adef2fbef179636ad328d292eae4fdb37",
         "dweb:/ipfs/QmUtFmceAancyQWjDAeLjqKVSvzv3iqobYz3nUJsLPrKa3"
       ]
     },
@@ -15714,7 +14499,6 @@
       "keccak256": "0xb9763efd6ba0a9190018f941ee17d7656caa601dd883c38dc6cda59aa2695898",
       "sha256": "0xb5d0b16fbc03b38895b4948b10eb1324e5ed3764a458f3eccd07601ee83fcfcd",
       "urls": [
-        "bzzr://3fd873f606a155f491b6fef3ed5b6ddccdd552fe64104735a0edda9d657503d7",
         "dweb:/ipfs/QmXyeD61g37x4EPc8ytVLMsXPhhSEYy98nH4Tt29AAYdVh"
       ]
     },
@@ -15727,7 +14511,6 @@
       "keccak256": "0xfb5f0d7766600837de71f45f9e287a7a2dc03f20f426c77b73d475b5cc64f315",
       "sha256": "0xe8f955a911e5b8d609ccc1f2cb473bdc27432cd4ec953022241fadb6d6904c17",
       "urls": [
-        "bzzr://64b1640822c365ec9221a29de8c60132dd5f2e10f5a1faedceb2e6a2a76b456e",
         "dweb:/ipfs/QmXD5YUXFQ7UBEDewyhxonKuxguKCfhzVUFQsTYRKzt5ke"
       ]
     },
@@ -15740,7 +14523,6 @@
       "keccak256": "0x336c5eb4506980bb34e81f2180414a83ec5862d3c40b5d156833a7edd5b7151a",
       "sha256": "0xc5356f043a6c94f87c794e03f94d3c7e6b392b44a82d1f30557b38a3452553eb",
       "urls": [
-        "bzzr://6ed3dc5edaca72dded5c9ccbfecc6102f0c30d918b2da1d5b87fd545f9d7e945",
         "dweb:/ipfs/QmPiNQUHUofd45eAPRwpTxiujrMc1S83ZfG9JjNMfVv9Rf"
       ]
     },
@@ -15753,7 +14535,6 @@
       "keccak256": "0xa36c8afec8af1c5f45a9a195c904f5754ab8fd722c03d56a541ef0ede0899d5e",
       "sha256": "0xd0421290589dc67cb3031782a2a3920df515119dfe130c4d0556e06811596965",
       "urls": [
-        "bzzr://f7b8a3cf5a3e090b23ea38867251fd9902fab0f3e0b21b203d19ea66f83ee14d",
         "dweb:/ipfs/QmZkXuD4Xyg9Pmg2UhpgsHQkUYd3WKHQHbECrjY3MZB4RE"
       ]
     },
@@ -15766,7 +14547,6 @@
       "keccak256": "0xc49b88584aee69ab1f0c4143353322d1759608a106c3028a37288ca3424f2d13",
       "sha256": "0x79935134048cd0d094ab4b5fc8ede96e899f651739fc8d885c58596459d99efe",
       "urls": [
-        "bzzr://0b939279c89c52e0ba7cd0de3045d86042444f0940d7ad686a7811afc139ffbd",
         "dweb:/ipfs/QmauJqwazcW3BTZe7rDDvWcvC65sxWhXPq1MBrPUq7kBfF"
       ]
     },
@@ -15779,7 +14559,6 @@
       "keccak256": "0x10b272199e871d90c2053fa40f42087210f242fbc7a6b0a5081b27cac47dcc91",
       "sha256": "0xb1cdaa78fb95b3296ac83f7b4fc90e9df7ef54e57ceb96d93c43c13ee9d72b1e",
       "urls": [
-        "bzzr://db3850f550d1b68ee39a20e45cac8245ab0d97a47e83108db1764490689fac82",
         "dweb:/ipfs/QmY5moJG9Zt1mV3w2sHDq55NDodhLgvhefVi4tyigC4jBu"
       ]
     },
@@ -15792,7 +14571,6 @@
       "keccak256": "0x7c5eab4061162388ba116f4b9d0ba724124b9161cd9aea8b3f020c1aa9e232ad",
       "sha256": "0xe0f8e6bb8a601c3d46a5c8d4e747f9c001171b225eedfed2b8a49b80a5d3ef44",
       "urls": [
-        "bzzr://4354c62d54cc9ad7c7542903e4eed9db5d19d691d75902d9469360a99afc1bb8",
         "dweb:/ipfs/QmZHQcHNSoxSiC53NioZiAhcmR99KVYrjVjaCwxk2fCHRo"
       ]
     },
@@ -15805,7 +14583,6 @@
       "keccak256": "0xebcc2650f7bd64b9bf3e7b42b6c33ce58fb421af1aaf6f1ce341de8b2e16ba2a",
       "sha256": "0x482f1e020a39836d3fc034d8947a2c479f2186f7907d9ade90ef940b31ff0ef8",
       "urls": [
-        "bzzr://800c84266fde08bb378c1d2b036d35cd14a1f00c129588ebb372518ebe42f79d",
         "dweb:/ipfs/Qmc6sfDqDExKTxVLDmJmAGeBthS2LaiHpy17oieB1bwhqe"
       ]
     },
@@ -15818,7 +14595,6 @@
       "keccak256": "0x65090ee4d4d0cb12e1929bd8e13760a463bc2f3bc36dadebcf49746961874bc9",
       "sha256": "0xd50f6494eab1562e805b2801fe5cee5226e657e05511f562b39351a38f64dc8d",
       "urls": [
-        "bzzr://0303b5adda98991a3c401affa5508c02db346a5c132eae7ca0dd7e2afdd6615a",
         "dweb:/ipfs/QmXgCj8ow8yL5TzaPryMnjvpcXMJ2smD3vWtkd51wapKJJ"
       ]
     },
@@ -15831,7 +14607,6 @@
       "keccak256": "0xd721785b3b2cc9818d6a04974dffd9ccb727ff1909792cc591e185de97fafef6",
       "sha256": "0xc5ab50b48e8d6f121c0e279bad1ec52add6d5938a439c5f53bdcbbdb3d954abd",
       "urls": [
-        "bzzr://4cd0ed0078704fabe9849e67db4fb2d5bdae97c5d915b8c9e2a3147ac92e1785",
         "dweb:/ipfs/QmbE3TiB8A57uhTPGQubtjgWYeGqnpypSG5e9GpHtdmNuq"
       ]
     },
@@ -15844,7 +14619,6 @@
       "keccak256": "0x212bb481eabd2b6127321bbfa2a7534076681435e45081602033fa3f0273baec",
       "sha256": "0xee01806420a8009333277f3fee1c4b89d8b85f6d83bd4864ceb8f5ae835fbb2c",
       "urls": [
-        "bzzr://b6e56aae0936c4a888a8f38502500883adce28fb48439c052e2d17fb727451ad",
         "dweb:/ipfs/QmVpSyfoQH9mBijutmwL4cVwAPAofTweZem1hCYqs41bqw"
       ]
     },
@@ -15857,7 +14631,6 @@
       "keccak256": "0x50ef3d1b3b5ffe3bd51cd33ca08de4084b18bbf3aa8678bb190655e1c903fa4c",
       "sha256": "0xad5a8b9b9eb385ccdc7ca79b1b2f58dba877cd85519faeaf016202100aaedca6",
       "urls": [
-        "bzzr://a9675aa25caa176c008e93b38be2c0235734dfbe22d7c348356e5c7dca70541f",
         "dweb:/ipfs/QmbzsnBDoZBvubgegguD2Em7MvAGS2ELGB2NuTe5scZqn9"
       ]
     },
@@ -15870,7 +14643,6 @@
       "keccak256": "0x9de700778ac70566719002357d44c401c9807e4154b109b3fa9f47ecd3db3512",
       "sha256": "0x27665f3f8872ce0626121ac575af0f8d89f8b348189532e6ee0ff5bab6afb658",
       "urls": [
-        "bzzr://5d999ce92268c2cddf7699b2597c14792869f29625220e6f06b705a0bb09fcc1",
         "dweb:/ipfs/QmVLEbVGsvXvbywZcYem3dLyGTknHuykozRYVuZAMQWPGi"
       ]
     },
@@ -15883,7 +14655,6 @@
       "keccak256": "0xddf282b1a117a815085c52aed28b574ab269c9371eaab34e402645f6bd874d49",
       "sha256": "0x805633d54ce5c8d8211df0ad8ba534bc69efe61a5e8049bc5c51c8133018182b",
       "urls": [
-        "bzzr://ec34b00a30fe871d633f8aec95e0cf1739c85aaa5ef6f81977056a4396bbdfb5",
         "dweb:/ipfs/QmYCG2BHS3Ym3EzKuVo9KJfkbjuVsnYWpNeVxdUVf8jbLS"
       ]
     },
@@ -15896,7 +14667,6 @@
       "keccak256": "0x34e1eb1fc3abdb41d668e1af187d38ea40223218feccc3029856564b193bb91e",
       "sha256": "0xe2e93f0092200aec90d619b6b601de8e4ea5a1a73980100b8552baf6dbb9bafd",
       "urls": [
-        "bzzr://caa06af241e2ad72572d65725d36ebf08bda31331ed9da6a018e5e5a45005b65",
         "dweb:/ipfs/QmX1Q7VVhGrFCGaT5gpkaFf5DKcGWTNDi5Yv1kTCWvPtju"
       ]
     },
@@ -15909,7 +14679,6 @@
       "keccak256": "0x5a4cfeca0c30e1e732113587ca204c0cb72c8af842912af16217dc5c6ba22440",
       "sha256": "0x016c572379a728a7c3e4d498533bec84a34f8c5b46025497cc592b1bc1f0db38",
       "urls": [
-        "bzzr://1fc1da5ca441f6f3731c3402c7ac0640ebc516691f41072e206fc6162f664112",
         "dweb:/ipfs/QmQuqqisPytX2wc45skna7t6bXQ3qrT3M3XbBkDRhcQmAH"
       ]
     },
@@ -15922,7 +14691,6 @@
       "keccak256": "0x5975dd901c960d4c41075eb6bb38a2e96c4e89da356ead06af3e79b7d79d8a86",
       "sha256": "0x47c7c22596e5501b3364a6a700efa4bdecc03391b0894761cb5592deb670178e",
       "urls": [
-        "bzzr://9e107855c31f04076a8a593eb842de4f4403576ad47a11a90b8fd0a6be81979e",
         "dweb:/ipfs/QmRCJo6HYqt9UtQVqbujvXePnMWCVRGyN19oqGRFiLEb2K"
       ]
     },
@@ -15935,7 +14703,6 @@
       "keccak256": "0x9b5847c79175a7f524da01f6af177f21325267baed25b79a458243851cba78ae",
       "sha256": "0x80ab3a685bce5e3b8691077840874d4c2f3ae5506951f5379d0e296382195c60",
       "urls": [
-        "bzzr://972544ab43aa9dbcd95022110b9b8f9af9b43ad24ce8ef3045d7f996693cece7",
         "dweb:/ipfs/QmcVTKWX9A3rfPk4sEmnaUGdBBGQGhYxqNvh12cANWE9hj"
       ]
     },
@@ -15948,7 +14715,6 @@
       "keccak256": "0x444c03a30962b59b6e8ae227f827aabeec13167ca0bd2d1d7055581b7d8623c8",
       "sha256": "0x88639444a6a255e3d580f10d7d20e858eb637d7087f43617df34c4a2dd5d784e",
       "urls": [
-        "bzzr://55046e6d3e1f130d998ec4171d6876c791f855c0040d8a0f8a4b6902fd2bc837",
         "dweb:/ipfs/QmZxJsm5LHXCi4XU3dnCKuxmhUrN8tQ4Fxq3XoP2VqvA3X"
       ]
     },
@@ -15961,7 +14727,6 @@
       "keccak256": "0x5bd14ebdf7b70b15d39b0c54c8510eca44f7754c80ae3af415f14bb039883112",
       "sha256": "0xd000ee1b9ed78ca2ea688b58c6cb16ed7951d684a00b60e7aa4a9b205f96ebe6",
       "urls": [
-        "bzzr://12b78c5f18fcf6f490dbbda533d4e2824a1c069cbf736a48b2c9392c56edad55",
         "dweb:/ipfs/QmUJM5C7f53DBpw9NYN8ahbX7emxTT2fMPdAUtbHjxqeZk"
       ]
     },
@@ -15973,7 +14738,6 @@
       "keccak256": "0x6d6d75b033717aae0a728e527005d8d2cc7dbd0a835c8873c630a2a9689a2976",
       "sha256": "0x4af595f976235d33a22ffe223e9e3210b4ca510f6a93f153b3daed60f2b11fbc",
       "urls": [
-        "bzzr://d501ee8c460db75379b5716bcb5ae10e3e32625d6c9b08e319822a110f178906",
         "dweb:/ipfs/QmNWkyirqXy3gDHNXpPuVUbExMGWjMqPR82Xzs64RzgQzy"
       ]
     },
@@ -15986,7 +14750,6 @@
       "keccak256": "0x11d0c9128e4a0b51deb8b3bdc3d7ed94723168b980fcb90d42ce9c59a395262f",
       "sha256": "0x100b0e43e437d90991b9b0e37c0832448c4c29e3a24cdfa1300e237f114d6c45",
       "urls": [
-        "bzzr://65d9ed65dde2ac1cabcb3854488b8c343518dd56e6070465301041e774cd705a",
         "dweb:/ipfs/QmdioCEdaSNqwaagGSCd44b82eeUozHe1xXExpUMdZ79SX"
       ]
     },
@@ -15999,7 +14762,6 @@
       "keccak256": "0x74073492bbf37358b472f3d04c8900f988983445286f8c58ab67a39bece17443",
       "sha256": "0xd6689ce982d2e303dd81c43d4466dbb703508bfac6ae0568f8bcd890633c11d4",
       "urls": [
-        "bzzr://e3701f39fedb80d827a5e64b7d62cc48122554f83dae82937c4a7412d31b223c",
         "dweb:/ipfs/QmPY91YEKCjiu843tbRNGekBNyXFcBi9nXazSXZ3EXuU7m"
       ]
     },
@@ -16012,7 +14774,6 @@
       "keccak256": "0x112ad59e28036aa064bb95ec831799593b495200365be54ad0e8ebfb4f132bae",
       "sha256": "0xc96a4406c8ab0e5e0db04f136a69d2797616d671c60909225922f4beef4cd3d5",
       "urls": [
-        "bzzr://434faadf9aac680573dde53ae486303050701d41fd5e9155f440c0fec56afea3",
         "dweb:/ipfs/Qmc3rXUrD2vvykYV4AjgLKWQBBXGTfbLCfN2MspgHwdtnM"
       ]
     },
@@ -16025,7 +14786,6 @@
       "keccak256": "0x493d25ff39ff34f9695be37e5df4bd8aee625da7d0ad256569cc7e02f5df670e",
       "sha256": "0x5b018c0af11681c50c407d4cc6b92825966f6d12a82a813ccd09e7b211f9f199",
       "urls": [
-        "bzzr://1ec30e6b4ba2f7a8d337cb409c5138a0df427261ca55b3716bcf76d4565f1b2f",
         "dweb:/ipfs/QmcmCJLU4NGBpftTmud6dZRbXZ2hjd6A8piCSoCgyVEf9N"
       ]
     },
@@ -16038,7 +14798,6 @@
       "keccak256": "0xff3ca5ab3b7d60d8de1fbceca802a06c16f090b5a965e4a41f181925873250c1",
       "sha256": "0x5e0fd49a6d45091879e15831b450123b3299330ae7fb4870c0d3152e80b3767a",
       "urls": [
-        "bzzr://6370f0e527eef7c4f7cf5754974e8eb6366e798979835dae383f6b654edda34d",
         "dweb:/ipfs/QmaJqUf1BWeNkAhBRsJrkZEEqx9gst9KPEuo1NaN7AoQL2"
       ]
     },
@@ -16050,7 +14809,6 @@
       "keccak256": "0x070e41c7f761ff1a8383a2c0d54c22aab0f115ca8c3790ecea27d6dde11611ca",
       "sha256": "0x06a671efd8865a6ecc0ad648076177b35abcd06a7059888ea65111272e33a57f",
       "urls": [
-        "bzzr://e4f8176cdb3a0f3ba0b7061079dd9d3495f6a2288bd724780337cacd96515148",
         "dweb:/ipfs/QmQre11ZPgWSx79Jzca1tkTYFyMbXz8H4kcrhfpWSj4qs8"
       ]
     },
@@ -16063,7 +14821,6 @@
       "keccak256": "0x8c1e691e3c03835657fd026d883a1d0e8dc91e0e4077b187e97ecd2eb5155e4c",
       "sha256": "0x6afb26b4e8e0f83f729a0f34ec721c5f194fca17500271811650bdb82bfca763",
       "urls": [
-        "bzzr://ebc9aad0d42d36d6a583f027a65c699b18f6764fd64a38f6f7e502c067ca1aac",
         "dweb:/ipfs/QmVhxcejWtDtTyEsfJSJn3PmtxMiL67Mcdq9euF8EnDsfE"
       ]
     },
@@ -16076,7 +14833,6 @@
       "keccak256": "0xc84f115c0ffea0d6ed3a652cf7c052d162441ac4519786e5fa0594575c2a2da9",
       "sha256": "0xf7577f3ba35e295f75ec5710aa2441800d0b0dd5284096de857c344b28583cda",
       "urls": [
-        "bzzr://524d5cf4d77660ce1f7148669d442811a9f644aa68c7e46d672758eefef081b1",
         "dweb:/ipfs/QmRFT9zAULAVsdg4UypLi5nq8M4oMfg56vgDoF6RBzoDM9"
       ]
     },
@@ -16089,7 +14845,6 @@
       "keccak256": "0x67d21887ffd506b975fd6d1ad7a659151bce9ee062bb2bae041655c4bc3c3c66",
       "sha256": "0x55d6dbc79b1e0dcb7e1eeb4ec0ac05d03e309aea23ecb27ddc5b22b8e0c57c07",
       "urls": [
-        "bzzr://9e2360121187c6642a622174232ec3b5fe1b2039367a27cb501f0c0a854aaae9",
         "dweb:/ipfs/QmV8ZbvrmyUQN2R4YZSzsvNrjwTU6xD9g4f4XdnfsAYUqM"
       ]
     },
@@ -16102,7 +14857,6 @@
       "keccak256": "0xde71ad0281b39212336ba2b39e4b6e2005eb287df5293f2403dd121943b5e903",
       "sha256": "0x6a43aab1cdbbe3a15f15a9f3ac138432abafa34ef53bbaa497999ffd92f77c16",
       "urls": [
-        "bzzr://5d3bd1a89136a0b7bfdd87cff5100da0b8a90209f3e6030636e715521ac91502",
         "dweb:/ipfs/QmTyKeryynX3QPB7TfLoHoKxPk6qzKCZWfmDEN8LZV98ba"
       ]
     },
@@ -16115,7 +14869,6 @@
       "keccak256": "0x9e4d310b1670690c0d15ee94b10cfcd0504238c1afaae9d7ec76708201cf65aa",
       "sha256": "0x27c50b5afcd423173885c1e8528fd2838e831155b438102d1625bc6021525d8b",
       "urls": [
-        "bzzr://96ce985530b930528c3c6e362b3e075497af799f95f03912a68224dc6564df18",
         "dweb:/ipfs/QmPkhNN4BRTEC5eVTrwgAkmytXWosppAAgWyus2UPZ2TEB"
       ]
     },
@@ -16128,7 +14881,6 @@
       "keccak256": "0x774dd51625bea7180ec3c02ad6f2e3b38f6481b08b7de416c5977291ca5ddce3",
       "sha256": "0x1a8400afe80766793f2b265762ab5e9e175c96ca7986d53c47206c8c9537f054",
       "urls": [
-        "bzzr://b5a683f95ba51c81a8ea79b0d987f8f85708954911b5147e4e6678709d037613",
         "dweb:/ipfs/QmXYso4txQWPDEh5aVZp2WM5r2oSige1fhF3GHHUSXBYit"
       ]
     },
@@ -16141,7 +14893,6 @@
       "keccak256": "0x2b3f3f70b8b98a0cd5cf60af0d62c6aad7351f1e428e4ff1eea573b6ade81b01",
       "sha256": "0xbd0b3ae3ac53c1e2ceae064f38bb6748784ef149bf1bd2e21b824b3c36b052e5",
       "urls": [
-        "bzzr://c449e7bb4ab64fbeaf894c08fc4cb08724fedb8fd5dafa7b0e4e0289fa3357ef",
         "dweb:/ipfs/QmWCLNbkkRU1zCcoQMtMiCVtMLJVEaDiAsxQSfXARmnjFj"
       ]
     },
@@ -16154,7 +14905,6 @@
       "keccak256": "0x7cff364917fc49bf244a44901289538bab1a9600c04aeecb666cd273006ba8d6",
       "sha256": "0xefc3f3f3b5755124b6c6012e55e2c3571252c7d15893903ca6add614f47f5596",
       "urls": [
-        "bzzr://0d5c08df01411587fe19f4b2ebbc4b7ee29f6a83fe4eadbc3aed82f75016b419",
         "dweb:/ipfs/QmTWXoqiTKipXTRv6USmXpVPwqase6qqXiL3hza8udMAnV"
       ]
     },
@@ -16167,7 +14917,6 @@
       "keccak256": "0x4edc70c69cea5ffc48f7c60c4b4bb9a88108da6c0dcd9c9f3b851fdb7d8bbff9",
       "sha256": "0x806840f8703be639bee5fa248f23a3522333340e51b4b9f2f2f12991c9a33aae",
       "urls": [
-        "bzzr://3539a51ae1dd44c20299818c877e09811e4dedc7e44403a1726b3a5c1064deb4",
         "dweb:/ipfs/QmT57K75ydFsz4bTuKC6JrFXcYgZJ1AUKAdk227Pp41N4z"
       ]
     },
@@ -16180,7 +14929,6 @@
       "keccak256": "0xafee76254b2a4c3d7e4793377d921e5507584a3db82f8d1578f33d3093cc03f1",
       "sha256": "0x6c6fceac89822699d73e46db2eb39fd392ba21e7a8bd2aeaf8a181d8d98f6761",
       "urls": [
-        "bzzr://68f775dc368ffebf467f4f3e343f26bd3a440454fca41ea289f8eab4e8a207c4",
         "dweb:/ipfs/QmUx2VBEitVdnahF8jARhSJ8aidKifwT9S11Na818hrLuD"
       ]
     },
@@ -16193,7 +14941,6 @@
       "keccak256": "0xfe29c020bad23efc138dbdfd2e539ca06363c976c4cf7b1df8a7d693ff6a839d",
       "sha256": "0xc57298d295e17609e661598ebb97cc8a798073bbc0e6733225ffbf02a7b5da36",
       "urls": [
-        "bzzr://739bf73fe4b7eaa3cce8d5756c313be367cb403e8ee1b078a74cd36dfd03234c",
         "dweb:/ipfs/QmRge8WmQKKN85E3Zc66DttZuF5dwhegRu2jQLWHWitmZB"
       ]
     },
@@ -16206,7 +14953,6 @@
       "keccak256": "0xe7ceb192cca61e5a0c5d0f5eb10475f2618d325a1150242414fcc22eb65985ad",
       "sha256": "0xf82b48c7c8b0b35c91865a09ee7467f843923f69a9eb94cf154181861bbbb241",
       "urls": [
-        "bzzr://65973f916c284c2ace27d2afe7b7483233b00f86313e390423d67d78f8b6baf9",
         "dweb:/ipfs/QmQ1567je6h6J4BPWC1KGzvZQK1nrc6GZ7cjgU2PUetyob"
       ]
     },
@@ -16219,7 +14965,6 @@
       "keccak256": "0x45b5e77c9e3795e7aa08bda3a23399bd9ac1f4ffbea03f99b6a574e51af94a67",
       "sha256": "0xc3b920f1d9a5da0aa391a75039d14c654abd31354931eafc5ad1f489d41e8959",
       "urls": [
-        "bzzr://9b1ca11dcbc85bc6ede615b9395f5118c2b6009529bc55539b9a7cfec0c37c4c",
         "dweb:/ipfs/QmPnVBNQj7H7QwfQBDQrfp3juHSSKbtFr9WJPWifvbVZbT"
       ]
     },
@@ -16232,7 +14977,6 @@
       "keccak256": "0xab9165665669b2673884a2e7ed64e35c01457352cc709838920570868fd32ed4",
       "sha256": "0x222f3cd5b8ebbd6e433e73f4bf15168bdf51d564a64b0eec3b5423337eb40c07",
       "urls": [
-        "bzzr://2d1ca39909f6b77dd1520957dd866296f1e2645c1cf5cef2529b9b14071b8742",
         "dweb:/ipfs/QmcyBuVvuP41h1doYqS51XugYM4w2zL7XsM88et8dUcSBP"
       ]
     },
@@ -16245,7 +14989,6 @@
       "keccak256": "0x445ef3fb3bb640844fad7f13c4e41fcb86ebc77bf014d43af7790d0f1a698fa5",
       "sha256": "0x5e94faaed7a49b28b5865e4485197c7b7d42c03ff2994df20f88282f04c5dfcb",
       "urls": [
-        "bzzr://8786b7d60e4ae111d18e627c0680d1ac6c1ffaba7539450b22394d33beda8039",
         "dweb:/ipfs/QmXRozvVQBLkwegMRfDNHe6uFuUVqDtLVpCVKFKsXEv2we"
       ]
     },
@@ -16258,7 +15001,6 @@
       "keccak256": "0x98dc39aa3ec29c4bc2b9227e1325a4ebd2a499fd8dc4f27e9ae57191e16c125c",
       "sha256": "0x0cac2dfbc54f7c6205ab66d27568f5cd1efa6fcefc1e0504c0ba39a80d438163",
       "urls": [
-        "bzzr://9f555d0e24491c8d04c16025901b20ace10c6d78a3ddd5b2ebfa6e0b87056b69",
         "dweb:/ipfs/QmfJv7521XNJhntdbNeE9ZS5i87qUMHYfM5f7DzPkvRK4H"
       ]
     },
@@ -16271,7 +15013,6 @@
       "keccak256": "0x8e5503cfe93a27374b984cbe34cb2ac31652c79a9d988eb1b4f129e908a89308",
       "sha256": "0x9ccc14a53ae9c546958cb222448d4b2e41abdf2d70d3ac378063418f10295be2",
       "urls": [
-        "bzzr://2473c26782bc9786d070f4be1ab16596538fb2397451c286f840917c52b9e499",
         "dweb:/ipfs/QmXBbA5BgzD4pcmNL7YHJRwzTSednsafzgRpKupiyrtSrb"
       ]
     },
@@ -16284,7 +15025,6 @@
       "keccak256": "0xd8289e591d92694d79f65ba9ce8ef9b7f774d86a4e72ed112adeb1656dedcd89",
       "sha256": "0xc3c3e57b87678c2c5e62da580a8642c21603ef6898d25ff9c40f1228605f7e7b",
       "urls": [
-        "bzzr://8029980d3030f991def66546223411539e107ddf7c0dd258aa3f9394b1dbf675",
         "dweb:/ipfs/QmUN5JEXMMJpzFDMgd49ZfQXAFesaPy17sU1k8f5nVAYdC"
       ]
     },
@@ -16297,7 +15037,6 @@
       "keccak256": "0x2b55eb95003941336bd73da320fd1f73a701017e4d9a5b9fc61ace29bf9e5167",
       "sha256": "0xb1d15e3416d71f9ff73d813df53debbe5dd6839ed4bd78c60ee3a09cbe34d3b5",
       "urls": [
-        "bzzr://84f7154168113b25762972a673bfaa08866ca1b8baa3765b103306faf06861a1",
         "dweb:/ipfs/Qma8dBaMFrQfzDxAkbrqGidjv5tiRJm6LMdc9BcRspxiuD"
       ]
     },
@@ -16310,7 +15049,6 @@
       "keccak256": "0xb7d9535df47b449e092f5112bd51b5a5189861b999a1d48a0e0eebd3a444a6a2",
       "sha256": "0x276ef88bf7f2d35508dce8ad74afd012aaf7d23b2a7d26ad93814999eae28aca",
       "urls": [
-        "bzzr://7778f3dfd0446be8b63f021a91f121e23b43d08ef46065f9529c866114201a6a",
         "dweb:/ipfs/QmXJvNjY3nMT7hP33B9EmSpAGRV6v1CuQsYuoZ2Q8KRCzX"
       ]
     },
@@ -16323,7 +15061,6 @@
       "keccak256": "0x1745bb165fc451bc62a24faa3b721cbeaa410f12df57c9a5fd9073ebd6639ed6",
       "sha256": "0xa597ff29588a3461435d5cc09f3790f712adb0cd7aa5af763405b577e4e0ba72",
       "urls": [
-        "bzzr://050e62153c2bbf3e5596fe469c3d2ec4c3d259b74e864374781e5fbc5fcb4d9f",
         "dweb:/ipfs/Qma676ssC4Ryc5sNSJ74HJCQ3NbZaSVXbv4EQ4n7RCsL2x"
       ]
     },
@@ -16336,7 +15073,6 @@
       "keccak256": "0x560fbf0908f1888636791f449023ba3b117bbff84a019317e88f954fc27db3e7",
       "sha256": "0xdcd1b7b65fe1c62c7f4d3f55d8cbd126bb0bcd3675576648e96836df80855b9e",
       "urls": [
-        "bzzr://d3a401214d5d789ec6716347d7006b0ffdbb0355458ce3e2e60e59a1168df202",
         "dweb:/ipfs/QmPB3gjLoiG1XbnroPSNpuUgNaDz31nopHneLv4ixe7ATT"
       ]
     },
@@ -16349,7 +15085,6 @@
       "keccak256": "0xb4cb106b829dbd9ff49018ed9645d714ac91fb2f35af3bed8a04b52baa2d299a",
       "sha256": "0xf4874d377b9a8661de6e0f6269792c82ad5d0d086d85a9301fdaabd7f3d60073",
       "urls": [
-        "bzzr://3e510f297af9aa766379ee674cb8b561184acdddf24621e96be23c3c34983b09",
         "dweb:/ipfs/QmXYRetER2Li3i2GGAbgCwH1WocL6cN22hUa6VRjwkbqDe"
       ]
     },
@@ -16362,7 +15097,6 @@
       "keccak256": "0x1efef014903b8d81443205f25e5e2365708e10ac2c55ed0fde05eef85baa974b",
       "sha256": "0x77d408647006841c09d6f15667a636e09ed22b38b38bc66fc9c3cc4f551eeaac",
       "urls": [
-        "bzzr://e23b6ba55a07c2abeeedb0cc60ebdf333a648fab6683bd387ce03a2a528cd44b",
         "dweb:/ipfs/QmbjWRDJ2mzPqP5ADsptdMDNQ2K3eGyqcovn5akNhZBXVj"
       ]
     },
@@ -16375,7 +15109,6 @@
       "keccak256": "0x33379658780fcc6713009ea00834ecdb967d326ceabfe3ec2690e5c562095f9b",
       "sha256": "0xf076773d5ff0718a9509b77189cea4c50fc671b26c6feab9bbe541174bb435f3",
       "urls": [
-        "bzzr://b0b898c9fa094be188b3d4b3a2db3f5b40360be2fadd3320abbc4567fa829240",
         "dweb:/ipfs/QmYE2udYzmiCvq62swzaVcgZFqBYnLauqfSUm9W1NNjNF7"
       ]
     },
@@ -16388,7 +15121,6 @@
       "keccak256": "0xb0549200deefefcbf0418abbc3aee5af6e1e33a1f046a299c8d9c45b85b752ed",
       "sha256": "0xcf9929031281574d13480d8bbb6cad57e5b5e623ff7e962397691dc9b683151f",
       "urls": [
-        "bzzr://09ead148419767ae30f5d4269573f977fd085f8c8d04c71b9ca46da3f46b967f",
         "dweb:/ipfs/QmR5TGXz5g1EcQeU3yZrDVhPM3T5mSckQWubSwDUDFoPCc"
       ]
     },
@@ -16401,7 +15133,6 @@
       "keccak256": "0xf79615cb7477e910dd6d152b85366bb00254e9b5d0f829db9dd99135fd91e103",
       "sha256": "0x6f26e222752105b2f2c05f08cdba8b32401dac54749eaf39460e2bd85c5e3867",
       "urls": [
-        "bzzr://78930769cfdc7b7d4984bc87662f3666f727d346cc0c7582fee59ea442f36e76",
         "dweb:/ipfs/QmWR1DN9gqE36UmzLt1mp2NqcNQwM4RfNm9eh5ZV1569Fr"
       ]
     },
@@ -16414,7 +15145,6 @@
       "keccak256": "0x050abe653b5034cf8d1326e64dbab2c0772cca216b1ddff9700005f0b687a06f",
       "sha256": "0x2d5afc5b27f6d1fca1dbdccf1dd4e9807b7551b9e8236698646e36f04e70c0ed",
       "urls": [
-        "bzzr://76c748a394dea2fefe8052b7bb27aeb0af332ed85c98c9d9a2fc2030dc7facfb",
         "dweb:/ipfs/QmRG7F3T9eNxRfQrCE1i3Wjdt8P5rPnVfSs2jgJDdnAW6Y"
       ]
     },
@@ -16427,7 +15157,6 @@
       "keccak256": "0x0e469a1571e2aa66433143c5b9b3a20784b108c2c6ec431eb378556dd50a0b5c",
       "sha256": "0xc92e6827d0c8543a596b76622a00ddcd9326a1937ac57e931b276edff0e5a289",
       "urls": [
-        "bzzr://e575400fe9e530c5ee3b23a6a9566a00141866fd423c4f9a11fce284aa95519a",
         "dweb:/ipfs/QmddqWhRywxKfonhdEMJgK2CPoFjfNftcYSW72DcVyMXRR"
       ]
     },
@@ -16439,7 +15168,6 @@
       "keccak256": "0x8d6be9e58c33d265b5a8b1132a27fce126067419f3f4f15d3ef6b7147593b61d",
       "sha256": "0x663ba99f7c7ee907f0f03227502d48a78256c3c292ace3b79a5d3eb510665306",
       "urls": [
-        "bzzr://0bdbad1bdcc3a9775f16f20a35556be4baa0e6c9a9b9d820e8e2cdea80667c6a",
         "dweb:/ipfs/QmYv3Rsi9pL6PZAtc4XLHezPqti8yCRGEdDBqzEsQv57GV"
       ]
     },
@@ -16452,7 +15180,6 @@
       "keccak256": "0x35314a2dbf71cb70a7d33d917f190afff338ddfa6ed848a5ee37dae3670c8c2d",
       "sha256": "0xbb76ecf59eb837d88cd6ddad9059fe7d8c26e58d936a5934b7bab377e84a03d0",
       "urls": [
-        "bzzr://2659bba46717d61a964563bfeaa3579583ec1a589c25dfd13860283a2e66e5b1",
         "dweb:/ipfs/QmQnsAfXwk4TqVCwwJVZmjzobxBwHmBhLMrrLdMAhbp5oU"
       ]
     },
@@ -16465,7 +15192,6 @@
       "keccak256": "0xee9cc3950896d787e48c8d7c1e3b22e18db80dfa659ce27e24543d8bba060afe",
       "sha256": "0x6d7b6068b2bd7ecbcea0878ca19e7b5d8fb9b9b7744671cb5de38ee88be1ae44",
       "urls": [
-        "bzzr://3562d9fa2765495bf2c2693358b8c79fe7bc1b4ee93a6c507b3dbcdabebd34d4",
         "dweb:/ipfs/QmUvZdfnmtVfJoVcQT6pV4QCD5HnyUEkXXMemmqbcFdJ2B"
       ]
     },
@@ -16478,7 +15204,6 @@
       "keccak256": "0x2a50c6b7c869450404e83a5ff8698c6efddb89d8c703bbb41e1578f42a3f8c2b",
       "sha256": "0x985d396862e79aff8163edeb0a1450d1935eaa1935d0249eb7ad45df0f2e1b06",
       "urls": [
-        "bzzr://e09d79f13c32dc601bbf2405053b4e8cfbe96ea8f1064226f72b38dafbfd85db",
         "dweb:/ipfs/QmUxDGfkyMprTNHGMh2BoXH8pTN3LWGrMpi9sgi9XA1UPb"
       ]
     },
@@ -16491,7 +15216,6 @@
       "keccak256": "0x26800ffe0a6aea0601f73f3675a059ac2cd817e01d5f72c14d611479d05e632a",
       "sha256": "0x81b42e8562e00ce23ae674424eebd73773bac7d6d8dff3822e056e1bd43013c0",
       "urls": [
-        "bzzr://1c59229b9ae3d4b1d4f852a6c7de4298477bf5947ac110cce8187b4e197ba855",
         "dweb:/ipfs/QmfH7cSpg2JTLzEMAebQdPHraBbr1azvBLN5hgdDRCkuwT"
       ]
     },
@@ -16504,7 +15228,6 @@
       "keccak256": "0xd74c4ec1f160d84404d0f897d36871929bb8eb3a73c9ca0c45766237a758bfa7",
       "sha256": "0x8ae7f59979ba3f4f0c3b48fc3e9b8420b440635b6586ddf4012a05399a432668",
       "urls": [
-        "bzzr://8bf197b084b44d1bf256aba58c0e2ed1befe13f178051f4bea490b336339f397",
         "dweb:/ipfs/QmdrSWkGQesrDEQzb4aMrjxZdY6AHaVMaLUYmmDezkZWbN"
       ]
     },
@@ -16517,7 +15240,6 @@
       "keccak256": "0x3392e7f5f9715df5e803765fc2ffb1ca687ca639363a5769cea96056dcdf7cdb",
       "sha256": "0x02805fb644b1b863cc6ad352c44f893e2e037d342724019746854b1828d06478",
       "urls": [
-        "bzzr://272ea9871f7c150ec7e46866488068f58f9ed5967a1581c310a8ee1d560015ab",
         "dweb:/ipfs/QmUpDW67wU8FGXboNQXtzcrwvvaZFNWS5Lhtqzni1ac7YW"
       ]
     },
@@ -16530,7 +15252,6 @@
       "keccak256": "0x37b9a0bb3363e76ff2f3d4cffe6a26b9905440a1b9a41c15e5fb47f0fe185230",
       "sha256": "0x95952cc07eede5331c15c4311de7adc9073767dec10ab5ff34cca5049f88b51c",
       "urls": [
-        "bzzr://0a9cafe5f42462dc2ac7bc86a7c2867f7074a518cb4aeb3d03021be232c990e7",
         "dweb:/ipfs/QmcpgCAsPtX3gSSacKpBrcVDRtutoTNuLsNQ5dfaPdfaZ6"
       ]
     },
@@ -16543,7 +15264,6 @@
       "keccak256": "0x8b7ae6153ca9221b0c1b05fdea399d05eb38996cff3dd5b9134dc202e1458d86",
       "sha256": "0xc1b318bd4d8dbd22d584d7a73585a3f908364f22bb889071169bff8a0bb45172",
       "urls": [
-        "bzzr://5daff62479dfdda04bbe111066a9e6858cd601c52fd2662f27176947e86715b7",
         "dweb:/ipfs/QmYRBADFwTWstSYAJ9VoMQK84WaCPbAjzsTurdQqjzMDze"
       ]
     },
@@ -16556,7 +15276,6 @@
       "keccak256": "0x40b7d096aa53ddfe8e6fb1d5ed34494172bb1f2fcee16ad54f0f467858d4bff3",
       "sha256": "0xc82efe8a8e16491d7996e14279d71f0a9471f812a5aac050c86d15ee5c0b1796",
       "urls": [
-        "bzzr://cf06637d094488e025487abd4baeb6f86a4ca32e117d47f50c5cdc795237ed94",
         "dweb:/ipfs/QmbKSubRo5npQ5PHLkygxakWqsWBFB7mBmdfFkd6hyZzBi"
       ]
     },
@@ -16569,7 +15288,6 @@
       "keccak256": "0xa78f58c1c0693596873319a472fa899cd0b2c0808bcf773484de624b979a5520",
       "sha256": "0xb2a26c297fd8794619212615aa849e33640a3f697b5477b923f410d0477c3b25",
       "urls": [
-        "bzzr://2b156e4c44424700f8015fa8fd4a95641558a21d96244ad48ced02cb6a042773",
         "dweb:/ipfs/QmRhvKu3brteKUMzERwWHSSETuphMcZFhNgESwaXBAseA9"
       ]
     },
@@ -16582,7 +15300,6 @@
       "keccak256": "0x6aed552802e9760e99c76a59d7eaddca3c09215c864550c37c654680b9e38f27",
       "sha256": "0x010d3f094cf0f0972924ef720b4057bf1755701fd086a54781f545f9e0726a10",
       "urls": [
-        "bzzr://d0b86b765d3713d4f2f727ea9119f43f3d9063e6fcca1d2166e20fe23c27277d",
         "dweb:/ipfs/Qmbg6WhK2EXiV2yWGUuUYvw57F4QqtqSn52P4Wt92otUQ4"
       ]
     },
@@ -16595,7 +15312,6 @@
       "keccak256": "0xdcb997044de21fe80101833f9cb6527ee25c8d5e5e9ca02d975821fd7c6b13bc",
       "sha256": "0xcef8cdcd40fe8e66adf4bfcd0377ed3da6e5dae048ac1e20b0870113dbd15058",
       "urls": [
-        "bzzr://d0a8527b289f6f5964e360bb7e3810ff5b83eadeb617d0c54b3300e8764e8844",
         "dweb:/ipfs/QmZXnXZVFhvK9wb7gzDaN5mVbDBhvWTjDWHeguMpupG7wt"
       ]
     },
@@ -16608,7 +15324,6 @@
       "keccak256": "0x32e6b88af5549bc052749e2ad3f9aa287a08c5904c7de6f474b8a6c3ca1a8cbd",
       "sha256": "0x7ebfadcc43a421bdf3c20d769a197063586a74a5557481036221ec9430f0ac87",
       "urls": [
-        "bzzr://811b2eeaa62698d4c44cfbc2cee92ed156c804f028dcc7bc4482f4b1998cb291",
         "dweb:/ipfs/QmfN21UYWJo1wF7x57uvQcGshTahLKirmrRBsv9Yq8KgF8"
       ]
     },
@@ -16621,7 +15336,6 @@
       "keccak256": "0xcceed635ce31f1b2dcae91ac48b09106e89fb50f9bf5edce930ee0b0ec3143eb",
       "sha256": "0x701cd415858e8fd62cf367787b38f9f4fa8d2fcafa27e895e77ea0bcb32405d5",
       "urls": [
-        "bzzr://3fef1c0355c1c4f45302fa3ab047d7b14a1beae9b8fa6ce796d4be9511643cb3",
         "dweb:/ipfs/QmQR1iqgdPAtDVWLY5MYmdXb8vMHHkYm5be2SF9FHnFEb4"
       ]
     },
@@ -16634,7 +15348,6 @@
       "keccak256": "0x5fb9b5fb6190fe30f103aaabe4a10262f100e49df1fbdeef5744b2fd8ef97043",
       "sha256": "0x74341af2ebe10a5d3da249840db4457b835b1459cd19914af236b238309b3051",
       "urls": [
-        "bzzr://64a962a4d626cf5b7a57abc5b426820031a3e5a3ba9a9abd266217ae65ae97ff",
         "dweb:/ipfs/QmVXWA1vBmwbGpUPAbj1SCBVY9JfMhjWH36F3qFnHV27q9"
       ]
     },
@@ -16647,7 +15360,6 @@
       "keccak256": "0x21c6dfe3480a854d63289fa9ca9050134ba981aeff51dcb634af2a5b61e9206a",
       "sha256": "0x61f29ee584209207224082de39fe51cfc8da8bfa6a7999089a3462c2916b1fee",
       "urls": [
-        "bzzr://10b6489809950a5b9403016289d4179efec2c4c3d6d3356c38e11784f857fa8a",
         "dweb:/ipfs/QmPeRuniSVKdQsubL6vjWyWsDeSH76UWQLXLd2TzTiqdAx"
       ]
     },
@@ -16660,7 +15372,6 @@
       "keccak256": "0xea512c6206b2f246a6e47249fc29c8628f55d38ec02a759199f5d12293af7cb8",
       "sha256": "0xcd0408296affd965c2f6c685114c57e39722cd350c68053e9afc5cb1ae01d98e",
       "urls": [
-        "bzzr://cc65a0efa06ec1b6dfcf2915adcc07f7ff0166325ab63c673620979290e9d92a",
         "dweb:/ipfs/QmV6M6mypksdotqoi3Win8UkJS2FwcCKpYCE9E7HWAhUA8"
       ]
     },
@@ -16673,7 +15384,6 @@
       "keccak256": "0x6d925a976c8e669ccf2291a41dab94a2aa9943dee09758ad21c6da5bc6c6ac45",
       "sha256": "0x45ced6081d6535aac1285136872482facc49015ffc51963336e49e68adf99782",
       "urls": [
-        "bzzr://75de0d519e588f546fb8d554444bffcf1a9a87cd90bf2ef6cebcf66a9459b832",
         "dweb:/ipfs/QmeNd5eYf1HmejGJLR6E8Xnooxhc5u6W89f8xxypsDFwG1"
       ]
     },
@@ -16686,7 +15396,6 @@
       "keccak256": "0x835267015822d6847c583a1b007aaaea8a68b00d6a6ff275780b9e24cdd50542",
       "sha256": "0xd54e008568a41a72d7f4df6fd8222c1f5f7a90a149ca5ea010c3aa27f9d7caa9",
       "urls": [
-        "bzzr://53516dd02764e31d0b906c4a3a24c4d42ec835d971ca80a211a15454e3688a15",
         "dweb:/ipfs/QmYo9c6qyXigffU3a2dsvy71ykvqEZ6Nm8jpd8ESDGZg9s"
       ]
     },
@@ -16699,7 +15408,6 @@
       "keccak256": "0xac9ab543505cb91d3ac7b57bc0afb4e78888f9f68b9146432be3bf5296a6a703",
       "sha256": "0xd1b83b7d2f49e813df5338687c341ddaf8be7b47a0490518458fd1e79e62e9de",
       "urls": [
-        "bzzr://6493fef25af2df9d671f90a8b8950aaa325c067b410acd570523e3333cb510a1",
         "dweb:/ipfs/QmRAVGzfddeZFRpuScgC3qRBcaGdGJAP5jjqF6hN5Dgu6W"
       ]
     },
@@ -16712,7 +15420,6 @@
       "keccak256": "0xffc5aef94da8a106a8c53e52b246ef6846c3bb9b0912ed4f8b1a73a626131d92",
       "sha256": "0x7a06c17861daf9a3046b6fe90371ebc2d785fe0fe53a086e51f823b46b3f6cda",
       "urls": [
-        "bzzr://6283edfe37ad5f885f97aaca45131065fbadf4a6eb6d228a2dea8477c119d4f2",
         "dweb:/ipfs/QmZNefhptFw8PZyVQbwsY5VjnngqKLi4kyiP2KpJMF9HDB"
       ]
     },
@@ -16725,7 +15432,6 @@
       "keccak256": "0xe87d5c3dd09bc85f1228b10bbc4a884c2dac5aa82cce125705d929125730e914",
       "sha256": "0x04c112ca1d255fb3cb61c2b202d99f2dddcabca8ff482bd1a020de3a2881cc5c",
       "urls": [
-        "bzzr://e6cd64032be5334176da8018ebc9e99f59c4bd8a28387b27c7cf472ecbeface8",
         "dweb:/ipfs/QmeV8JDS3CER5kwdGSFywHoARC9Y1Jbrs9mf29bMdXH4w9"
       ]
     },
@@ -16738,7 +15444,6 @@
       "keccak256": "0x031bb02e5ffcbdf3a97c14a2a20727612e62d44edc9947942456185845eed614",
       "sha256": "0x92858e382dd253c7feeae383b5cbc6f84fde243986d561fb34808c1b58084b98",
       "urls": [
-        "bzzr://28928be05772d01e4b077793e0ee525747adb00c52fc0fad29b69e14cf54862a",
         "dweb:/ipfs/QmUw1QxWynzfX3xWppmhrqcLMgUikzDDos5Zdyas41LJAW"
       ]
     },
@@ -16751,7 +15456,6 @@
       "keccak256": "0x3fa6bfaa3de28e6d0070672e7be6497cc5ba5895ac5f39623a655c4451be84b1",
       "sha256": "0xcd87baa9daf569c2169728e19e5331900566b7d2bf3aebd50bcdee4f90e53087",
       "urls": [
-        "bzzr://d58f63a5644b1caf7ea9c11617aebaeed5fef100deb4ff434123f77f723f2688",
         "dweb:/ipfs/QmbLfTHjjtMAJUaYcUEpn2y3K31aMf3fNKKge148AnJh5V"
       ]
     },
@@ -16764,7 +15468,6 @@
       "keccak256": "0xce61002fa6d826cdf0c4ad82bbeb549129dfe786c1cb7a4113e77cbab42bcddd",
       "sha256": "0xe16386004687b5d06a78ea999dd65c812f8468bacd2457d09b1c526531860038",
       "urls": [
-        "bzzr://b0aae157f30689108630a14cfaf69b8b576a20c54b172c1d64b3a7e0174efdf2",
         "dweb:/ipfs/QmceG2DcBog8RmmFR4q9JvUczMDkoKtn2SyXKrdzkuk9RL"
       ]
     },
@@ -16777,7 +15480,6 @@
       "keccak256": "0x47c2a7830a544ca0a21430d9494ce1e4db85930489b0be6b93276dec07b4cedf",
       "sha256": "0x9feb2b571d8e549bc76edcc16301a426501be9fbfada94c11e071d9c0c8bebbb",
       "urls": [
-        "bzzr://dbd484798dd03be577d4ad7749f494cead5b987868b24f5d06bbabaee1aa3d3f",
         "dweb:/ipfs/QmXxiAqBXqfMhz7KCJHnTppgCydudvhehd2MNXvh77Kgzz"
       ]
     },
@@ -16790,7 +15492,6 @@
       "keccak256": "0xf57f46032a7bb10cc863684ec92b762c014853fca6d91240991bc109c20a7b8d",
       "sha256": "0x5339b55650eaca41367e23dc31ec8129e921ba052e13008d3a0de1f0682edf51",
       "urls": [
-        "bzzr://fd7358537a155b1dea8378bb4fb16c0ded35a44fe0bd3c0d8835da0ba4363a56",
         "dweb:/ipfs/QmQWtjxHJGCJFBpsDoSDCsSX51J3N9CjQEQvV1MAuR5Fd6"
       ]
     },
@@ -16803,7 +15504,6 @@
       "keccak256": "0x0cf275ea2f84e4a741a72e4dc2ed9764ae15c2d57cade49c93a1bf9f983fde22",
       "sha256": "0x48ec0dddaeba9095a1ab3cf192eb0754b49c873e6adac114ced1e787d37a0c63",
       "urls": [
-        "bzzr://25f5a3968a6f8c027893b53983053bd8cb7249d1c1a6f2a537cee58f1c618ac7",
         "dweb:/ipfs/QmdPvEPNUfArBC5WRpHMSm4GLfvVmLcJdiD3PMRki81PLY"
       ]
     },
@@ -16816,7 +15516,6 @@
       "keccak256": "0x1ec8b8ee45bad6482ca8b468a361a62d82f8c62c50ba28f46570b1947d3a3104",
       "sha256": "0x2c3bfffe524ea5307bc9325e6ca9ea8ba64e9b159d23ddbbe69ea6f9aae7ba23",
       "urls": [
-        "bzzr://fa4b122a3111fcb08898926840a6fef3011a571a508c58b6a1621f60b1628bc6",
         "dweb:/ipfs/QmSYncr4fbo5irr2jBCbMZYLjLSZvFBAUntr5MXZYbArD4"
       ]
     },
@@ -16829,7 +15528,6 @@
       "keccak256": "0x47d429168fcb439822be95eec04d966f3780a31477f8c6f5edf009346f9c5284",
       "sha256": "0x3fb0cbdb5818d44cc5b209998b6757ed1e3aabebdeff94802cf62f4a143cb968",
       "urls": [
-        "bzzr://a92926cc4ed4261e9ec1ed5a90c44de421b0ec01a1e0cc121fc2d1e383627010",
         "dweb:/ipfs/QmQpncgmgYGkPtZLHKkpcd1opc5t56FefHBs4ZmBqASnMV"
       ]
     },
@@ -16842,7 +15540,6 @@
       "keccak256": "0xf1bade81b24046effa9b17b8fb418c5f39320bab553999534d44ae518121b6a8",
       "sha256": "0xc13722abc1a98a18220ed75063b68124032d5be2d2308803498a80f85f0448ce",
       "urls": [
-        "bzzr://141d58df4109dc1c446cc138ccc0cfeafc3fcd073cbededa05fa2a7a1b07a05d",
         "dweb:/ipfs/QmU5iJGFZcaz6CnvUTKaCK62PkTH3oLvSxCEMYV46Gk8Sa"
       ]
     },
@@ -16855,7 +15552,6 @@
       "keccak256": "0x9c6d474687cf27ce9333503578f7cef807bd4b6d57e8f40fe8395a450c57bdc8",
       "sha256": "0xaebfbc6916cc99fae3f976b6536612d1eb1bed133e7cc14c4a30d44388e13e80",
       "urls": [
-        "bzzr://029821defe237537439cc8ea4165118b1278672e6d5de2576280e7248e26d026",
         "dweb:/ipfs/Qma6qpvjNBiEtb1r8Qe2MVCC8cAfAiUutJj9W91uZeKqnn"
       ]
     },
@@ -16868,7 +15564,6 @@
       "keccak256": "0xf61f3f166582fec79c07e820c8b7762463274f53c2e4cecfc105555affd268ea",
       "sha256": "0x9e2ed87e283302d5913105bd4fb6646cda5c286260f41544a7d04108c57cfd25",
       "urls": [
-        "bzzr://76fdda27b0b611aab3a3147ac4b369dce6ecff16b6dc017f11c28d0ef8d3c780",
         "dweb:/ipfs/Qmd8ueG76LgX7NvNEGWFKspEq5rUCqc8FmdaNj9ZX6jwhm"
       ]
     },
@@ -16880,7 +15575,6 @@
       "keccak256": "0x56cb2f6978bf1213982ef217ee76b39dc97b6e66c92a7be7a1b44079c0236e5c",
       "sha256": "0x534b7d4079d13bb4cd10b7559dc105c2adec625df4105f20ebce47e6da60bfda",
       "urls": [
-        "bzzr://7543aa16521848b06a1359afcb9dbd7be1dd09a36f4ca53edd3ed3a512a475e9",
         "dweb:/ipfs/QmZaSrn3TPvPVoShtjSonQLFd3BV6RdgRMqw8GTzhnKYpm"
       ]
     },
@@ -16892,7 +15586,6 @@
       "keccak256": "0xbc470ab3442e78bb4d3f16c01c39b2f160f4f34eb4373efed11c234e1c7f6ca0",
       "sha256": "0x5b25f987aae32a0275fdc6c1be36cc47cf126024a04dafd8e4be39a1d1d1422c",
       "urls": [
-        "bzzr://83bf64f11a09845a6eb732da08283a58f877e9227190f489c9852f790c81d0c4",
         "dweb:/ipfs/QmfFq3MvisCSUJy8N8EVsBribgPbdpTZb7tQ2eHYw7dwag"
       ]
     },
@@ -16905,7 +15598,6 @@
       "keccak256": "0x64131808e556b5b2ecbd6516bc1f05cdaf3750a33852e53aece7aeaa8dee14d9",
       "sha256": "0xae2ac8ad81fecac8f1091eca0bc1930648101a74a1dd71894c6ed9e2816a10c0",
       "urls": [
-        "bzzr://c3042b9fa07de4f63c00feaf7ee30374883fbd90f1827eb33bf7a38bdaea61db",
         "dweb:/ipfs/QmRJiSPgNQ6sJFT2yi4dqjUTAtgr3E99nC4919QNLA1zm6"
       ]
     },
@@ -16918,7 +15610,6 @@
       "keccak256": "0x56330274899613513737957a7acd6d190df1101b8d2b1d2c37b388a0a0a6bef9",
       "sha256": "0x2d98a93fb7c8c0a884ce4ef026d2c6489a9e24ec1bf58f707a532b7270926b7e",
       "urls": [
-        "bzzr://39462e1faf6cf01bc48558840b5e11822ed14014d7430472b108ebbf62371645",
         "dweb:/ipfs/QmckZHMzUGEt22JWnMKp3GwRM6TyBCH9ox6AfyKSDmuiT2"
       ]
     },
@@ -16931,7 +15622,6 @@
       "keccak256": "0x6369260fafd230bfa4a8230ecca6966a9257424fb1832c5b49ffadce46d34297",
       "sha256": "0x318b86649a52562631a6c79a168b5ff68f35927a550a816804e96a4e82f4ddf7",
       "urls": [
-        "bzzr://c62a85080d84297aa8cc6e65c74ce9cc61b23d000d6a6e7941a7cc8e979e8fad",
         "dweb:/ipfs/QmUNP7FaWZWh6kZGVBZFjAVJcciK6M3u4i4dXNqcZX7nj6"
       ]
     },
@@ -16944,7 +15634,6 @@
       "keccak256": "0x5471f1b1898627725090894429fc1ff49f3b8a25e5b5049ea29a5dcc18b409ed",
       "sha256": "0x1fedf17c40320f2fedae50067ba2f7333f42bb43b1a5b2148c696026e8c47177",
       "urls": [
-        "bzzr://ea6b7ccb8a036e9c0fb40389a7f523f7c5ae5b8166d58526ff1bdbf842d0f562",
         "dweb:/ipfs/QmSWft55GQQ2LcLn16Uru86Ur2SzuWa7s1G7YDSzzXUM8m"
       ]
     },
@@ -16957,7 +15646,6 @@
       "keccak256": "0xe449286d744cbfef407264c81ea9d5318c9dd97041bc0b4dd79a308c0f38cc5c",
       "sha256": "0x87dddd28a44524935f9de749406bcff3b32963a1e1cb3e749ed11188c65527ef",
       "urls": [
-        "bzzr://2c483bf70d7ca448e449e6c4e6a36e32bf698f44a4b8a9fa401f78b749edafa9",
         "dweb:/ipfs/QmbbPdkvS1acYoBe3c3Z4QnAbbjdjhQimowxpLeYp9NdkA"
       ]
     },
@@ -16970,7 +15658,6 @@
       "keccak256": "0xa23ffd292d66c5f1e219e1069b32206ba6e7c712ff9385fa246611cd6fae42bb",
       "sha256": "0x07e268d94112e8848009a0aaf77d99c50dd904c63b8ce88d4e635b20be97b544",
       "urls": [
-        "bzzr://d91b602870e759c7616a02d01cff580fc7045450ce62ed58a81456b9f3f9738e",
         "dweb:/ipfs/QmdNNexpQA17yyc6TcktsZHZb2N9DubbC3jyUXk2ESBWPC"
       ]
     },
@@ -16983,7 +15670,6 @@
       "keccak256": "0x24b67d677e6dbe00ed82205c9c1aa9edd292e5955700ebe27f1f64770f31bf4e",
       "sha256": "0xb549e2eafd6c8f6ab5c5d4f28bb626a4577d748bc5c80f4e8b35a190cd9d427d",
       "urls": [
-        "bzzr://2bcd3fbd87ea73ad2e977afe29466f56b7cadf2ee81f13ecf82af7027500debf",
         "dweb:/ipfs/QmQs9Df9XmSTFkEtZDc6jGfgroFarDd84FoPUp36R6zHj1"
       ]
     },
@@ -16996,7 +15682,6 @@
       "keccak256": "0x42ea2801748a5fb3f1ba16dbb6be376caefaf26b5db5b2adbb83b5e0c2dde507",
       "sha256": "0x2ed58f6207884a50523ebd25e90482d31a257f47c1111fe05aaed94c7e5cb676",
       "urls": [
-        "bzzr://52dd64bb332bc3bb8e0521c8172fbf2bf9003bc210923e26191e79c10fd147bc",
         "dweb:/ipfs/QmRTAVnhpRFiRAsi5A8oKHw7sydiDCrkhbiXWWzWqVVemQ"
       ]
     },
@@ -17009,7 +15694,6 @@
       "keccak256": "0x1002f0ee07bd61f795c4f3193de5fbc62e9532739eddd5db96d0ab205fef16e0",
       "sha256": "0xe0262d99a166deed00514cef9d5f5f8297a370d8790c5efa900388e2691dbfc6",
       "urls": [
-        "bzzr://edc15328acbb8d40a5e2817dbba5cba39bfbed843a975b01c6bbab2f2d6ccbae",
         "dweb:/ipfs/QmPCo6HjbCx6PSGo36quseLY1RqXFMdCrK5D7oGCZdBGee"
       ]
     },
@@ -17022,7 +15706,6 @@
       "keccak256": "0xfbb3312e8a2a7e6a397350fe205ccd702dff36f185e16f8fad6f95bc92d2fca8",
       "sha256": "0x892b0ae05142d4d99a3837af1d6817a7ac860c4b54a9521e3d9484326bee523d",
       "urls": [
-        "bzzr://63a36afbbbeb7a76bef9fff6e08920162b1ea5b1fdd174bc22d54325424146da",
         "dweb:/ipfs/Qmf4PvrEyzHMyjRmcpChUE7UGQzVgQaa1jtY1goyCjVwts"
       ]
     },
@@ -17035,7 +15718,6 @@
       "keccak256": "0x0781c1427066ca83eb590277e18edd47048fbc444189180be13de767803408c4",
       "sha256": "0x8ffe23756cb563b86b1601a1c70d0cf3d61b4f7a1d1fdd695639be0a16aa4742",
       "urls": [
-        "bzzr://de0507d13a9e9998992a57f51c3a586899d63d416b94620629e671b12bd9f271",
         "dweb:/ipfs/QmVMHBG9xB5K3MxnEDhUiJREHHtzcR4FtxgWHExiYN33FW"
       ]
     },
@@ -17048,7 +15730,6 @@
       "keccak256": "0x45d1524710b4d26a005e9ad154f57bbbfb1ec295efc1f6dbffe589dfe33c7fc6",
       "sha256": "0xdacc7e27dc62aadc0bf4a4cf874ef8fcbe40b4c89ffe7502e41b20db4b0a8a6e",
       "urls": [
-        "bzzr://45dc6844a7f1ce5796c0fe848cf3cb0e1df5392c5ca12e43cb49569912f20230",
         "dweb:/ipfs/QmSLFzc2qqaxDiT81ouihnfhHqsYzH9xcmQvbfe4LCRPkD"
       ]
     },
@@ -17061,7 +15742,6 @@
       "keccak256": "0xdb71cc106246d5873f7182b6a4a8de3a51b22f1c7249b55bdefe1f6457210ba0",
       "sha256": "0xc9ca626f1a3ff82ddce2b4b46153734a57bfa77fbb452e94266db7e7c47ce8a5",
       "urls": [
-        "bzzr://20bd39accc6ecf81ec76441a177430dc92aac6c28c9afaf52d192fd1bd7d5ade",
         "dweb:/ipfs/QmNR38xfKi7qHZEX7ZbVSXjaeNmJq3BCU3feVPpqhv3RxD"
       ]
     },
@@ -17074,7 +15754,6 @@
       "keccak256": "0x54183c56b2d0004a5e33b805b4212297848dc79113993887903822e639b95fd1",
       "sha256": "0xc243efa1bf8b5238e6f56c9f2c15f48aa4e4a21b59ed3b2ac830694d9e77163e",
       "urls": [
-        "bzzr://6fcf68b2b4cf5aa6cc96d249ddf4cbf56f514ccaba60fea3bb26e051575e6ae3",
         "dweb:/ipfs/QmeneQxeZZbzjCZiTajPhxn2FYJXvJaqkHnXC7SHsqqvxp"
       ]
     },
@@ -17087,7 +15766,6 @@
       "keccak256": "0xec7ff4d45da1b7677c2a2314a96074541f56e80296383351bbe1f201dd08eb07",
       "sha256": "0xc410b8a5282e3079c0f5faf057cdda4271d09891ec3f28194fa3e31e83b410d3",
       "urls": [
-        "bzzr://21a8f65405179cf54d27cd237c5bd869d6b3a1bbd794481c86182a4ec76e3c87",
         "dweb:/ipfs/QmX6p2HSxdVQXYhaRqzVsSLZqn8AmV6RM3fj1hGyKoD4Wi"
       ]
     },
@@ -17100,7 +15778,6 @@
       "keccak256": "0xae35363bb2f2243e155f788886f0ba46b5c3562d22942ddf088228f131bc5e73",
       "sha256": "0xfbd38cdf3c49ccabcc9aeb6dfa54b7fbbeb90ec42e5fd2c31891dca82c3daded",
       "urls": [
-        "bzzr://5601194cb6ac0b02902f75feb6e100e9ff0b52606838575584b98686ded9d982",
         "dweb:/ipfs/QmcFVVDXcnJ2Ek6ZdnZW9dQJdPgYc1Tn5Jtn73ihmsmGHp"
       ]
     },
@@ -17113,7 +15790,6 @@
       "keccak256": "0x6062632b6ad4582b51d9370321e2ed31d8cbaab9e9849a2e2e000d0eb7607b58",
       "sha256": "0xb322931b3f35183e0094ae2e5e8a04886141762c594c92ec8303a16893f8f4bd",
       "urls": [
-        "bzzr://e38e2f10a02bec04881c031fd8b110954baa9bdc71bb8256669fb0d2509f4fdd",
         "dweb:/ipfs/QmeNpprWrpfrJGz9gjsNPQyE7oBXUuy1e6PqJk6NAk1Utd"
       ]
     },
@@ -17126,7 +15802,6 @@
       "keccak256": "0xb49c47b7ffe42589b724b4b0c3e21471a57576628d7142c77e6d1bfe18e0b880",
       "sha256": "0x2a9372e69575feeb9343e55cfccd545f562e328f90990d7339ae8a76c63414a7",
       "urls": [
-        "bzzr://165742161bef27fb5570d59975dd493628e38db52898b3a98f11083a02d2fa80",
         "dweb:/ipfs/QmfTyASyQbLb8aSbcd5S7Ak39puTutxXtP3kWuKDKmzdU4"
       ]
     },
@@ -17139,7 +15814,6 @@
       "keccak256": "0x2ced2c892f879806acb379b3f933316c35838c4a195781fe6b3029c0e6c1a5f0",
       "sha256": "0xd58132bbeb46b2d0e87ae28e4b72e81572d6fce7930b6f084c2f3811becb78ae",
       "urls": [
-        "bzzr://59e05906a3a135c4570cd73ffa765d67c7325d823b8efa3ee35153b037a177ab",
         "dweb:/ipfs/QmcaHUgPyuFshu8tsc7VVQx3KHUvUZ8SxySei93jgXMkSE"
       ]
     },
@@ -17152,7 +15826,6 @@
       "keccak256": "0x57c16015f011bd86dedfe223e41cdd51e0c6ca6f1928228e53fc5793f21e44f1",
       "sha256": "0x976906f9d6097e224e28c7fdaf1f3d9abc90194c047e09d011a2cb7eed960394",
       "urls": [
-        "bzzr://a743f29425eded2e4acfac9793942fc7630fcf60b30cd433a21042bd14959c05",
         "dweb:/ipfs/QmP6QwRmX14msTsY9bYKXfDsQpdMJGGT6aHDPv2TSTvpDP"
       ]
     },
@@ -17165,7 +15838,6 @@
       "keccak256": "0xcc67567d1d81f2c186b75825daf11180965bcf22a634fb57ba1952e39f1f7c05",
       "sha256": "0x0c7b7b5641689c5879abb03a550b87cf7ad6afcb836daa3bc0e75cd09387d814",
       "urls": [
-        "bzzr://8059c0e4e1e521bd12ad4d4fc82ef6b0479f6c642bc6aaa36e98fef6968191f1",
         "dweb:/ipfs/QmX4ThtVXsD76h6q3g9rhe4NXNUFxneFRcRTFf94atBp91"
       ]
     },
@@ -17178,7 +15850,6 @@
       "keccak256": "0x61699e41126e6f593e46685ddffe3c8976282982040b29d849ca4872a2aaaf20",
       "sha256": "0x8ea0c1faa5ca53571f08c1a165fb22094cbb56717380cb7c7b1a675c0b798bdf",
       "urls": [
-        "bzzr://739317d051af3f1947e8d2fb8de37d616f230c4f4ff652a1c0258e3492a4391b",
         "dweb:/ipfs/QmZSZTDuroNgM3awsot31bfJSZ5JTMVFmCoXxdSkP52WCe"
       ]
     },
@@ -17191,7 +15862,6 @@
       "keccak256": "0xce97e0ab8808b6a0a49873027799e9ea9db5c8b8e4b981cc824c7cce8c928337",
       "sha256": "0x73c9e5fd0aefefb333c28b2809140346dd928e26de42280f49c5f362a1ef7dd7",
       "urls": [
-        "bzzr://a6170a6c9595415e6ba14dea75fbcd9a287ada960e22070bdbdfff7e14dccd78",
         "dweb:/ipfs/QmZK5hAK71Hv4VjTDvuLZn1jBUq3xoXYrBd4jJYbGCYuSA"
       ]
     },
@@ -17204,7 +15874,6 @@
       "keccak256": "0x78207d66823a7eed97c23dd41ff880bbf70e04728cb74440d3bddebdd82617e4",
       "sha256": "0xbf23313f3a4f5133afeb7dbeab87e66345c1d25548219c95ae447d70bfcd0e87",
       "urls": [
-        "bzzr://aebbb61358b37a7702d94726d6ecf5f79c32cab35500b98b43a99587c0841d5f",
         "dweb:/ipfs/QmerRbmj2hLE1VzeCCyFG7jhMipMJnZK17R68v5hZRJwsP"
       ]
     },
@@ -17217,7 +15886,6 @@
       "keccak256": "0xb9185a5c71bacc846e93aab1ef07c22a8ba2e12368a8f33ac97a6f79a2b2b737",
       "sha256": "0x37267f7c20858b3c1a26035c75f2363757015bc4db981cefb587c0a618b91e47",
       "urls": [
-        "bzzr://92edb1d399227ae6e0bc8c01789ee565a6011ea4000b235e2561cd8f61b027a7",
         "dweb:/ipfs/QmSGLFPgJ14aq5inXWzXMNycZVUcoLnS455y3S3uCNQ16r"
       ]
     },
@@ -17230,7 +15898,6 @@
       "keccak256": "0x2435810a1b4f04020f9ba9f3548af3dc6263ace6807481e01927152d614b54c9",
       "sha256": "0xdb7a175ccb37d0257b7ce02ca69790854d0243b0f6d3527d40480077cf180854",
       "urls": [
-        "bzzr://6d139672dd17bec40060fdef926aff9f57aaa94f0c342a2c27a977a550330998",
         "dweb:/ipfs/QmRgx39mDWMNNBia3bHwra9F3aZZoFGeNnMRKVnPV3YPRp"
       ]
     },
@@ -17243,7 +15910,6 @@
       "keccak256": "0xf25b80d51dd22d138942bac584b397001e385a50c1ce6fce3cf33307db4be990",
       "sha256": "0x1f06eef1a2de3fc8d42883e02677f6b64b562476cbed0b2050877645f7cd0134",
       "urls": [
-        "bzzr://a258b158e833012ead4285687d63dc41839c0f8bfa48adbd47e89a0e59504fe3",
         "dweb:/ipfs/QmZa3kS8HzdTPhFgSS1bbBNvPx3PGffQ3ayBs6NjvGUiRX"
       ]
     },
@@ -17256,7 +15922,6 @@
       "keccak256": "0x67d457ee9a355a78af79edcf1a3f875fb8f789091d12a70c8f21bfbc705fcd60",
       "sha256": "0x9f2d1dc654c369218fceee2dd139d1c05326552105f4a978e44b9a8b6c1bc4fd",
       "urls": [
-        "bzzr://350fe1bc2717ac43d0735e928feef595a4163bfa4cdc951920cf0411ee8baa75",
         "dweb:/ipfs/QmXdJJMF6j3QFwrbYga3qf9cvphZGJe6PRJFnN442fRQPK"
       ]
     },
@@ -17268,7 +15933,6 @@
       "keccak256": "0x3820aae0de50f10f62819d65f0b5a236ccffed11ab465a3295a5408fa47e24f5",
       "sha256": "0x5eaee3240a06891abf5ac70c75caf9a0c33ebe9a2736abdaa22a337f86c22933",
       "urls": [
-        "bzzr://5124a21890d6b0ae70bfd031f741d7edc74cff70a26ca74750d446b15a8efb06",
         "dweb:/ipfs/QmcsfYpEWbPXfVptzi1YvGokxi2FYCUzUr8rQYJCc5fEiB"
       ]
     },
@@ -17281,7 +15945,6 @@
       "keccak256": "0xb20533462a42a87e8d5e7ef1b4cd1c83c24e29078a61d208b96842125ed196a6",
       "sha256": "0x9b0dfe1170a006c72955f8b0e161c8af2109e9a425f4658662957610c1f095dd",
       "urls": [
-        "bzzr://bee76aeef1a043f394991d5b26d75e55f2024d8efbed6bb3a8b961a80485df1d",
         "dweb:/ipfs/QmNyjhRAvTMCKaSHAdYDAm9zSqvjsVKtDhmG7roG75rB6X"
       ]
     },
@@ -17294,7 +15957,6 @@
       "keccak256": "0xf02492521bd3c5a8a8723beddb86b4b5721025e60f67bb8707b33e67082d28f5",
       "sha256": "0x03ed4e9a85dc845d090f08add230706a1566d82d7467b495626407c7d6bb504c",
       "urls": [
-        "bzzr://cad931e93a842ae9c38769f8419460ef6906ab91b002064dd59e808dee0c129b",
         "dweb:/ipfs/QmXBuequCr1NoxivKtdTfAng7HXFQ2SY3Nts7oggc1gy2U"
       ]
     },
@@ -17307,7 +15969,6 @@
       "keccak256": "0x756d13da0a4aa29d6757ff5dc3231bcb5de3ddf7b9fb2c05fda6b8c4365d8d69",
       "sha256": "0xe7e1807bbd69c7891f3bc199df1e1b3bfb121446e9362088a1ae63c620a9b7fb",
       "urls": [
-        "bzzr://f37bd33dd61b67ca8130f73610d8dce4c205723c491227a84719456595b0755e",
         "dweb:/ipfs/QmTPUcMrtbnPYKZDK8pGPhUbwfKSTiXpCaVWTFiPTnnoEd"
       ]
     },
@@ -17320,7 +15981,6 @@
       "keccak256": "0xaee3dea17317b0a7c9cbb454bd859a9717a1952d4511d58a2263633ba4dcff2b",
       "sha256": "0xfe31a2d216b74888d8fb6283bb93bcba7d6c66e981d5fe00bf69f3271ffba17f",
       "urls": [
-        "bzzr://70ef80f7b5bf99f7d24ac16b8c0b70d5626960c62550273d1d68ab0ebc606887",
         "dweb:/ipfs/QmWTetDvHv2MiHz6TeZVbMsh9YNhsKXsM4riSG3jjTKJBk"
       ]
     },
@@ -17333,7 +15993,6 @@
       "keccak256": "0x86a9be3cf91c42db2d3d2de91486af5fcf34fbf183e8ed32d40d222670606f13",
       "sha256": "0x4b3c7f1d7601afe5d0ba3d434c4d3707ac5342f8b00e5c71bafbb80bcd338669",
       "urls": [
-        "bzzr://f4c7dec62e0d288e1c42134158e81b91a194c6f7626d9594a7234e5a2eee6abd",
         "dweb:/ipfs/QmQ17VTZNzGGabb7zPnEWTaXiSGuDPn5mbKQdpZnNtvbDs"
       ]
     },
@@ -17346,7 +16005,6 @@
       "keccak256": "0x99724c499d43b112017e3c7a032d82a0229afeaa4c414de2676390b8f9b94c7c",
       "sha256": "0xcb348b93ae23e2759fb1072de1eb3ce59da659e9577ec6494e3e0cfb3c981d5c",
       "urls": [
-        "bzzr://7335180735b05634ed77b6fd17ce78126f7664e10739e61bacf0bf8f6584b98a",
         "dweb:/ipfs/QmRmahRK15EPcuJxgRwifGV4z2oA3C8nTkvNPnsAfrc2BJ"
       ]
     },
@@ -17359,7 +16017,6 @@
       "keccak256": "0xd53b9a1b0c7e2f4a5c00c79e63229aca2a460beb9f2f02862e50374a7dc378a1",
       "sha256": "0xbe7cf00339c5f3e02825318eab0c31b4be14dece213d9f5e80c95745272572b0",
       "urls": [
-        "bzzr://f7add8518c6bc84593317de539f7adffc1ac5b9261fc0900c270fa3e8ffeaa93",
         "dweb:/ipfs/QmVzGNoJBNRnWn5qoy4gXxpDgT64BVmdsTaYyqc4HtUxm5"
       ]
     },
@@ -17372,7 +16029,6 @@
       "keccak256": "0x66c851af8cfa87240cec85c03ce995832c17cddb89fbd30a97f4e94dd235765a",
       "sha256": "0x0d13021c701169016a46d6165e694640bc4326c5f920a96710b20bbcb23db29a",
       "urls": [
-        "bzzr://154d464ae04772a67fa75aae8833016669547329a52a92452db6c22e7c35d75b",
         "dweb:/ipfs/QmewU3WRueQZbvpfdGDff55hp3G3AAVQxmUgCHdVZX5Qf2"
       ]
     },
@@ -17385,7 +16041,6 @@
       "keccak256": "0xc78a13305f3af807be30abe7aa357d50073508bbb3155d5e4c7f0df1e70836ad",
       "sha256": "0x0326541fd7a89366dad0a8eba4fc8fcaa932a2149e69760574b0f593e9b93ef9",
       "urls": [
-        "bzzr://c36b660f51173d25d694be5ce907560a43570db28d6c5bd0f621f18f80d431c0",
         "dweb:/ipfs/QmdbKSHsq33zFx1daWJWeJKjqeUfboKdB2kx2c1RjrYDMf"
       ]
     },
@@ -17398,7 +16053,6 @@
       "keccak256": "0x0233aee6c0db9bcee7e6ec20370812dcd8ee74dbb707142edef77c400a99c238",
       "sha256": "0xaa937c8519ba64d865d795a0d483bd9bbb55c1d5862ed56bd269c106a46c9cb6",
       "urls": [
-        "bzzr://359f5826dfbc23e9fcb9be4344e4f7ac6e16d837902c80f0ffff25ac6ebddf77",
         "dweb:/ipfs/QmXP9xnrfjw5uM8GiVJh8YKLZhEDdkbUtCW4BjPwXXzzjG"
       ]
     },
@@ -17411,7 +16065,6 @@
       "keccak256": "0xeb0fab03ff926ed4d1ab792a0c6854f1a9b0d88bb703f30e2eb03d922a05eaff",
       "sha256": "0x2b9f30ebcaaed37d977e4771c32f431ab6aaf7e91af914c172ea67a6a4263c22",
       "urls": [
-        "bzzr://12edb3d38fe4ec0d9620598af0322004ef24ed8276e3f80db8726a11c0fc8d7e",
         "dweb:/ipfs/QmSFUP2NniKuKFTtwVJ3d5WjAVhXdfVybsLNFhw9JnQjnz"
       ]
     },
@@ -17424,7 +16077,6 @@
       "keccak256": "0x7279b07acb8b3bd785489d421f9c2e27dfb26f14875c4f2271cc93ed467d4dad",
       "sha256": "0x07b51f0f2133f24b9d3aabc176edab5ece150c36b256930f891c0cfa254b7623",
       "urls": [
-        "bzzr://b49d235f72b179d4989147178f767035e8e67d34c6d2da506649c71a017b9512",
         "dweb:/ipfs/QmPoLGPT7Awbpoj1cmHaSyU9mLFyeoRSfTfvzRbYRY8k1Z"
       ]
     },
@@ -17437,7 +16089,6 @@
       "keccak256": "0xc7d9d28aebc780fdde40250ca095d1cd6e3e577ad074bf82d0ab85dda05d9aab",
       "sha256": "0x943e165c123350fed56748db871e6eed85eadbbfc97b8cb74b9fe541d51f7af2",
       "urls": [
-        "bzzr://3a7e79a07ac9702861539a0a11c6ffcd91dfa2796a30d1254a9a5f87b31cc580",
         "dweb:/ipfs/Qmb3eT2CWf67JxUFoDrxwuNCpzBxisRS1GoU7wd31qzzdV"
       ]
     },
@@ -17450,7 +16101,6 @@
       "keccak256": "0x77133f9ca2d9eeeaf93dd23b4c8399e207a1aa54fe644d8f063b32cba2d59da8",
       "sha256": "0x2a25791ed2a918e11a3a5e20474fd0084ae5d5f86ba1181f876b9ed196632eef",
       "urls": [
-        "bzzr://3e5f682a961966c53c2de4a5cb779ef2e1afdb21c61ef14ddcd86601ebb2a0c9",
         "dweb:/ipfs/QmYKgLSFhEgDnmAKzmABL7cXxGeWKZexer5vk9Xgoo79MQ"
       ]
     },
@@ -17462,7 +16112,6 @@
       "keccak256": "0x798b23086ce1339e3d47b3648a1f3ae40561e2c9f66ffcc98e71fc14a7f77584",
       "sha256": "0x64117d4b13bfc5bc6e5f80823519b140e753a0c09e99edd756772dc3029bc1f8",
       "urls": [
-        "bzzr://0fd1c8db6338b2143ab0e49a33edaa133108ba77f1238408018b5b2a0ecdeb62",
         "dweb:/ipfs/QmNQTFQmfnjxnDmbguVSnZ5DiHGFQHCsffccW5c2DMcSsT"
       ]
     },
@@ -17475,7 +16124,6 @@
       "keccak256": "0x50ce53fca65685494ff1fbf018c1e33543b166a6bbadc664d9dbab65c3b33e9b",
       "sha256": "0x9d3e80e0673627d4a61b5402ecb593cdd79f274d1f50f1e6e9e21b4d0f238147",
       "urls": [
-        "bzzr://6444cf6628eeb055d370921db03708361965d1b718c6313db0a5b6956a9ca84e",
         "dweb:/ipfs/Qmd5gMTFd7HxFYz2bxVBBKHniJ1p415gtmE55mDNbkPGmT"
       ]
     },
@@ -17488,7 +16136,6 @@
       "keccak256": "0xf1f02efa3474923233e9ae0231524bba695b4773e459c16a17aaf31555aba130",
       "sha256": "0xb8ee2d10c775a12244b0d29a19a3b31ec643405fc346f910f3f94675cd9e41ba",
       "urls": [
-        "bzzr://b1599f62b3b96d5b07393c38272519e5ead1f6ffb3ac4d958b4977356d7f10c7",
         "dweb:/ipfs/QmSCgaS6uUhFT83reAksA3AKjffKTL2a821o37uEnuQ8YX"
       ]
     },
@@ -17501,7 +16148,6 @@
       "keccak256": "0x36c956c870be2852e6d1852957cd1ac05a3d1798a704ec81242e82b03218a37f",
       "sha256": "0xbcc8e9418b641114a34b858791b4ffb9e675aeaf64ac8628bbca3cde406c6f01",
       "urls": [
-        "bzzr://914bc464f86345cadc730e1bc07407c128f007cdd842d39596ca67465b52bdfa",
         "dweb:/ipfs/QmTzZuJbvr6Jy8ajQEwn4sxLSfMCaME4MTaujif1QZ1Cgw"
       ]
     },
@@ -17514,7 +16160,6 @@
       "keccak256": "0xd69a9b1a4fcf65f9ecdae29ddb66d3a636b9a80b6c58adcdbeeb4e4e9072b5ca",
       "sha256": "0xb3e547cdafdd56fda0b5cf088c8c094f4b13a3b2709ff371c4d4f07f7443b885",
       "urls": [
-        "bzzr://f9bee25917a96108fd1069710f194dde60b5d67d55df7814dd05d62cb18a46e6",
         "dweb:/ipfs/QmRoBc5q5amsHA43i2gzvfrkbptzXT6dsGD8hJZ6AWj7re"
       ]
     },
@@ -17527,7 +16172,6 @@
       "keccak256": "0xf281fde09cd89a2716ba67bf648da15a066ff0f4377979df0da25eda2da691dc",
       "sha256": "0x4c132ffab1dfb376c3edaf27f1f374a2db1a45770038c5e00cd111c8fb2a0c7a",
       "urls": [
-        "bzzr://50f32aedd055825ba060b44190c4c4fcf8b813ab07ffa908a788d68d3b389383",
         "dweb:/ipfs/QmRAz7evFbwqB6rJSWATnqnPFSqzDKivwUNrfF8E9cLqbm"
       ]
     },
@@ -17540,7 +16184,6 @@
       "keccak256": "0xa49748ed3450eeeeebd5e2c6740bc55da820f571d980fa0c37462a1681aa1989",
       "sha256": "0x4486cdfc65fe83980e9458e6674c7c5d776c5a2587feb3e449e7fdfbee8ad1ea",
       "urls": [
-        "bzzr://f1933e96418466c9826db4b9bbf87722dd881c39f0d7a3b716822ad2eb67c62b",
         "dweb:/ipfs/QmZQvY3rarAdxxrKsFARvwTr7sUWMbC2i7M5VZD3auJrF1"
       ]
     },
@@ -17553,7 +16196,6 @@
       "keccak256": "0xcf3b93ca6a562b7db055ffe67974f765ace4dc7d867518f92941d4efa956c9d9",
       "sha256": "0xa90c2d3dc48c9dea916340210ef4cbdef695e6eaba752b56ce69fc17d4641f47",
       "urls": [
-        "bzzr://d89a1423863f59a343ade2f777990abd14c75840b4cdee1c9e92afa23f4f71f2",
         "dweb:/ipfs/QmYtVEKgJvxR6EKuQycYEiXSkzrxnBQBrRXHmbvzwKxYAK"
       ]
     },
@@ -17566,7 +16208,6 @@
       "keccak256": "0x08b8b2da07d67b188aff39ea81c3d5685f99cebf87063c5ce7636e49ec7c317d",
       "sha256": "0x62b8922ad92823bf9b0ec0f17792617a88bfcff533b8ae4590222c02bb85dea9",
       "urls": [
-        "bzzr://e7694d3d322a8fc3084965cdcedc3073697b59957c24917c68f135a4c8f610bc",
         "dweb:/ipfs/QmXeuUnCo7xjaPHKRFmPhG3s1HVKGC6LXdoH5mqBCaCLcC"
       ]
     },
@@ -17579,7 +16220,6 @@
       "keccak256": "0x5840a73cfef513ff672cf477ea9fa47b212d1071b87d875b55e713f5d3a056b1",
       "sha256": "0x41611c5744181c59e575243a3131e24313d95c0e34ff200ac3d7baae76074b1b",
       "urls": [
-        "bzzr://e2dbc118f14d4dd3c543eb610acbb3bce118a8501e9d41a3c1b6749f1b57ec8a",
         "dweb:/ipfs/QmTudJjBGZVYaKHHLb8TTD993GbCH3ydm5ensMakdwjRpS"
       ]
     },
@@ -17592,7 +16232,6 @@
       "keccak256": "0x2e4dde81c1f167188b50f455070869539c9d960dc24b100c245adbfd36108d2a",
       "sha256": "0xeefc61bbb67f130030f46338d9643041c75b515dd4efb48541bd07f3f523708c",
       "urls": [
-        "bzzr://7ee769b94570d8318af636590592d4890a9d87c167355e54f68b173c2e067548",
         "dweb:/ipfs/QmaPh8F3atJhKwnxkkCwvAFRHHK11jdcqv7b4f9dC6obRt"
       ]
     },
@@ -17605,7 +16244,6 @@
       "keccak256": "0x8c5c8ae5a53d1a69f8419894fb116c7ea1d3ad3f8fb7ca4526f10537d39a42c4",
       "sha256": "0x603df2323f48f2013e6787cb9b0cbbea3510ec851335b5ad429710c22e18985b",
       "urls": [
-        "bzzr://9226267f9ab26f25b815666e7ebdd6098d70f8509c8d33187d4c613df2a32747",
         "dweb:/ipfs/QmWQZ5LBwQb3KYQbuGkNzx5gJEFpbhw8ggyvSFwr4d7ZSP"
       ]
     },
@@ -17618,7 +16256,6 @@
       "keccak256": "0xed4d895cad3d8a332ed1bb7e87e31da0cafab76627237435c258ae181b3ec314",
       "sha256": "0x2933da176deec9c2a662ff935ec2ef5f3a0bbba0e292cf970f38b031bee68697",
       "urls": [
-        "bzzr://8711bfb7c94db781442f8ddefca0ee6123d473a0e4616bbd60d4e25c8cdd595c",
         "dweb:/ipfs/QmdDipyyvX6PeY2KeBtAzXjq4cmqGLkibneZiR9Ky5LDzo"
       ]
     },
@@ -17631,7 +16268,6 @@
       "keccak256": "0xb6f2945df383616eac69ed1d66c341f30a74e39c32862b5b5a7e9260c9026baf",
       "sha256": "0xd78dfc2c97facfa685a4052ead48a05d7c9e226eb40854b72520a12d8bbead77",
       "urls": [
-        "bzzr://2891b86838b10bb4ff13dedc83e7fd87d52fee9627e313e876beb2af5fee2529",
         "dweb:/ipfs/QmYu4NXPS2vHZRVmMgk59B2pWSkk2FStw3nnLJ36KrgjWJ"
       ]
     },
@@ -17644,7 +16280,6 @@
       "keccak256": "0x9cd759a4db740018b3f74adb75f81e427a7c578582b2bef0162d1970800747bf",
       "sha256": "0x8f8f6c6b4abf67f1fb71a87c10a697e12f736bc321ae3f6e9bea5a59c109f3cf",
       "urls": [
-        "bzzr://d7cead5228c371d389c28ce50a0de7f7948d55b773e09e2f913309ca847af4d7",
         "dweb:/ipfs/QmVj8cpddmjmE8yVf613gURsGs7TaHcv2x9ZPRuajPeNqp"
       ]
     },
@@ -17657,7 +16292,6 @@
       "keccak256": "0x2a793ba5a9a14d3b7d66ef192c3013d1992c8b9b5370e0993b09d9b4ddd0354e",
       "sha256": "0x169f41f09ff4268158a0a3053d99a16db4f5891d95067c910050a0f897343ecb",
       "urls": [
-        "bzzr://0e3f697e3d83df71205bf0658919217e1bb50e4c02d13cbbaa4ebec5ed0e28ea",
         "dweb:/ipfs/QmeWBdD3fT9iGxvUUngosHSdCmPWxq7A2wfNvt3vZZj5Xp"
       ]
     },
@@ -17670,7 +16304,6 @@
       "keccak256": "0x9f5faa41bca344d286951feb2adb597ba6924f342882ce912a79f3c2c5add36f",
       "sha256": "0xca0a1c8f8b2f1dd4c4d3c650e51b0242daf03ca7175b93e8ee43c749a6930fad",
       "urls": [
-        "bzzr://a591d6af94171c19ae08febfaa73ba28b0055c9cdadf97050ce65e5624c25802",
         "dweb:/ipfs/QmWMRj14R6kPxvBuAHGVq2Fzhzs2MtC7Gx9sWVXNd8rUkG"
       ]
     },
@@ -17683,7 +16316,6 @@
       "keccak256": "0xc81e094430d7b645c93a412e632223394a7c715b1e787d8b0d005965d9130db2",
       "sha256": "0x5bf8a6fff698e9eec2bbf86b73d4cae4c22570728312574d7015727479dad204",
       "urls": [
-        "bzzr://a88267c93460be388f4a0953c2456347b3a77178ce6769fbe95b53eb22c32f20",
         "dweb:/ipfs/QmSWEam89yDfeA4cKkXTzWGr9A11nkZCKuVCuPy5aEKNVP"
       ]
     },
@@ -17696,7 +16328,6 @@
       "keccak256": "0xf2b241b4bcc78d941a12d7d9ee3973b468a96c1a8846b7ecd34e2dc52e320c9e",
       "sha256": "0x492f9630deb8363bda6892b3394e06f0438a10b063e71ed195c86a6990bdeef9",
       "urls": [
-        "bzzr://056d1fc1cd2c7eda1332c053e765583119d68203563f3c3dbf68dba72fce50fe",
         "dweb:/ipfs/QmQBHjxW6HwxHLx6fpLguhbEma4Y9ueEZA6vVPCKANJZY9"
       ]
     },
@@ -17709,7 +16340,6 @@
       "keccak256": "0x345cef81e19c2be5e00ae381e525c22ea289c04fde1b1647efaa0dac9d0e6a2f",
       "sha256": "0x8fb25890eb144848012b9e51425bc550367b066db1e0f34ae46c0e7253bb7b93",
       "urls": [
-        "bzzr://a510e7ee5a4190a059303b34c8875fda78f1e55850f169726dbb72cb9cfc1b6a",
         "dweb:/ipfs/QmT85oDcVcgg9NDBAmA4PCApdKUEASLunmFCwGWo9brAcb"
       ]
     },
@@ -17722,7 +16352,6 @@
       "keccak256": "0x1fe137aef54e3d013c7d02d76738bd3589d851d9bd77b3ba1060c086fb4c0744",
       "sha256": "0x1267931c6afbbe5b887f7f7b7ad99fdc7df3c838583a7b6549ceb5cafc79ad20",
       "urls": [
-        "bzzr://6b8d43d4d80823e65c8727ad907c12c7aaaad05ec9dc554482ad80b581a30f84",
         "dweb:/ipfs/QmSad4b2AbHd6gbNG1MJfEcPwfJsGqZ6FThkUQ5SWFSWFs"
       ]
     },
@@ -17735,7 +16364,6 @@
       "keccak256": "0x3efcd7317cd52424c90ddb3f1280df89d7939bebdf4bc7c2ca4576ce3e181217",
       "sha256": "0x5d4bc85d9a128736e7a10d2fd9fcb22a3bc1841eaa5e64ac13c65e56552b2609",
       "urls": [
-        "bzzr://afdebee729f59e3959c5d258befb0a3cee7a13081f0147c0399e3938b418ad95",
         "dweb:/ipfs/QmcXoqUmFu5gUNYHYx6TV9rD2cZ9bUYQZzF9NfBfp7Whdi"
       ]
     },
@@ -17748,7 +16376,6 @@
       "keccak256": "0x02af6d156729257dd7340331fd09e87dde60f79ef97ebe043ca53fe698bb1674",
       "sha256": "0xe098afe59b030fb534df32a1d5df6d1fe164e2ed3d2871147c958d22d40ad8cc",
       "urls": [
-        "bzzr://eb67177287f3b485191e434dbfdee75e29426ecca834ae7bbf1edaac1d08cbcd",
         "dweb:/ipfs/QmYWDPKsftFJhytEPTXwJVooo4LqX5p7oLVwTqCpFqCG2T"
       ]
     },
@@ -17761,7 +16388,6 @@
       "keccak256": "0x5ee59f3ace168a543ff3c366ad9a8bd27b4457157667831d60de9ae96c76e44e",
       "sha256": "0x3a735336098d8bbcf481b7ce1e403e773de07e4e028308bef334ae5b525de528",
       "urls": [
-        "bzzr://0215407379ece599f40c883e702c58ebd3ac8ca5ebfcefa1724ff0082bd40bea",
         "dweb:/ipfs/QmcXFBw1sH33JW4Tc8yWSyHtHRGGqPvLEQcirws61qdLap"
       ]
     },
@@ -17774,7 +16400,6 @@
       "keccak256": "0x908343eb6e3c305fd51c13b969312836b1c0ef7d2bc214915c324ec6f650c217",
       "sha256": "0x28cf3e5232ba7cf7e584e77efa23b5a4296109c46d0796f764a4a5147e36d502",
       "urls": [
-        "bzzr://a3aa3f1afa2d1fd3dba6c1fb7bb0f646b77baf569a63a907f5460685c82c96a4",
         "dweb:/ipfs/QmQyhCjn1qKuDMPrXEiggekedcbNLPJN4TEvq77n7juYP7"
       ]
     },
@@ -17787,7 +16412,6 @@
       "keccak256": "0x59a5805c3c9f0bca69d177a9ac0d86b645fffcf0e80ae9f25665dcff5e7909e0",
       "sha256": "0x46d9085a31b15ae936c50426dc42011a1ba1227c4de0ce76ed1bcf65a5e2114f",
       "urls": [
-        "bzzr://b9d1974f86ab4d5deef25bd4da93b8ea69ba568d34babc04c1ccd8e8c612bf57",
         "dweb:/ipfs/QmWtVHp85whTkRLz4BtsJEQyXnmkk8VQm3Vqm5G3qDFix2"
       ]
     },
@@ -17800,7 +16424,6 @@
       "keccak256": "0x551898e4a5c848373f7a83153847a295ef419f4b72d5e6f1e2d9cffb9c3ec537",
       "sha256": "0x36a4a5dd56ebc800e94cfd5a9d1b3732e901eda622039993a28d70c464a7a6e9",
       "urls": [
-        "bzzr://05d9baef22222b32e89402d790e97c2b5177e69c45283a8205163f318f3de4ee",
         "dweb:/ipfs/QmWDZ7trWUVY7RB7ZdM9Uh57JMNNbo4VKKBtL6DHudmoPB"
       ]
     },
@@ -17813,7 +16436,6 @@
       "keccak256": "0x4cda366a6c2a98a90af8e2efe6a8d29ade7342f060532c453200e2e4f764a242",
       "sha256": "0xfe8fcb189c6c957595da65a686d4c9a932ea21f52385f34d0619ac6b311d2d50",
       "urls": [
-        "bzzr://a0ca1c95b216800f5fa9f1f0028b27204df92bd1474e5b20f1a92fd8724421c6",
         "dweb:/ipfs/QmW4TH5SGpHtQAJDMN6GkzjCqxeGPfC4WNtTxM6wy4CikC"
       ]
     },
@@ -17826,7 +16448,6 @@
       "keccak256": "0xc2eb66650a5e17aef6c6800dbc77bf27251f70ab192eb056afc376f906f51258",
       "sha256": "0x1b59813e462bb557f66b16f33cd9d02cbff50905d08053216ff95871b556957c",
       "urls": [
-        "bzzr://04ee88227584d12239e7d7d72bcdb7764dab39f816796d21498776e508369903",
         "dweb:/ipfs/QmXh5h5B9xyDLfYzFJBYwaMoEwaRhLCYDz8HWSkdDhd2P8"
       ]
     },
@@ -17839,7 +16460,6 @@
       "keccak256": "0x93845fa1681b4e6da5a916ef75a1514532680c232fad7762735668e7393f1be7",
       "sha256": "0x518de03c2f4157adcb953d5bb0a0c0dc4aa347f812b59aaad56a473387db7e01",
       "urls": [
-        "bzzr://e64182e07bef7ab162c8321f2d5071d59abeb0bb90c5d7eeec7b0efb14ceaf0a",
         "dweb:/ipfs/Qmcy5wyCRjhH8mDFnTBmYj5dpgKdnKS4SyFHVUDDLYwYdM"
       ]
     },
@@ -17852,7 +16472,6 @@
       "keccak256": "0xb8ca8b9c7f3ecf8a54cdfbce275cfa3b4fcd3e9cc38445f31fbf963bc35f2fef",
       "sha256": "0x52e7251f4ad50cc29a4edb6253cde8d190c8eb0b5acee6be41ac8ce8b55b12fe",
       "urls": [
-        "bzzr://12b453ca481777b0da2a74ff4a0ae7241d135244b1b84c1bfcc16b884df3a721",
         "dweb:/ipfs/QmdJ4xPwTBi2gPgb3gRcf5p1k2GrwLU4GexjFLzHrR3Wzf"
       ]
     },
@@ -17865,7 +16484,6 @@
       "keccak256": "0x39831409f76ebd221d2430d9574a57177232ad3be23bdc582d82a66e729638e7",
       "sha256": "0xc7f2b89ebe441fc78109f3798f248c7fd5744195125f75d856a29274e52c8749",
       "urls": [
-        "bzzr://56136f21459e89a383d0af1423577d490131ceb30669119f38f6c1ab8c61d726",
         "dweb:/ipfs/QmdNBDvDQf62dwn3sUQQvC1QJP8zaZXdPxM1HQpdU9kgDj"
       ]
     },
@@ -17878,7 +16496,6 @@
       "keccak256": "0xbe0010ac5ef38559fefc017f4c749ea61fa5f9fe67de5960bac814dc7db18c0a",
       "sha256": "0x4e96df75a878d6c55ffed9cd162c311ee78d6fd360428a9a051c94edffa3347b",
       "urls": [
-        "bzzr://2f074cdc68bb0aabfd7f63caf6d42e764afc263595b5da05d5a30361428e54c1",
         "dweb:/ipfs/QmUDx7B9k7aFXc5GRcbngWwEsGNjX7HxyLVUPkuN8u6sAh"
       ]
     },
@@ -17891,7 +16508,6 @@
       "keccak256": "0xad70ba001fa742d09dc5b825125af8bdbbcadc2b4c39f1fa273cd26f8627212f",
       "sha256": "0x8cee5221d262c3920e2e8e1bf83102ad844f62e101db22bf922af31ce4d8f36e",
       "urls": [
-        "bzzr://e68aa9fa4f369784b756c70c6926e0b7e9a2e5ee341b2ee35ed352070f3a28a8",
         "dweb:/ipfs/QmUw6n9FHQX2X8BAqpv5YBJMcaDRp1116RZ8afwHmYDXe8"
       ]
     },
@@ -17903,7 +16519,6 @@
       "keccak256": "0xdd4ae95607655404b769fab5f949ac95c6a1a506330f512aef0d92974c390431",
       "sha256": "0xc2c4738c96ad329cbb9baea615ed50ffb5a53d93fed8e00785e47242581d3c60",
       "urls": [
-        "bzzr://38f396377d5a5a60d0b9d8c4dc1343485517ff31bcd281d531f98534dc79d811",
         "dweb:/ipfs/QmVdW2ygaT2vecoSUog3HUn8hZqXU4XXQZvuRSdpV6DJPL"
       ]
     },
@@ -17916,7 +16531,6 @@
       "keccak256": "0xecaac8cda77c0be2bb7cd63d874313c559bb37d0cb6452aae4f80d6c9510cc38",
       "sha256": "0xd5537e3e69fc36256931af5bd90332252f3e20ab11adf64f12551f22c1627485",
       "urls": [
-        "bzzr://be6c4b18a27a82cd04c3e4d1882d516840d2c211c40e9ea7fcee86613b1379e4",
         "dweb:/ipfs/QmZgHwR7cihMXFbF1jxb2kZ4qNHmPcBzwFqD1ZxYJs1ubH"
       ]
     },
@@ -17929,7 +16543,6 @@
       "keccak256": "0xe6ff73e8f81b30a095c4f7f7a2efcd514698f7e9d0e996ab912e02a08eee776a",
       "sha256": "0x212dc8b465f759a90279f4d6d209fbebcbaa3100a65ce2cc39c7af7abe4134fe",
       "urls": [
-        "bzzr://36f7b297904b3b1a942574431e5dfd1dee5a2b471b1937d66d9a4c0c02b446e4",
         "dweb:/ipfs/QmQXSJNuJ4yeTyXm9HgD4pfhY3YjBuvDgtpU8yKnRNXA6V"
       ]
     },
@@ -17942,7 +16555,6 @@
       "keccak256": "0xdac490c95b37847fadeb5457e386c1f07fe2fb046af30ae94f376758725f44a6",
       "sha256": "0x6c963259a21064f7a1332c512396f4fcd44b18be9663144d670bc9e3335c6b71",
       "urls": [
-        "bzzr://e378df2d5b9c8034273a4a24e6f77a763dca44dc5e8d6eb181b9fbe827e06007",
         "dweb:/ipfs/QmbpoLxgbtcMtrEn6D6tat1xRd7NYg1rNG7Ab7QDPktD3u"
       ]
     },
@@ -17955,7 +16567,6 @@
       "keccak256": "0x611de5d7848d7e080aa9ef1e52799a6b9e0d4cc39eb8abc5667120c9e4eb57c0",
       "sha256": "0x4c9841bba178703e83e44e2b0b44cf0fc1613570509e48ca56ac2d3ae8c21631",
       "urls": [
-        "bzzr://417754b91f5af44ad8a5f57b99ac30e968c53e555ffb45a31735a3c7c1e4c2d8",
         "dweb:/ipfs/QmY3wsjzJFeiaQrRYPxb7Bmf44e5rtoyMTxAbGMoJ2gNem"
       ]
     },
@@ -17968,7 +16579,6 @@
       "keccak256": "0x0a497744fd60aefd8362e7e24c08a9815c3bc8832bfbc1d2b6f7698af8dd7f6b",
       "sha256": "0xe6ceec77baef73b26138bc61e2b4256b406ed7cfbfcec5c8f10f38de27e1a319",
       "urls": [
-        "bzzr://b5ba307a16c1d85410fd92eb9a455436ee2ed540723fd598088629bf9a773a77",
         "dweb:/ipfs/QmUbTeriPybEtMcWqBG4d2BzqPM45Z7JphX2KomVRRxbCL"
       ]
     },
@@ -17981,7 +16591,6 @@
       "keccak256": "0x6166fc75f585ed24bbcbab7368826e088ca3f3f9d8c56ed2093e824696fbc26f",
       "sha256": "0xc8c1b807d96215693ed787217babb879ea1808dd6d3e1cdcec0d2179e4140d4c",
       "urls": [
-        "bzzr://e8bef8bf9beb75f52f9c45b605c45f905c5e6da31ed427dd98e1f682986b94f1",
         "dweb:/ipfs/QmVDMboyEHdjpgqEP1h2jQqk3ap8BYTq2Jt1YZxBWW9FXt"
       ]
     },
@@ -17994,7 +16603,6 @@
       "keccak256": "0x813bbc2eafa5030783e79facd939da94f70df37e0a8e73386b749e3ff2e4886b",
       "sha256": "0x2af81fa59f810a23610586ddfa1324274fb260be775de6b8b3916dd6e97e8110",
       "urls": [
-        "bzzr://68c9478e1f3b913a8d0010851c775e91c65bd724759d0329430fde11f1ede54c",
         "dweb:/ipfs/QmdpTzWAwAiCYhPJzjsBL3BtKBHkuxDPVgWYEMSedpLP9q"
       ]
     },
@@ -18007,7 +16615,6 @@
       "keccak256": "0xcee7a58c77b8b442c8fae45d00adf86e0823963901ab580de8f5e79ae5fb0897",
       "sha256": "0x32b3ad34dd7b286f160b028f87261c01689956246f75fc9faa95dc6fbcdd2de5",
       "urls": [
-        "bzzr://61b6c29b7ccbd29c7ff510359ca71c9bd632f80b762193fc6c9e2217ae7bc7fa",
         "dweb:/ipfs/QmSTNeJGpxMdT8gCYhexYeiijnDsC8Bhj4AYj7frJz3Bgs"
       ]
     },
@@ -18020,7 +16627,6 @@
       "keccak256": "0x1579ece15e4ffafaa334ffa1d21fb40580523634569384c4d7687f94b507bd9c",
       "sha256": "0x43699f25712c93b650fe5f83035aec9b553713e3af4c2c4388012b189141fc14",
       "urls": [
-        "bzzr://d8b4d41f8889c4499427945ef3df0d3ae3aade6a917b0b4f276d4e02cfd25057",
         "dweb:/ipfs/QmNQkeo7M5J2gVVNxs23mAqyiNdVtJGrJ54sTHVsocaLL8"
       ]
     },
@@ -18033,7 +16639,6 @@
       "keccak256": "0x86c03e57fd00ae7642d83fcb1bc3a190d5554455d7eaa2a459e7fa75b82a968b",
       "sha256": "0x5b6eb47455055ff4bf27ebac425593827270c9c81715e7a2a2b2c7c1931a0c56",
       "urls": [
-        "bzzr://762d4c28fff9362750e8ce16cd33cd37a8a2cd9a4fbda98059d548fedcf7edde",
         "dweb:/ipfs/Qmd9zVubMHNgwxKjJPa9JXnPrGJDhLKR8hDSHm62XJeps7"
       ]
     },
@@ -18046,7 +16651,6 @@
       "keccak256": "0x8039699e6aac1065282447f02a68d4ffe8a4fd33e0fde284265120c2b8d96c48",
       "sha256": "0xb8426a2d5e0e32204278f182a4a52f0c28045c22a68f08814782b9e84301763c",
       "urls": [
-        "bzzr://a28e6d1b9eb559d3c552075e6df49e4b8bd4e076b026e0a84d6a04e39a20b056",
         "dweb:/ipfs/Qmbks2eTwzzbfpYH5PeuR18YkBgh6ANracogcTg3FWsEtn"
       ]
     },
@@ -18059,7 +16663,6 @@
       "keccak256": "0x055ca78775a4ed722e1a33f54fb4dc51cf291e5742f65b890903769b1faa1fa3",
       "sha256": "0xd5658153fca372e7e46d5b0be67c811e0c84b6703ea4ad79f9910767ef58b589",
       "urls": [
-        "bzzr://b8e2646474a277c5317ab668e7930edccfca9069ef5f46a652349c72f8a7861a",
         "dweb:/ipfs/QmbmnYso7NVn3jU3vYRwS1N1kDzHj2NXwULLsrrejYNKxD"
       ]
     },
@@ -18072,7 +16675,6 @@
       "keccak256": "0x1a801a8f326c0c23a83f41ddee4890d38fe810a44da0841079cc058035302202",
       "sha256": "0xc38d65863d2cf75746b0879e45679046bc60092f3f3e35046d7b1f62a2baf781",
       "urls": [
-        "bzzr://4507af2093c2a2fad37fa62925c71e3e5c34dec785e0dc77eb0b6be280303d0d",
         "dweb:/ipfs/QmQr3Z5Nhp8gboLXpZiXHgbbJLp4SZDsKTaGfSgVBTDqDp"
       ]
     },
@@ -18085,7 +16687,6 @@
       "keccak256": "0x52418d7a9e879bc2639e6ab22131f8f5747183a2107cc4fffeacf302cc752c88",
       "sha256": "0xd151e994e88cece3fad0d65365159c39621439f309d1d5cfc16f7375599b8f26",
       "urls": [
-        "bzzr://9e64ffdf5471f1a37a182c415090e507c9a0bee231a89a27bfeb781e45b47c05",
         "dweb:/ipfs/Qmdqsdf8NeohTKG6vSCFoVRgAQWZHYcrbcxtBnZ4wrvJbT"
       ]
     },
@@ -18098,7 +16699,6 @@
       "keccak256": "0xd6bce66a3cc2378fc5f473468743b1293d46c15bf037e57d8c526ae2849db1cb",
       "sha256": "0x766527f26a80db0e05c52699001771a5e1eec2401c6dc6bbf0cc318a1592819e",
       "urls": [
-        "bzzr://380475e5d69d875d0683cfeafc49b1bef516f390b08eef8fc25037d97876d1c7",
         "dweb:/ipfs/QmWngEzH5NE1Xp9nJaGS5Th56wjwJv7br9oKkfFdbiWBf7"
       ]
     },
@@ -18111,7 +16711,6 @@
       "keccak256": "0x7fcfed48e71dde148ec84d0649a2fda99a6de24ea13238cd2bbc4b8e375a59eb",
       "sha256": "0x752298fbaf754f0a3743e02396e57ff0cac19f65c3732388e2559911f4b904b5",
       "urls": [
-        "bzzr://2d3285787dac40bc0136f9660ff8818ec9544331770bbc70a4dde7f69e44198e",
         "dweb:/ipfs/QmVQRbfbLDp8Epmp5qAUGL32QpGfj9ggPBuRyUWda3Pk16"
       ]
     },
@@ -18124,7 +16723,6 @@
       "keccak256": "0x37668c38943c0097fe7dbed8197caccebc36c33e45de2b1ee41a26421490e569",
       "sha256": "0xd1a38e0a9643a1194939714aaf8a547cea8fedc515c1faef05d2e209a1a6354a",
       "urls": [
-        "bzzr://8a11488d3525dbe2f9d951b1adae314d62b7a1e387e147ad56259d14b0c98bcb",
         "dweb:/ipfs/QmWbFmqJzCb4NxkjE76NSSfo7BiVB2acFk1LkobkdgbdjE"
       ]
     },
@@ -18136,7 +16734,6 @@
       "keccak256": "0x9afa714859d1c8f8ed2fded497b83a7a420474282494d25d4c9f592667729f21",
       "sha256": "0x387343bcf8f2b77fe4cdcddcaa84361fabf8e1c3508f874fbbcbb9c313542f56",
       "urls": [
-        "bzzr://ade0fd040981c4e8c7adfe366296e452687c7bb6421de8546a0678be4add016a",
         "dweb:/ipfs/Qma9V9dJwmkim98H6DQX4f7RH395vsUuqHCDxbKetcbj18"
       ]
     },
@@ -18149,7 +16746,6 @@
       "keccak256": "0x6dbd8a838b42cb1bfac19214684d4a5f3ea939b38527020fd44a10da19840a28",
       "sha256": "0xc5f53a4f31a3812ce887ebfb9263e8efa96be92dc44e4240a82a177ebf9ab08a",
       "urls": [
-        "bzzr://6e7b0291a56623115a88f6a5079e1ff01f2f14c127d6d28adc642875f03255aa",
         "dweb:/ipfs/QmPH1J6oLna5G2FfCxHjBktaZSNkLqPJVq5hKLZFk8jLzC"
       ]
     },
@@ -18162,7 +16758,6 @@
       "keccak256": "0x8b12c4446906f76c98d18a0c1229c9b490543a2a25af648e97292c6f1acc95b2",
       "sha256": "0x090b3c2c653510d12f7a41339ce652e98f495a9bf5d0c93f9be1a28f22097f53",
       "urls": [
-        "bzzr://9dfc05ee64e89082d46e0d64719f17cccd81557f289aca33eeae5f65c85405e8",
         "dweb:/ipfs/QmbDhHjVrC4bwLQDAKjq3ntQ2aJimiPMvpRex9hdsDsAMo"
       ]
     },
@@ -18175,7 +16770,6 @@
       "keccak256": "0xc90e062cd07a6c2e7be92c77e7f81cdbb9f237128c2e5fe028d7991c9b5bcefd",
       "sha256": "0x84a03cbfc82ea5cca096adcda1514a0d6df7ac4628a75c5c94789811df0fbc7b",
       "urls": [
-        "bzzr://32d5ef4f2557abeea108c0003df711b47225eec2a6a7b1e6436e739e34c5d602",
         "dweb:/ipfs/QmPcbHFCvZkLxFsdhNNVNrtSNrKM48Hud8ZsprPmK4KHfC"
       ]
     },
@@ -18188,7 +16782,6 @@
       "keccak256": "0x149f48db8c7ce66a3daaa66469f70950c5c262664145a6fa892d285dc12072d2",
       "sha256": "0xfabb8f10c59fe538006ed8fb26f7718716b600796b96da0cd303a4467f5510c3",
       "urls": [
-        "bzzr://76b02dae52884b32cb342f09b0630cca808a7a265357b9485e15e238cfdc9dcb",
         "dweb:/ipfs/QmSL1v54Lb9arnqMDQPNUULvaCUXey4c3aWfTNvV2Aaujb"
       ]
     },
@@ -18201,7 +16794,6 @@
       "keccak256": "0x830d64be2deb4c355cb376e6e5f9049a55559f97059a6b18f44f7c56c52783d4",
       "sha256": "0x1fc60122fa4344ba8d09919bbfa9872dde9ac84a6c33995e611bb58340f19126",
       "urls": [
-        "bzzr://50a9e1e001ff11c04d6d645191ea111bfa21788fcae727b31283a47c3e1fa646",
         "dweb:/ipfs/QmZSwucvyJtASCkzPoEyEjr1sRsC7B97J783QWAbT5K5xL"
       ]
     },
@@ -18214,7 +16806,6 @@
       "keccak256": "0x8125a0c07a8fb355555a632535b1ab687d5d82298fe4d363473336314fde3e2b",
       "sha256": "0x72a895d2c5748948d5756a43b5c1fc3c3988e4398660674909a1b3c727c31fb0",
       "urls": [
-        "bzzr://aa7788f479ed58a0a66cecc9ee1dcaaaf987eb59f84f519e7a891422cc47fa89",
         "dweb:/ipfs/QmX7DNyxnfHBuyN4mLBqZjMVE5WBnUoUf4VHzs5g9hq6gc"
       ]
     },
@@ -18227,7 +16818,6 @@
       "keccak256": "0xf6c5c48146abfcb4b0a600c4d9d47021e0c620cdc3e84d849bdc7c571da96b00",
       "sha256": "0x4d936e4497d1e816c0eb5acec21fa4ee185e67f224cb1ba9cf4fad499d771601",
       "urls": [
-        "bzzr://c78a1a1092aab7e0262adf86b1054d69c255f08e3a13813b0086cb6676ed43e3",
         "dweb:/ipfs/Qme6A4NUV8WBM4igRYf6r8nFG2iwqpbN8TUoFRAkquhv33"
       ]
     },
@@ -18240,7 +16830,6 @@
       "keccak256": "0xb0a8d2d5fdac8ee30bbb2d32caf829cf59f697bef0a25807938c68fea6ba7d91",
       "sha256": "0xe1445d1d26167ad1b3902226786f969fcd024b36c604e570fe1927d08808da80",
       "urls": [
-        "bzzr://093ea087a1e9aa0c552ab7054fb6fa606866dacbea2d0d58cf29b821bdef8896",
         "dweb:/ipfs/QmWxs7phpb5SUU1eVQHttq6iELcz51y1817ivZ6uZUp91Q"
       ]
     },
@@ -18253,7 +16842,6 @@
       "keccak256": "0xff3e3dc1163c7705ca21a4a2012a74c4475a66ca8c4c69d95839a0655bd10772",
       "sha256": "0x4419412c214cef1b38f9ff0e0e71c1201e742fd0afd2c4850fd5fb87ee45137c",
       "urls": [
-        "bzzr://421dca85897eeec30207937f13a6f133ecc589ce5c89d0614c52ff00b61db63d",
         "dweb:/ipfs/QmPJMa2PLcTCBNMr2ryExb7QaD2JbMivunqXWsG7GexUt5"
       ]
     },
@@ -18266,7 +16854,6 @@
       "keccak256": "0x105821c0eee90c0ada28c929085ec000e78e920430473a475d69d359cfa802b5",
       "sha256": "0x6e41a918af8b0f05a23c0e3e425a240ab87860f59cd1ab86e35340e01e3b92b1",
       "urls": [
-        "bzzr://05e169823f9ade2b3c82976f106fe2503e788a6af0458f2f9aa19b0eca677678",
         "dweb:/ipfs/QmZuRrLy5jvK9zFqo8JTiNvvX4DLFmkLmsSjBTakiJyfG6"
       ]
     },
@@ -18279,7 +16866,6 @@
       "keccak256": "0x49ddc497af6ed677e959e876e8e00a7872a6151876f729117a7b4db722767906",
       "sha256": "0x3609eea5e7f3592ba834591fce6971c847015478cd9c2c3619e884d81b05c4b9",
       "urls": [
-        "bzzr://c33a449f6da7fdfb1ac4f12ca3f6c55ed9e95c72d7473b35a512d57e87054922",
         "dweb:/ipfs/QmSzSWo4iU2PXCVe7RBmJcAF94w5dCbNFQZuLe5u7FT8NZ"
       ]
     },
@@ -18292,7 +16878,6 @@
       "keccak256": "0x63ebfee323bc6ce00b40b062fa4013b78ad93ef5572eee29e21eeb9c548b8ead",
       "sha256": "0x24dc8b7dc37c204158e746bc6c270f9ef565b6019d66f28270f92425a6c0cae6",
       "urls": [
-        "bzzr://321cf8e7cbc9cbaaf72984de9841da1487e74c9066a9f4665c69267f7455b481",
         "dweb:/ipfs/QmPLdKkzeKkpQAs1GuirzzkTJGP7gGYHZSCTTUa1MLPNHN"
       ]
     },
@@ -18305,7 +16890,6 @@
       "keccak256": "0xcf0a3d60e7b0eb0e84c17b4028b8c825d66a34267467df653db4ae025148f301",
       "sha256": "0x1e0c43ca53a31c3aa9c2423319359dc2ca9b4defc1e7986a52d1b9803348f51f",
       "urls": [
-        "bzzr://61895a1fdd4e9279e8bf79ec107e9142b040318a565ec202c89df13858748f95",
         "dweb:/ipfs/Qmcfk6RBy5GfKRfFkR6ghPipu497WB5b63PDpyUei6szP6"
       ]
     },
@@ -18318,7 +16902,6 @@
       "keccak256": "0x36c7a71108683413d937a0deabec7cf139f85cb185e50d882c12763212a34902",
       "sha256": "0x8b3929b48934098434470a07f8fb485fe3ec853667b8844ec0494a24207728fc",
       "urls": [
-        "bzzr://e352149f5c266a247fe9cdafbac130774554955465de65fa77d87268bd057254",
         "dweb:/ipfs/QmNaNMD7RT9TW9piUdzA7Ga1H4ACmzTLcqiGJnxCQMhjrK"
       ]
     },
@@ -18331,7 +16914,6 @@
       "keccak256": "0xe9e20a79738df947d69a9a2920a328c1af4967eebce4d519552f02d025bfade1",
       "sha256": "0x9ba722e63894c046baeac4abbd9187bba42bfa99f1eb0aa399e02705d5428926",
       "urls": [
-        "bzzr://66b310699f12ffe8f1d56070bb072230b7a60fcdeac3fc7c98bd0408638e1b94",
         "dweb:/ipfs/Qma5LLEV2R3et5EjeApJZ8tj4iEKhQ2K3C4S6esjXpU5gx"
       ]
     },
@@ -18344,7 +16926,6 @@
       "keccak256": "0x39218ac3ad982d23ea41d876f045be0df04acae6a30d6730b12a2fddfd03ec83",
       "sha256": "0x2a580920b2ccaa72b8b759b76dc517d318ace6793d02eff2c35b7261cee506f0",
       "urls": [
-        "bzzr://0146abe99c8a1a8490c41b99dd289f043cb7c7e9b82a9cb4174972f774d3694c",
         "dweb:/ipfs/QmZ9MDww1sJdxZdCRfwNKSEwpwbowRc7XcCGKE61cX6NtP"
       ]
     },
@@ -18357,7 +16938,6 @@
       "keccak256": "0x3d527ba1c2c358dc1c7d35dc592e58b1f92f9b7a0ffc64eab87764d8224d1b60",
       "sha256": "0x1f703d0929d04a085612ab6bd074bcc6ed251bb55c1de98018d3fa23a699d7b6",
       "urls": [
-        "bzzr://baa589caf703e35c13b69384ba90911437c309c82805cca27b96963b4cefb6f9",
         "dweb:/ipfs/QmPKs15VSfoiBtzqdfjhycKZDs9KtRU9To2JUFiNxL9V9D"
       ]
     },
@@ -18370,7 +16950,6 @@
       "keccak256": "0x7bb747905345eb6f412d713d09cce606b3a62a2e3973712674a42066ff8538d3",
       "sha256": "0x701e45742f545592e3fec35bb6bc00afe5be56c7efa8c4c5c9b6e7309acf6989",
       "urls": [
-        "bzzr://15d1afed75f35f5166b28b3e316895db8801981ecbe75f05812190d54f8d0f8c",
         "dweb:/ipfs/Qmc5iTcus6JD6FZiosWvykerxPtbHpp4VhEoHRtqukcz9v"
       ]
     },
@@ -18383,7 +16962,6 @@
       "keccak256": "0x7741b24cb4dad87870ad0b6473c0c03171196b6ee5acdf1543e36ccc0adaeb72",
       "sha256": "0xdea03ea5fdae747820499808e8c7d29511eedab3b1244cfe1ddb7fc9680e6fc5",
       "urls": [
-        "bzzr://2a53b0b318fb0b1c6c7696084f81874bf120873d7efc4330b753c54f05ec31ab",
         "dweb:/ipfs/QmP547miTozcE3fWoyER4piQMG5qzo9KAAJS4EaiG2TwKS"
       ]
     },
@@ -18396,7 +16974,6 @@
       "keccak256": "0xe40486666718baa7675ea968030c8c1aa742dc8e60b3e47ed44d36835e9793e5",
       "sha256": "0x19e1709ec73669540ab7629fd81c1a062fdd0193bd4415b3ff49979ed307e3a6",
       "urls": [
-        "bzzr://f28f26af14de0ae4de1b5df314ce1dd538758d0447fdc8dac1ff6014a17279af",
         "dweb:/ipfs/QmUGnERKUVJrnoivTGSC34upS4P4LT5LQX9ZZxdy3sdVyg"
       ]
     },
@@ -18409,7 +16986,6 @@
       "keccak256": "0xdb4fcfa0dadca1ce210cadb6ef8159a3f0aa5378b383fc1e061685266dcaa3e9",
       "sha256": "0x01b6ba67ec312cb7a062f0dcbad6f0d4d864214a2189ef01af144d06bfc14a06",
       "urls": [
-        "bzzr://ae49fb5d4f533666abd3b5151d5fd519f47c954ffb3a78c193ec0e42af82818c",
         "dweb:/ipfs/QmQkzHBrdUguvewDdzVZsCyEfHDUKj3m2UA1SaQjZR27Ku"
       ]
     },
@@ -18422,7 +16998,6 @@
       "keccak256": "0x67e8a491d9cbb500912cb07c4d6ab97137b03c6ba1a6bd42d87f8681bc3139df",
       "sha256": "0xff05fb235063b77036263a6f7d753b07cb8d9f580672d4c649f5b8ee13e39369",
       "urls": [
-        "bzzr://169d02c424f2790087a1110a8f3f6b71615da3dd2e9c4cc0648440d08345fcf3",
         "dweb:/ipfs/QmVst9QSqZTK2avL11RVKYE1UfdGB7D7rX5yoJAmsbfv7b"
       ]
     },
@@ -18435,7 +17010,6 @@
       "keccak256": "0x1ccd09e36318d8a27b80bf71307f7f38db9385cd959daee7c464dec311e3ecba",
       "sha256": "0xed874afa7efc2f8d32cad24831408ea7a5ef9ec91719b9e61491e5f809045c3e",
       "urls": [
-        "bzzr://384ecaa2a63ed55337283641828d0e68eecfe44ccd7464e292fbe80ba80ef2b1",
         "dweb:/ipfs/QmXsjx2xxVr968cTrh1vy31TmG4DcMRiAoeRyovh7zqGTF"
       ]
     },
@@ -18448,7 +17022,6 @@
       "keccak256": "0xe8b9245136e80d8e0633ece7f8b99ed713c2ee306f53380b2f9d3fcae59e090f",
       "sha256": "0x28365c73010dbdf3bdbfd1032b414272649a84331e90552d3588b9f69c0f7e34",
       "urls": [
-        "bzzr://0384b5cf7901d576c0da96661747e50c3a9c07291c3d2eb4f728ff01d5391df8",
         "dweb:/ipfs/Qmc6GytcQiAWSuhYkniotwXk4bY7AfE21EosivoDfTqxn6"
       ]
     },
@@ -18461,7 +17034,6 @@
       "keccak256": "0x5557f160e72e13be0be296cb269f3a8e9c9b248db5bfeb93346249a4c1cd988d",
       "sha256": "0x2eb5a700193aa6715665fdce0dc68905a23cc2d4cd4cb416595c8c6854515a43",
       "urls": [
-        "bzzr://6a0bb7ef2d4f5dde231276059f19c4e76deb4d2f9311dc57ca0c37ca1f596ce4",
         "dweb:/ipfs/QmX9q39bmepzM12zShAJetptxsH9m3y864o3XC8YKGSxtR"
       ]
     },
@@ -18473,7 +17045,6 @@
       "keccak256": "0xb0f7f19a8590e5c0aaf779019c1deaafed170d8c26bec9bfd782d212e097619e",
       "sha256": "0x7c3b3d0066fd381283b1d8d9a86153b2ddb5c01da14a1ae015c05cfa484e81b6",
       "urls": [
-        "bzzr://fa438d41ed52c9e0cca556efee61486fc77e60df06081921abb0a0f19b602d35",
         "dweb:/ipfs/QmcM1TcDB4ta8ttNLWZ4d24M4Qs35rc91sQkdNmJMNbuvV"
       ]
     },
@@ -18486,7 +17057,6 @@
       "keccak256": "0xc43a2b2d70fe1cb003440f6380550665ef83fb15ba0807be8f19894f5b5eca17",
       "sha256": "0x2158766b886616ea79896a1ecd3f026078f80c9da5368acf4b954d976f31a221",
       "urls": [
-        "bzzr://9e76deea665e6e3d3dbebb764c90c352baf711e96736383765ebc93ee0277eaf",
         "dweb:/ipfs/QmQjaqNHuYMysATX4bHvVsWP5eKfqVHCgdfbcjzi8y2x8L"
       ]
     },
@@ -18499,7 +17069,6 @@
       "keccak256": "0xb5b3ef6f9c37e669a03a87bb213bbc3e975a0cd59ed212743cceb14ca151b096",
       "sha256": "0x4fc18b63ca392cfebbf61fa602b267c0cc611d1b86435713417b6cdb005efbcb",
       "urls": [
-        "bzzr://3ac6c37efbaba619537b425940804c2df75798527ad82505865aceb4d8fb4f28",
         "dweb:/ipfs/QmWZriFtBQ5s82XddcRQKWiqMis1XjH3YAK445HpXrQbig"
       ]
     },
@@ -18512,7 +17081,6 @@
       "keccak256": "0x1697cd1daf5f5760f6b07b4e3ed015d20345db42a2b64db20702c8c27e97ac90",
       "sha256": "0x4f3ca4952f37a8baaa8375854b7498e795c618ae3186e11f536552ff8769898a",
       "urls": [
-        "bzzr://3005ea4f6667360c9e6e2f7db14e9ee8c479b621ede7647b1693c5a5412d3ff4",
         "dweb:/ipfs/QmW5S4Yx5XW5p6gmVjsEo37ssmp5ivNpM8cEjJTtRKZaDN"
       ]
     },
@@ -18525,7 +17093,6 @@
       "keccak256": "0x992ce515de6c20b39d99a27c715b580dce1eb083d5ca79a4a0affeb43510520c",
       "sha256": "0x183a9ad978c75e407958a6e3974089a1f9d120ec74dbdf0307c5338efb680f64",
       "urls": [
-        "bzzr://b43d7346917e18caafe0a29878708bdcc9b411d0b0ffa2f93fd9e38c77b4c9e6",
         "dweb:/ipfs/QmdjSjZ4CZNp59J94UdwKdHKYmWiCKcP3UQi1oLtm3BGNS"
       ]
     },
@@ -18538,7 +17105,6 @@
       "keccak256": "0x72c4588ec42b6759d5a99a4a0977e06329681333f8cc8623c61c9b97cacbfb19",
       "sha256": "0x1b29dc1102ad77cd6b533f84c18a2321f3b95c3a4c358abc55e8a2016dd78b45",
       "urls": [
-        "bzzr://2695e8f4630287a3ffd60e2d7a0769e84c70965769d930d078e9139c25ed69c9",
         "dweb:/ipfs/QmPZUh8NYkjJGiVtgcqrzFk9J3qZ7riKRLfXYYFjWmCzW4"
       ]
     },
@@ -18551,7 +17117,6 @@
       "keccak256": "0x58d89c45cf4d1d0a7ac2dac6af3b04294dd2845f5fb4802724a76ecbd67fd202",
       "sha256": "0xc132a7540f812eb9b83b95146501da42a4e0a715a3cf65b463990a3f317efae3",
       "urls": [
-        "bzzr://aee1845e172ffb9cf25677327d047f14a986f99d4a98356a89644e0e312779bc",
         "dweb:/ipfs/QmcxrBCxyzfrmAwEeaRU9daSMPuwVS34mArX6U5b38JV3f"
       ]
     },
@@ -18564,7 +17129,6 @@
       "keccak256": "0x8702ac0817f97168d40adb9255c0ae68fffaeef200d12f7c89dc0a7acb3146d3",
       "sha256": "0x11ccac463edb5351716820d29a75b6208d68901c7b76d6ebbbd474ce864fd212",
       "urls": [
-        "bzzr://4defe2cfafd509bb4c370c231cdf878eb2fca1fd6548b15b2225e0ffd34e1dfb",
         "dweb:/ipfs/QmPKvLfwZ6DWKwY7hemmVEnPbL9pohTXaGBSwtzWWLFQPE"
       ]
     },
@@ -18577,7 +17141,6 @@
       "keccak256": "0x04c2849fcff214a630335f46d2eab2b4958884508fd0483edabf690169ea0a46",
       "sha256": "0x4fc7375ac9024d05bf1f41d96bcc6157da53a72be4f1b0de0471b8b40c6d1a7d",
       "urls": [
-        "bzzr://51be675d1aad2aae2ce1dd529c99f500ba3fe52ec88e229c8fa43ebf7dca86a8",
         "dweb:/ipfs/QmXcGCnq6NekRTJqgx5Fz6FFezMiME6rebtsGNHZCQLN4q"
       ]
     },
@@ -18590,7 +17153,6 @@
       "keccak256": "0xa2f2257fe92ec4ffd0a29a4e2c1b3671385cca9f7e276c036ad21e9b4d00e528",
       "sha256": "0x51b20c3b501f81eb618318cd38a0479392029625f8688d7964f6a9f4e53f228e",
       "urls": [
-        "bzzr://3a4f2fc9ab8f17ebb168f8716397449b9528bd381b8065e902f6502724080b25",
         "dweb:/ipfs/QmUxccRivYPYcK1cB7k244WwtjSEZDpFGpUyoXMXJbFHEy"
       ]
     },
@@ -18603,7 +17165,6 @@
       "keccak256": "0xe3794a6bdaf5ded606069589eeb0733a962b3e712b6faabd800a011ae66724de",
       "sha256": "0x44d44eeaa67165b2a80de93960cb6cdcf43f6e1659e1bbc2349e5e0a985a0bad",
       "urls": [
-        "bzzr://4ba3ab07c50e06f9cae5a012cf482c3dd2ab6e52f8f21faf1c50a68cc05778b0",
         "dweb:/ipfs/QmNhbeEEkMgfjmWNyxXwvD3pE8kMYbE4G73TFbFwZG5vjS"
       ]
     },
@@ -18616,7 +17177,6 @@
       "keccak256": "0x30901b94854c5093aebe146aa375a960d3d7b0b169245b41c69d1ac9e3401e65",
       "sha256": "0x45f40aeff48fde939a37011c800c37c17fbe90359b621854e0dcd93e033491d7",
       "urls": [
-        "bzzr://8f5d29985be0a7b5001ae8a0355d0c1628300e8554b2ec2b77ea06a9bf2125d0",
         "dweb:/ipfs/QmWCfc9cfWhUbQ6jH71r3w8gRUPLi9Lavu4D2AK65aAdje"
       ]
     },
@@ -18629,7 +17189,6 @@
       "keccak256": "0x3a0af2fe548ff5572da66632b520825162aaa6ee33ecf5d80e776e34dd105504",
       "sha256": "0xdb8ce5ea5421924267ef273b4f830c25bdc19d288550576024ba7c3a91c4bdda",
       "urls": [
-        "bzzr://35e34202033208b3cf7c1ba4184c7f58375cdde861dc96f49cbd5817b96a58f1",
         "dweb:/ipfs/QmaDx2VxwMnmGDWJKzyrx8RKZah4QCXtVdo7F73MHBSanT"
       ]
     },
@@ -18642,7 +17201,6 @@
       "keccak256": "0x1d8cf10234521204ecf1111f105e8ccfa936129361b3addc20584f0a4229596e",
       "sha256": "0x10723ea95f86cdd50fcfa8acfdf3e6c2eef353fd4239f8448a231c0281b8d075",
       "urls": [
-        "bzzr://39ba5fdb98a3ad0bf1fa1123b84211bae747fb084ee6dc242995dde59d049904",
         "dweb:/ipfs/QmYx8pdgs6rpj6hayQZQfsJZr3SCmWXXugyWjFSEiZUH2K"
       ]
     },
@@ -18655,7 +17213,6 @@
       "keccak256": "0xca60b095075d3cc9be717b39dee396475e50086aedff8b76a20ac9cbeedeaf2f",
       "sha256": "0xa6bbb86cdaed748f1878c4b678170ee60b59c9ddf15d0dae5b1f33051f242dbb",
       "urls": [
-        "bzzr://ec92765725dd1c01e50999085717c45fbbdfe6947203d3214261422b6f0d0e40",
         "dweb:/ipfs/QmcsBTuYbFxnjAzLsFybx9nh2gTfunw8WvRFLwcmhmoPHp"
       ]
     },
@@ -18668,7 +17225,6 @@
       "keccak256": "0x6c0dd3027ba158afd77e459410e2fe65d27aca100d5615dbfd84a8dc4d8ebaa8",
       "sha256": "0x9956bc6c320e6efdd5d85c5c86054b5276ae0cb5a6627d01046b67601e48fbc0",
       "urls": [
-        "bzzr://399d61c1eee761d19e56ac765ee6d7c48c982ff7767589483c425024b0db56ef",
         "dweb:/ipfs/QmScLfZtPwt4T2p1FTvGC1fEHprrEcTjPuQxhzX7axXrMU"
       ]
     },
@@ -18681,7 +17237,6 @@
       "keccak256": "0x2281ef878f71b388a4b35593721eda836176b982a9553c1ed09f983f2fcdc17c",
       "sha256": "0xd0b29a0d63cc3e84b6721e000f08bb75071409c087147577f0ef146e6734a354",
       "urls": [
-        "bzzr://09fdfa69c6ad30446a40c6b3b4cd9034c2af08db43cd12f4c19a526cc0afbcd3",
         "dweb:/ipfs/QmcGQ39xCnexmapxhJFFWPmSJpBT7BdX6Ga3M5ZKbitzF7"
       ]
     },
@@ -18693,7 +17248,6 @@
       "keccak256": "0x4f6cdc0f25e734bcb977bb6a3e22fa41d8a82cbd5f220a2e4238c2d233526d1a",
       "sha256": "0x71135e459d691767ce3453bab4564ef4a640dd50182da36517cbc1f96c1d4c7c",
       "urls": [
-        "bzzr://ac5baefba32f4779a03d1207d9f1ed69365280c702fd73002a729b7a3d52c425",
         "dweb:/ipfs/QmPiBrYZxxpNZPQ98GNyL7Xa1F9Dq7uHtdt9ESwhPNkHhc"
       ]
     },
@@ -18706,7 +17260,6 @@
       "keccak256": "0x29637021d53afe2cba405b1cf88157904d292535d8b4949d6af12abbb67c91f3",
       "sha256": "0x9634f392ebc0ab0e1869a6ede12b194877d72018c32575281aa21c0b943a44b2",
       "urls": [
-        "bzzr://3174a27913e7c2a5e7a6873a68c6ab7e43fd6c11826d18130c54095f161c5ccd",
         "dweb:/ipfs/QmRURVBFPeAa8FHnSPQKLTDjtDVerxwyRucCwonvZV9C2q"
       ]
     },
@@ -18719,7 +17272,6 @@
       "keccak256": "0xda13d3441ad331a2b29a0cf30058db716160f5457fb5dcff3f118eb7042fb7d5",
       "sha256": "0x0ff8ec7c1ea8d513e2b06ce3410cf487517599b103e4bc9cc4510df7bcfdaa00",
       "urls": [
-        "bzzr://4136c989f5045b1caf311d01687dd503ebccfa843ef1477ea2a1d7dca26e8011",
         "dweb:/ipfs/QmXVworrztYSuMn3rodrEpChDiun1NhsrLMPQ6XgvmW4bW"
       ]
     },
@@ -18732,7 +17284,6 @@
       "keccak256": "0x1dbe4b7d5427dcac9b9a01c449856f74e65dad353f2c10202421ff31ef770182",
       "sha256": "0x7f0a39d3b204d2200db03156fa616f4f5f80bcb52db22e8453efe3c2d8f689ba",
       "urls": [
-        "bzzr://e273efb424fc5b4d0d4e299286d58887c9a7e3b02f7800e9c3a35a892973ca67",
         "dweb:/ipfs/QmVZPnnjJ8RS3zvsYb6Q5cd1STeudWdNZmKT6x2wXK6P9X"
       ]
     },
@@ -18745,7 +17296,6 @@
       "keccak256": "0x015a23e4a25158bc29515550b0fb8c10b1cc9ce4d24fe181cdc7ceb4a1c82370",
       "sha256": "0xd61864413386377c7ba2fc94339e377e224017ca923c616749d98216dcacaa70",
       "urls": [
-        "bzzr://e93f50e4115cbe4f535149b232481e6790d32c2a3a9dab5057c13bfdd6876f47",
         "dweb:/ipfs/QmVWYLbPNHui1hVfJpNEUDpW3tggmzxJX97gaHtpagy9GY"
       ]
     },
@@ -18758,7 +17308,6 @@
       "keccak256": "0xd13a052aa23997cc5b17ce33c8ae6030d187545d421531e2913b5013a620863b",
       "sha256": "0xce51492d4a1ccb4940168c546a6869c8251934389ce6c94e9766570743ae6adc",
       "urls": [
-        "bzzr://1fac48a96bdb1e2949f89efc95ba559492b507a5ef95b5f10ad05a2a84251b28",
         "dweb:/ipfs/QmQLJf2aXQWM4qFvUmH7sBhWhHRAiE54731WkMXmcRKFXx"
       ]
     },
@@ -18771,7 +17320,6 @@
       "keccak256": "0xc8050c8093fcea30603a28b44832d159022eedbe5bb6ff9c79fd89225fa1937a",
       "sha256": "0x4fc5fb137a49e831bcd94ed8762ea58bd0ff5946b33f3ae5273e2022d3e1a608",
       "urls": [
-        "bzzr://14527df8d24f61139244d7f3984ba5bfe761ac8017e9758d1572ff899de3d928",
         "dweb:/ipfs/QmYwzbwutMDtY5jWKg1kr1z7BPYD3AoE9GfSrxQH7CUTXS"
       ]
     },
@@ -18784,7 +17332,6 @@
       "keccak256": "0x861818d5bfec59701d61ec5908d676b53150ed619803b3050e53e5ff8331f32f",
       "sha256": "0x199891c84f5515cde91a6abec5b74a41423d700d872b9a321cfd4f88986f8fba",
       "urls": [
-        "bzzr://a78684b8ba712fc311671387bc9b04804aaff9d95ad34a47fba17136af162b02",
         "dweb:/ipfs/QmNmf6mL2DFuGai6JN8CmkC87emTu5R8YUu1AeXj6qG94M"
       ]
     },
@@ -18797,7 +17344,6 @@
       "keccak256": "0xdd0ef94dca66c1b6fa164c33a46592bcfa9a2dfafc2392f50a8a84587bd7be99",
       "sha256": "0x3b124626725c92c5b90d33187612aaaa67c5a45fae709e471d952138aea7fc5a",
       "urls": [
-        "bzzr://87628f344a6c79cb77ce5a2acd95f595618e19c9bd6adc63f2bd1505f8c843a3",
         "dweb:/ipfs/QmSxn81Hs3BCaLkFAzUFqprm9LQFPYgD2cQzMut8nFx9pm"
       ]
     },
@@ -18810,7 +17356,6 @@
       "keccak256": "0x49dfeb5a73467b155c51700097cb1c620878b32d2e91a4a357dcbc18afc6d172",
       "sha256": "0xda95e48c0c5886ca07a08c7d4cf96e0713f8d2461282d4a5dea8d75bc435b3b8",
       "urls": [
-        "bzzr://4039f243767b14c0eb7004a916ca1d4fc616c78cf20da908c0fe248588e5f5fc",
         "dweb:/ipfs/Qmecw9b3LcAnYhpNvaLXd3g6XX63UBo5XLpPFE7Ex2qUjb"
       ]
     },
@@ -18823,7 +17368,6 @@
       "keccak256": "0xe1fde9791889d3d4ab576a16e1ad358566d812c7d724d2f48dcec99a781c60b1",
       "sha256": "0x47772d59f6ff315e698bb0350d7215d7585abf6b9e2ef56eb52b9a8722261178",
       "urls": [
-        "bzzr://3bdb14adb20c7c73226b7b3d954ebcb1071e9b53853b50f1a0bf828d32d3264c",
         "dweb:/ipfs/QmNmySqyeFwwhKdECo1UpYZ73ZJ431h7RZQm57PCPwjkym"
       ]
     },
@@ -18836,7 +17380,6 @@
       "keccak256": "0x8c7ffcee026bb3b7cce70d8e71b27beace879774df5340f40b246389791be4c9",
       "sha256": "0xd0032294fffef113bcc3c02f80798a04968769905e177d7499546208f4df166c",
       "urls": [
-        "bzzr://a7b5ecbc9db7bf33e6bc834e40cc4c75eabcf25d997e03750fd9b9f23502667f",
         "dweb:/ipfs/QmNYNDBv5Yt1ZryUhDAxJm9vvv1XCNeKUeLd2A5QNB65Kj"
       ]
     },
@@ -18849,7 +17392,6 @@
       "keccak256": "0x651157ca3c71f854a17d7fc23117da2bfece1c3e6f46fd44f77b860bcdb137b7",
       "sha256": "0x99e766077c974df2721f9dd2b11af20fa06686aaea4e8f625897e733f80010d3",
       "urls": [
-        "bzzr://eb0e42f574173e30187567804c21c47f441d8fc6c6c256b9dd473fa4b8eafaa5",
         "dweb:/ipfs/Qmb4CvKV1f2LxFhnzXjMN2H2wxEmy8uYN4CRMQUEUMnDYf"
       ]
     },
@@ -18862,7 +17404,6 @@
       "keccak256": "0x3b2a839f3305b523041bbd7e1178a014fdd981001cfad030f22ac4165ee12bb3",
       "sha256": "0xf888dc3f6a7c1ac034adfc92eb1a3e649a13e712cc4271a5b2f6d53026995203",
       "urls": [
-        "bzzr://daf9bfefae8e13e0a9f14b972a24ade8dee6e8b6151012b6c06eb189439de0ee",
         "dweb:/ipfs/QmPvHQDfxVsTnVkjLMMkef8Ea5puNqUHuCUHgqgb6nQgpN"
       ]
     },
@@ -18875,7 +17416,6 @@
       "keccak256": "0x80c274558c882984bac1d65027cea6932a820ada664868fe71e6e9fe8c2a5e47",
       "sha256": "0xb6d47aaff965b081100ac388d6c67d59c03fff7d80c93d7512aa3a0e2c5c02cd",
       "urls": [
-        "bzzr://942ef6cbaf4e2d4eb46c63df6871da165e44394c5bbf467adbfd205d8d78d5cf",
         "dweb:/ipfs/QmQcmE1vQSP3wdmcQ8vHa42JLbaeEe3zhT86JPhCajLQ46"
       ]
     },
@@ -18888,7 +17428,6 @@
       "keccak256": "0x4bcce65ef1e1f7d30d39fb70674d287eda800922f3ad57d5c910b4f6187fdedc",
       "sha256": "0x8eafbcae74e27b6c76321742b923cbf3e7ad0fd82cdaeb029f6bbaa3624a44c3",
       "urls": [
-        "bzzr://f8964492c0e04a97787eefe3382d47b7e90b1514a28531c7c014a9ee11b7e788",
         "dweb:/ipfs/Qmby7V3fFHBRZGKopSpm3pTgepPmvQA9JPY3bhcbJaHPrf"
       ]
     },
@@ -18901,7 +17440,6 @@
       "keccak256": "0x8acd7600bb937bfba1d17e0826c108618b1a90ff2f34f56d8bc33b896b104c8e",
       "sha256": "0xa0aece00114a63362c6c00c701dfc1c3b92224b275119764d78af2913f513a91",
       "urls": [
-        "bzzr://90bfbdf13806f823a0bd6803713cde37fae8bd9b4ea0caf65ee90a55079a5500",
         "dweb:/ipfs/QmefRRS7DZMDg5zYprqaMK754QAF1M3jms9rKYxtzcmXpx"
       ]
     },
@@ -18914,7 +17452,6 @@
       "keccak256": "0xdfe5ebfe4c964a7eea8d33b687752d0448db6062b7757efa288f520f5c4e06b6",
       "sha256": "0x701f69a05ea44758477185181058be695f8d8b4ef6b023e59f495dce77da4ccd",
       "urls": [
-        "bzzr://b63b0b0c401c5cdc371bd29f9c1158de228b13e0c3c927f8c8f5ceed78c9bcdd",
         "dweb:/ipfs/Qma5vSq2hHfinWGwXDYtLJ8UPgtTz9y7oxyo8zRc2XtH77"
       ]
     },
@@ -18927,7 +17464,6 @@
       "keccak256": "0x98817178d8a6b5762f196cdb860fdd275a332b0ffdd3a1e238cc45ebe3143a6e",
       "sha256": "0x1f0e0ef6582e46067d5391c9de8167028f0f75c2065fb63654ec5b9408136f60",
       "urls": [
-        "bzzr://222e2393d50fdc79b0e1e893ce9f9d8a88a27c10bdfe13532b60ab31d053097c",
         "dweb:/ipfs/QmeWa7BtzWzbnnLR99ftj4Tp1J5Cfe5rddwVtJ3oZmRxWC"
       ]
     },
@@ -18940,7 +17476,6 @@
       "keccak256": "0x39e5388212876deed94e470ac786f3682786acab034c7cd99f847c3c2d3de56e",
       "sha256": "0x926dada7d31261a997f18731b8fcdac65c6a27e4f65880a01d9088f98338e131",
       "urls": [
-        "bzzr://9c50bd1cfdef217c24569b0829b0a87346f0ac7172063fef008b7fe1e5c38b42",
         "dweb:/ipfs/QmSfxwD1Xeq3pJdLmxMfntYxhqQVReDSCZx4GJiPhC5GUd"
       ]
     },
@@ -18953,7 +17488,6 @@
       "keccak256": "0x8912f9309b55e1b9b681bf45a1171f093478a0742d18cf92a0797048f03d1929",
       "sha256": "0xc0eb9462477295a9e307601d6cf88b59f8f956b5e9dae34f9f808b920dd7d437",
       "urls": [
-        "bzzr://c292434d2d59a00597bd6b7566a4f71994677127221f16bfb9bcbd50554e78b8",
         "dweb:/ipfs/QmPB3D5aRdUTA98Hvno7BbsKfbDGretPLWBCpaKSDMT968"
       ]
     },
@@ -18966,7 +17500,6 @@
       "keccak256": "0x5ce83832e42d13fa08690fdbe6ac64347509bcc18273e799cd44edc24f07385e",
       "sha256": "0x6677734482952ba0efbbfdff502f22c9234b4c34daaabc165866c61d14032edd",
       "urls": [
-        "bzzr://2fa77dab85606d0fb6872be02a35b170862c28b575be097965cf7b8f9c18f115",
         "dweb:/ipfs/Qma9j3BJMEQ9YAurL4MK9AvaLLh3V1W7BHBR1kSyKTKrdd"
       ]
     },
@@ -18979,7 +17512,6 @@
       "keccak256": "0xb93b0d10d940596dfa938cdc6054a56a15f198c20209bd5169c947264a36db7b",
       "sha256": "0xcb3cb16eb1bce816b28327a049ccec70dc0970590ceadfb3906fdb9027922b73",
       "urls": [
-        "bzzr://32108a095f87cf34a548aac70e516f802d0869f114bdbfd1429d5ae8083fb542",
         "dweb:/ipfs/QmcL3xJe4c1ZjJ46KGo15R1zrzyzHQuaZ3REghdSESP9TM"
       ]
     },
@@ -18992,7 +17524,6 @@
       "keccak256": "0x5775764b38b5694f8bc9bd48c367f3beadc465dfcde543150c751d05c67ab8fe",
       "sha256": "0x14df4725cb72bc7844a8f27956d5f6af3e74da48708252aa65c7e36489af17f7",
       "urls": [
-        "bzzr://83d73950a409f41c5bf167503544d04ac26b68ac578ce522a3ac8809273dbcb0",
         "dweb:/ipfs/Qmd7qSGz42dtMtZeYHnQs2d93fh4cRguv2cAiJk9FRMSLH"
       ]
     },
@@ -19005,7 +17536,6 @@
       "keccak256": "0x12715057e2e57a8e959941225fa24424e0b9da8e7d263ad7d6bf027b5b0668ae",
       "sha256": "0x6c6d2190a92b8e144ddb916848ee76a6b22f7eceed452bb6e0bfe693c1603419",
       "urls": [
-        "bzzr://5f83088dc4f76133db4c07a074b54ec823ddf1cb1adaadc5cf70118247f6b597",
         "dweb:/ipfs/QmcMf1jkfTRbCXQs17eJt5jiD5Nhct1ytn3KEZT23Ua755"
       ]
     },
@@ -19018,7 +17548,6 @@
       "keccak256": "0xa1f0bb4c1cf2aaf3e8149b28cd6b1227fb9aa5c2945d9701fe1f6ee44fae3de5",
       "sha256": "0x93c6eb74db5d8f3570e705ec43298ed23defe0e181d53899c70868b310091d6d",
       "urls": [
-        "bzzr://c22460eeeb6f18463b54aa53fdde84381ecd9abb29464814e595b449a8cf8c01",
         "dweb:/ipfs/QmUHTtN2FCwweT4VBqX6XbZDXZ2DvbfzDvStZ2zkWABVqW"
       ]
     },
@@ -19031,7 +17560,6 @@
       "keccak256": "0xe292eb581fe861218e5a505b7b55724ccfa89d9c5545e212e779c5238438d217",
       "sha256": "0x12c5cfb004662e3e001463b8949ec0def6834c1aa4db417586e5680c98415abb",
       "urls": [
-        "bzzr://79ea19bda17edc0c72696e224309a08f832753ca5be32471694f41edfab3208e",
         "dweb:/ipfs/QmNrnKSvC1f7MDxand5eer9ET7AJLkqEvsiYhKv2LQcqKz"
       ]
     },
@@ -19043,7 +17571,6 @@
       "keccak256": "0x331f4bc6de3d44d87b68629e83f711105325b482da7e9ca9bdbdd01371fee438",
       "sha256": "0x27b2820ef93805a65c76b7945a49432582d306fd17a28985709a51e6403677c2",
       "urls": [
-        "bzzr://af0d70945c85865298732ac2bfdacdf2774fb4daf793c94fafe135b839a60a5c",
         "dweb:/ipfs/QmWzBJ8gdccvRSSB5YsMKiF2qt3RFmAP2X25QEWqqQnR4y"
       ]
     },
@@ -19056,7 +17583,6 @@
       "keccak256": "0xbf44a68879781f61fd5c162aa84a146887f41b22742d1ccd5c55187a7cd44311",
       "sha256": "0x0c26c71c7decf0236049844660c9562a1d52b765d8ad82e39be6da4399787e0d",
       "urls": [
-        "bzzr://3ff7726093c5f2778dd07fd08ae20d85f39c2692f52b8e5334b38c00fa2340ae",
         "dweb:/ipfs/QmciZvqBSsj8Hmg48f3AozA2kLm4FWZL57mzZgXER1hZoZ"
       ]
     },
@@ -19069,7 +17595,6 @@
       "keccak256": "0xb4e4b3caae89e11ab3c72c238f7f0dff06f46fcb73384bd1ae7feb0b51dd5d18",
       "sha256": "0x0d05fa01baf096341e6474cb172abdff4b7ab4fc054303369030323ac53a1c0d",
       "urls": [
-        "bzzr://7bcec6ca699931c5bb43d36651e337616c150d1c433b4063b471e878abf9891d",
         "dweb:/ipfs/QmTJFVkUjKtKcgbYvAiX2ndBPWf7RRJQXptMP6Z3kjviER"
       ]
     },
@@ -19082,7 +17607,6 @@
       "keccak256": "0x40586329f110ecea10614659ded759bd0bfb49b7886b7687ac6889ba06065669",
       "sha256": "0x3c32af338c276e3b8e157795bead4b6c898beae6f8e7fad98494cd8e820b363e",
       "urls": [
-        "bzzr://f6a8c8de71acdc063231dce2de965f6ecbd2fa6ca9c376588d7ef96e0d5f84b0",
         "dweb:/ipfs/QmYvezCNZTxi9d172drrXSn3oP1ppRh5VW2VdeG8rZU3eu"
       ]
     },
@@ -19095,7 +17619,6 @@
       "keccak256": "0x011dbd8f14cea97ba67a51eed4192737ae0a266d65f175d842fc4499cbeca4aa",
       "sha256": "0x2f2d466836d3793d6c3cb9d5b95a5ae4191e2a77f747e44ec47c8924c2c43f2c",
       "urls": [
-        "bzzr://d825b9cec6539285aa93461d12c5d04c5028b82230bc71590941bfeee67f0f83",
         "dweb:/ipfs/QmV8YcduyvxZ2pD3BRkmpg99XdE7c3zZ4CVDKmbKoJfpGh"
       ]
     },
@@ -19108,7 +17631,6 @@
       "keccak256": "0x48d60c3997014e04095acb29b232c5f01a4bb994c1f0f47d298366e126fda738",
       "sha256": "0xea0b4c0f6bc2fc24ff63a27e9923e323f7c40c161f73773624e9d13650c3cce3",
       "urls": [
-        "bzzr://8f9fd363d77431e211d618a40105869e1ac287790d4b5703400882b28beb368c",
         "dweb:/ipfs/QmPLz87kZG3XdkG7gBGAzgG1u3kJnyEtGodZM5CCjaDDDL"
       ]
     },
@@ -19121,7 +17643,6 @@
       "keccak256": "0x5ee040d8ad943371d3039211c9de0f426b0d048b53f9b6af5f18860a1dbfe2f9",
       "sha256": "0x43eefc40284c5f947ff0172ef4abf1d63c762d99a4d2413c07fb3ee8409e9d29",
       "urls": [
-        "bzzr://71ad4849d247ea50fbda17d5e778405ed6b818d5a3ef13cebbc7bee8c59ed24b",
         "dweb:/ipfs/QmZiz2XmetPWSNGccEudg9mvitG7QR4F3YCBRg1LxXDH2m"
       ]
     },
@@ -19134,7 +17655,6 @@
       "keccak256": "0x8c8cf2e3341e7a07fcb8fbe825ed7ef47735924e67ed2556ab9fc2f41005f1fa",
       "sha256": "0x1d56df9e0f3e39105ed1e4d977600236c57c6aec649e5f4903ed993c434cb56e",
       "urls": [
-        "bzzr://0fc3ccb024609b486f6e397593329f4f9e6d48e1b709eadcea39a8b068313fb5",
         "dweb:/ipfs/QmQoSsgtBDwxUnQ7csm5y5arcvczkRNpMukMZickPr7ito"
       ]
     },
@@ -19147,7 +17667,6 @@
       "keccak256": "0x865c948f786b7c4d321e05140fe556d537b5d445ea9e9853a3ca6521c2ff64fa",
       "sha256": "0x12d521b1b960d5a0cbf36e49fa7c0636d25240c2098d3b29dd6e207be8fe9f68",
       "urls": [
-        "bzzr://6598e3fb90271eb7e803bddd6e8dd13917397f8bbf97e20d7ad1638b22af3368",
         "dweb:/ipfs/QmTCpF2woBG6eQP5fyEdrvWperKZR3m5txBKi7evnwaMJp"
       ]
     },
@@ -19160,7 +17679,6 @@
       "keccak256": "0xc02e75768762e51d0d9e2b00e1ecbb4b99b8db0f132561b740f2801dd8a8ee32",
       "sha256": "0x0150b8efe2263627d4a7db3db181052291e4fa08888b7aed230fa18d351f35c2",
       "urls": [
-        "bzzr://468fd7a2b3112017f14b3fd30f2bf7f49cd7742b8e0bcc46c27b16c5973a086b",
         "dweb:/ipfs/QmSRCZ4YbBgvXjixDwHuegecRhe8oFueBJKGQm2S2uDVkt"
       ]
     },
@@ -19173,7 +17691,6 @@
       "keccak256": "0x12a6f75215c6e53f80df96057a6e6a209f6c66079ffe268903db1cbd59de5918",
       "sha256": "0x61d6e144adf0eb78588e9fc98f11dec7b8643d7ef4bb61494938edfe42896ab0",
       "urls": [
-        "bzzr://51917340eba34e379b412f19e2cf183b514bdb565a65f09d9e5695a55a8851ab",
         "dweb:/ipfs/QmSq78TJZ94mJSVZhMEN8ateGMKNrYLCe8AKKE7RBZoV6p"
       ]
     },
@@ -19186,7 +17703,6 @@
       "keccak256": "0x1a08acc78810be5007368fac3e9039af9cef8d847cfb1bdeb3e186aa294efe41",
       "sha256": "0x19b83b484e2360fb7d255661824f442519f6509fab265dde4f24e6ae274f0819",
       "urls": [
-        "bzzr://9666ae8d78a853563d732165f02c03cdbfaefe9d803f1f163c571db179e657d2",
         "dweb:/ipfs/QmNSUsmy97YWT5NxhGRK1Kn3aQdWXC8ZDZxaZSw43MBURi"
       ]
     },
@@ -19198,7 +17714,6 @@
       "keccak256": "0x3f2be218cf4545b4d2e380417c6da1e008fdc4255ab38c9ee12f64c0e3f55ea9",
       "sha256": "0x617828e63be485c7cc2dbcbdd5a22b582b40fafaa41016ad595637b83c90656c",
       "urls": [
-        "bzzr://fe8da5b2531d31e4b67acdce09c81eccba1100550a7222722152ffdb16ea85ef",
         "dweb:/ipfs/QmTedx1wBKSUaLatuqXYngjfKQLD2cGqPKjdLYCnbMYwiz"
       ]
     },
@@ -19211,7 +17726,6 @@
       "keccak256": "0x9c727e97111e88101a20d768a35650443de8d69f3be855fa4faa4fb6f1aa0578",
       "sha256": "0x24ae9c43aa7e70933f97136e5d059c364e9cd9b81ce847a900e950589dd1a5fa",
       "urls": [
-        "bzzr://4eab7ce3e6810c7beb8d2a0299532a8fd4c631009daf8e104a403e0931169422",
         "dweb:/ipfs/QmR3ozWKCANdU53EERVtyAwuXQg3qNsUuTCiaF43FbNkuo"
       ]
     },
@@ -19224,7 +17738,6 @@
       "keccak256": "0xc7e1356dfdbea29b26167aa1b523d109f27a266145b936ca310b4b01ebc80d3c",
       "sha256": "0x38aff48ea3528b505897fb2d7ccb4753350a3acccdc154b8b5631b31115c9723",
       "urls": [
-        "bzzr://c346fe9b5f8247b7219bb3fdf13e97d6cde664401e5a4156a6d4db3bd493e63d",
         "dweb:/ipfs/QmcapgLqmPRTvSmacKj46jNTxFgmVfDykXk3fJMMPAUrBW"
       ]
     },
@@ -19237,7 +17750,6 @@
       "keccak256": "0x9109196db822c45c7729e3a4731219db9975e9eca0d5bb5e8316f383b61f408b",
       "sha256": "0x9c0a6c0687bb6a846b9ba1f9c574011e6e8ef6081cd6c817d15a8b390fdf891d",
       "urls": [
-        "bzzr://fbbcc0781aed73a4afd36a6967f6d0e25fdb2a8f79bea1a309698d21fa0434ec",
         "dweb:/ipfs/QmQNWyVZWzK25roEaHpHMpeFUeBqwAuC73AC9zqkDKXj5s"
       ]
     },
@@ -19250,7 +17762,6 @@
       "keccak256": "0x16dcf498059961802265390bc0aeee25e6b89576ad5727e22c26105bd96d85a5",
       "sha256": "0x5967d551b5e5103490f2af906dacbdf9e7f780bff05672446e82a7584e8975e9",
       "urls": [
-        "bzzr://ffa7a252b9ef53a00a2166673d51a933690fc87c105a3cd52d16e75533cb7991",
         "dweb:/ipfs/QmTnCHvMmahDKJ4LkZ52YTfXT3nMqaS39WxQ5Tq6E1hjx5"
       ]
     },
@@ -19263,7 +17774,6 @@
       "keccak256": "0x47a8ac7e95b02b24f4187fc4c722aa58b3efdbbf1b23426f09505030582cf03c",
       "sha256": "0xebb5eec5b25e7ecf0c4ffbd8d40aaaa362e6bf7a1998d17016d928c1c5e35dc3",
       "urls": [
-        "bzzr://dec6e201a844b836fefed86e9f02ded93b627d48ae5d47abb2a2f0587c9d2617",
         "dweb:/ipfs/QmfGjgW3kEwGBDs583m6imuSMDrHYjwHFFfvEbA51aKJPt"
       ]
     },
@@ -19276,7 +17786,6 @@
       "keccak256": "0x967b0084b530abfc57a0426470eced385dab6869d7094969e47b4128bb61f89e",
       "sha256": "0x02f38312c2ad8714faa66641ba03df9bc8336d87254fb2ee15207e3899de40aa",
       "urls": [
-        "bzzr://4e14ee30b37ddb2637ed030cb5d5305dc383566096d35e1907165839dc2b9e33",
         "dweb:/ipfs/QmYM1N7E1UY9QYdLehJ8mZ8GMDxqo1XZZH1QU3H9oBwdMb"
       ]
     },
@@ -19289,7 +17798,6 @@
       "keccak256": "0xcb50799d8d4f20d3eeee266f115e2a9d0e0f747e310ea5d2c9a7c292f08e22b0",
       "sha256": "0xd9d1808fb4dcce38c729709268b42aaedcd184f5aa25de16d9401271ebe652a1",
       "urls": [
-        "bzzr://b974640ce96b6ec57813f0a3ff1b21e3aece70c314703da5870f5ec61f48ebe3",
         "dweb:/ipfs/QmaEBvff9AqvV43UEkTguBsEL2BGdkKN5wV4GZqB3D4k46"
       ]
     },
@@ -19302,7 +17810,6 @@
       "keccak256": "0xe61c0f43d732357afe5d26347b0e91d538fbc6e9884a9ab90575f6d1d6cb7b32",
       "sha256": "0x62c0b4d4e26076597f6dfe8c575060ff6db080caafcaa5c4476a2c5c18d2842a",
       "urls": [
-        "bzzr://7904a086bda16f7f9e685a22c6d9acfffd7885df7f9e4c1e2b3391ca69d969e0",
         "dweb:/ipfs/QmRTs5x6g5z76mz9EEChEEwg8kcGTNqv4MCofPiTHCe6HE"
       ]
     },
@@ -19315,7 +17822,6 @@
       "keccak256": "0x9c2a7812bab492cf18106e6abfc084a15b8840f6ed3b7fa01b8b6797cffc7a7e",
       "sha256": "0x1c655986e9147dc6f5eba9b310554de652375b5f36a57c63b9ee7c04af3e43b6",
       "urls": [
-        "bzzr://1116f0d4396c8b6b0cafc2585555219bedb810b173128dfcc629b87027bbec03",
         "dweb:/ipfs/QmenrpSSjENfRQunrC25p3fLsWdRQ4HKE86FYEmVhbEfJF"
       ]
     },
@@ -19328,7 +17834,6 @@
       "keccak256": "0x19fd547e2b3950de2fa4695f01d1be65f5c0da7f20a35f2e39cd63a2a591cd6c",
       "sha256": "0x8ebfdfb5745e786d4c549fe5f675655a5d2074cc7e026fb4a0a938f7f7294983",
       "urls": [
-        "bzzr://007c6606fe9e3458ebaa4aae99c6e0481b9170f16b00bac44e28f5c2d308aba6",
         "dweb:/ipfs/QmUsZEPgWk4padVz1bgzE9oycY7NyWsDTipYtygGxvB3mm"
       ]
     },
@@ -19341,7 +17846,6 @@
       "keccak256": "0x21763cde7848f3065ccbeb4f34d36aebdbaa135c91b8999608f491a7a60d9793",
       "sha256": "0xb2f753f59b3682f45069e880e96fbab6a76408b262194a56d8e8a174d25d7d5a",
       "urls": [
-        "bzzr://36124bf4c5b8f10402618727e8f935c13cd9e3a70769e212aa404ace3c9e4e34",
         "dweb:/ipfs/QmSsTXDd7tZ3QoWxPN3gt163nKKMKysEVxAjMH5nc4TAh3"
       ]
     },
@@ -19354,7 +17858,6 @@
       "keccak256": "0xc4e51314db4003e34516d52b76a4693d71e0af6afa99f5b39649ba97b3368a37",
       "sha256": "0x647a0d94dd6d4f20ee0cc573e7e21bc391fad09997b897ca89f2582648ba22af",
       "urls": [
-        "bzzr://190e4c23fff08e0fb9119d275ecb97cf0a77913918eae1f2091046443959955b",
         "dweb:/ipfs/QmXdSP1TSvhXUYrkUsMwDTtoy3KkaQSFkTcBv4oWhRaTbo"
       ]
     },
@@ -19367,7 +17870,6 @@
       "keccak256": "0xc3b1c30629da15254535e70957f80b2a988817530ce3848ce76c2578b4cb316b",
       "sha256": "0x283d747f911f48a9a8cbc3d3a96f634b8537364e68ff832e561f51b886e63513",
       "urls": [
-        "bzzr://660768a2ff7c8ce3316a51ff9c7a5d45788a8f72736cead52f34bef0a73cb440",
         "dweb:/ipfs/Qmf8ffJhS1HcJHNdkrui7UrLHb1Vaz1jhdcfhZgDcskVsi"
       ]
     },
@@ -19380,7 +17882,6 @@
       "keccak256": "0x7419c424f698bfd1c0b419820bebcf22485e8c6df25e4bd376bbd1699ec4fb63",
       "sha256": "0x1b152f07935e7e603698f0ea1bc3b285a84e72b93005296a6d164523381f027a",
       "urls": [
-        "bzzr://eb24782a7df2016afe07504f8e5b669109a094c990cf0f9dda87ee1d83643254",
         "dweb:/ipfs/QmdKSdTUPHSNMxPPfHy8UhuEGo36fc19xdaWeQkNYWc67a"
       ]
     },
@@ -19393,7 +17894,6 @@
       "keccak256": "0x96cede8fa634c25bff3d7f0084a9bff2e143a1276cf6d53f6e6bace11236a4dc",
       "sha256": "0xbf10cd59075b6b2e5ec3d095f5dd26b0858dea041a82ff2abd27039fa2fe8e03",
       "urls": [
-        "bzzr://db8f0e25f215297df6a30e9a7002f9b2db62e3611f13b93f7a65126f2e56d96b",
         "dweb:/ipfs/QmTJd5D9uyAy8XU3pMQx34dSNCjLnYq8pJPux1PingK6Ay"
       ]
     },
@@ -19406,7 +17906,6 @@
       "keccak256": "0x8bcb64737f158515edf926c3a7d08cef082bf905cb9b54532153d7f92bb42d89",
       "sha256": "0x2722d6a456ab952a0a897988db3397b2b8eed9da560186dacaf82d5f5e9e6ba4",
       "urls": [
-        "bzzr://b558d6024d56d8fc2f7e903b86cc0870617107220b31737342f42c1a523f7381",
         "dweb:/ipfs/QmbYu67vJprJvSDBzMzMG2Zarryh7xwY7H1AZu7fkJWmLM"
       ]
     },
@@ -19419,7 +17918,6 @@
       "keccak256": "0xd4f6dd82dc125d6b422aed38115f67dafda32ea7590a4dec5ee62aac901ecc8e",
       "sha256": "0xd1c9a7a1392bd840fb46ea392eee3e7ee8fae8f9c913ef55e31da250b2af1fb2",
       "urls": [
-        "bzzr://d57db1bdaba520394027e03ff94b9117b5ffcd6a751f0f8e83f7d7677ca28ee2",
         "dweb:/ipfs/Qmc9rWk2E3bQggcfhLSBfYSD1fbaZJksmJJcrSU3CU8MEK"
       ]
     },
@@ -19432,7 +17930,6 @@
       "keccak256": "0xb4d250747756df7d15e2565a7d81f6b7363a50ab2ab3ecbeb05310800f524884",
       "sha256": "0xf2003de071a4f51093b6f9c1d985ff750003b86b514c78461eea7009b3b7e4c0",
       "urls": [
-        "bzzr://504e530aff550c009bd30e235ded41f6923270ec29dd3667ea50ffe04c180703",
         "dweb:/ipfs/QmRB9eaQPrMEGgnwm9E5cga8h9JemMeb3HRMTXwpawFfKc"
       ]
     },
@@ -19445,7 +17942,6 @@
       "keccak256": "0x33c8ff211aa3238ded855bf3a43473ff8960a87a74cde89a0e424ff0076d2eff",
       "sha256": "0xfa4b125f9a78697948adc7d5d2c47595f6ecdc67f0ae263b873f22a9bf617b00",
       "urls": [
-        "bzzr://e8ebb26a06d76625706f8d54b2cc9eb0a0a920d7959da3f1bf259964aea265aa",
         "dweb:/ipfs/QmfG7mW2ZiPRuaUCeptVKq1WEjYgMhGwg33RLuALovgsQo"
       ]
     },
@@ -19458,7 +17954,6 @@
       "keccak256": "0x57b2963dd286cbf07670c81f3ae41412e095cb0e08cae230b5c5a66f37a197c5",
       "sha256": "0xf1ab1e7421aaa91ed5003e377580292c362c8b548b3fd875f7a7fe6f31e5edf3",
       "urls": [
-        "bzzr://6ded2ea9906e19d3ae1079a40ce878737278a63cc2fce4d3ccfbd4be9f76bbd0",
         "dweb:/ipfs/QmSiE3C4xD3WiNMMVju54o1MMAAgMTZUfRVv4GTsu9woLu"
       ]
     },
@@ -19471,7 +17966,6 @@
       "keccak256": "0x55807e0ada507b6d9ca35d0da513df3ed7824d60e073e2d8febc369a7cb120fb",
       "sha256": "0xa042581d21978e6e16191a3a1e48face33064e73c3b9bffe211a5a4204aef5da",
       "urls": [
-        "bzzr://aabb1979580ad1c3e4fbe9ef4e1fedf52ed6a8eed2c21e81bbdc578b8777a6f5",
         "dweb:/ipfs/QmSJragJfqkFS5uXrSVw98Nyb8NK6cVa5VQpqNxWPWihxS"
       ]
     },
@@ -19484,7 +17978,6 @@
       "keccak256": "0xce1c531d566ca731d2693db3ef05dfa6e7fc179d8358cd5c0c6cdc97f97f5e8c",
       "sha256": "0x0ce36d446648f9fb7206d0419186a44eba67cb425edcf4e69d3b1e45eb76b0fb",
       "urls": [
-        "bzzr://9d88f8edee1e039de3ccd15ce6199befb6a36bc751774574ba8c6ff696563633",
         "dweb:/ipfs/QmafyxRk7FpHJvRdcUx2BumxVsgHYmimWfWDMsnKuLnZ4Y"
       ]
     },
@@ -19497,7 +17990,6 @@
       "keccak256": "0xd056db03e22e402f52b6c182109b1ef4eb83f996a83d74d2eb1413e124e62192",
       "sha256": "0x5c8e23732b5a6831dd934c9d3092be32ed24d036087e1d0bfc85b38ddfa5efd5",
       "urls": [
-        "bzzr://94ee073646bea43553b8a74c9253e29bc3f5343d215a6842fab370aa932056ea",
         "dweb:/ipfs/QmPrGjb6T4d6MWhkHRxfTw5ckQDcQUgsXYeN6djZxcE2Ex"
       ]
     },
@@ -19510,7 +18002,6 @@
       "keccak256": "0xdbcae13ea6463de4531dcf706beffc70d8a703f1e818f97e132860b33c85beb9",
       "sha256": "0x31c6662805be10c0a77437f2aa230cd9de7ea15ec863120b834cebfdf6c42e82",
       "urls": [
-        "bzzr://870b17a51e6e59940a3e79fd2f468c0e8e2f6077bad3c0273df7bc71104e8e47",
         "dweb:/ipfs/QmP8XuguoNbf6G4HRyLUtA8nFR5Zq8fGKX7JKxarfyi92q"
       ]
     },
@@ -19523,7 +18014,6 @@
       "keccak256": "0x0fcd8abfa0157f63795dd782ee7b444a09f234d64e3f71373a1a9e53e8bd1b8d",
       "sha256": "0xccea9185c8552b090b8e2f8c9701579e335fa7b36cad22387419f5fee198c03f",
       "urls": [
-        "bzzr://5eeb3ae494a1b77810f992e7be743e3dc3be1fbd16036a9e85b943d16482b534",
         "dweb:/ipfs/QmcZu35we67A7GdGyfKAWud8Tfds998wwd8oGZmEcvBB1i"
       ]
     },
@@ -19536,7 +18026,6 @@
       "keccak256": "0x211db6c562e30919a1a286cddb6d542c872a8d42ec984d3fbbc426cf3e9cbaaf",
       "sha256": "0x9e6c1036f5532735734c14cf0d4090b8b184dff76bda743c6f2e2d99f689386b",
       "urls": [
-        "bzzr://bf8f42fd847dee1ef1694d4df1c702166e7f2767902dda5357a0f44d0e805af0",
         "dweb:/ipfs/Qmf4NmumtJEWpsaaRkqfauaYW3H1PHJTU9vvCNfpwFMY4x"
       ]
     },
@@ -19549,7 +18038,6 @@
       "keccak256": "0x7c4957721010f24b4900515221dc35c3aa7bfafa4336094425fc214233763fd8",
       "sha256": "0x382a82c257be9f1afd5dbe80658070bd158216f52e9008fbeb47204758f8312d",
       "urls": [
-        "bzzr://1177ea7ea2656d99ca66bc4297ba07b9446f3f806167d0d87d35e8872d764d46",
         "dweb:/ipfs/QmaQjZYmKRiRVuFXqpuXcVUmi64vZ8Ea33RgLJzkKhbcgm"
       ]
     },
@@ -19562,7 +18050,6 @@
       "keccak256": "0x5a80f90abcfdadc55e0d5403edaa679a6314c7bf8a15fd0110035fde9e2c864a",
       "sha256": "0xff579ab307c15f8a7f3e4e0fa30f87779fd74efdf7a8b0fb12d084202c7fe3a9",
       "urls": [
-        "bzzr://9362ef87d472a2b437726ee5050c89e30b84495de0b6fd502c33617a30f043b3",
         "dweb:/ipfs/QmRBEE4gvKwJ7HftrYYCFpD1G18UwPzmzMP7fepueeXxuw"
       ]
     },
@@ -19575,7 +18062,6 @@
       "keccak256": "0x263d0ca4e31b79416a161483c52203e551dbbfe7d6ec7419f018ebdf82be2919",
       "sha256": "0x3cd1efcaae3012b8eadda075805ee3d5fc1efef53c1ff8147311aaf9aab1e219",
       "urls": [
-        "bzzr://151a9f07f744a84b7620fb54e768cb622237bd32abaf2e77260f9bceec91d520",
         "dweb:/ipfs/QmXYS8dzBgNub3LXiH8eBityfVNkTJxKeZuN6ZvcgJi8aE"
       ]
     },
@@ -19588,7 +18074,6 @@
       "keccak256": "0xa89b52e5047e0d1181b16dfcc06421637b92bcd35f428692d0b04483e871081e",
       "sha256": "0x21b7b0e63e484fb2ddc7bda602f30f455d187b90759d3355565648517ca87ba5",
       "urls": [
-        "bzzr://7cc5bf3b79e4ae5895fc6cd4ba330bfea4a19b322c310e9821fac8fb1d49248f",
         "dweb:/ipfs/QmRdVhbZT5x7mhm3jMMBNarN6qmB9gHHiHWUmqmWrNrYnJ"
       ]
     },
@@ -19601,7 +18086,6 @@
       "keccak256": "0x6db09b6d22226dcb61a0e51e523301dbfbc73e4a926753e68c0dd6c64378557d",
       "sha256": "0xde9373c691b608c25c56d2cd740cfd57bde519e6bd14751f1aee0618471d6630",
       "urls": [
-        "bzzr://9fa092772180a69c0cab2d4908eec3a554674c3af8bdb5e170a3863bfff39d31",
         "dweb:/ipfs/Qmf6pLCNvvYrB7rTAuPdzhg1zyEMNCB5HZyuGy9w9EN7rF"
       ]
     },
@@ -19614,7 +18098,6 @@
       "keccak256": "0xfaa446b142d323911c9cae34781e597dcaa429dc07dc333fe5ee6488912c9493",
       "sha256": "0x45bab6f3777b203cb754ab30609308ce7c742d8419582b8f43636a735ee07aae",
       "urls": [
-        "bzzr://e2ecb3d0e7630067c1d190a508641c60b5470cd37df6477a703d56c3ad57c00b",
         "dweb:/ipfs/QmNzA4V7WgpDromZ9oMq2HDF5qZ1ruALPKZdJ6bQdBy9vt"
       ]
     },
@@ -19627,7 +18110,6 @@
       "keccak256": "0x07a4902c08ea7a70c11acec312ce9eb2d8a6a7ad3ec925be7f375e5387f41592",
       "sha256": "0x69d325756386c00f2c88acf1696dd0b39fe09534d297a0723619cbdd28d84f29",
       "urls": [
-        "bzzr://e2d13e779c202b5603140f7aa99d46c183de050a5f363ba8e7f9f93d9d94231e",
         "dweb:/ipfs/QmWtytH3SfaszX2uzgLKfKHjwSwcHpaaGgnoXNwwmmXtj6"
       ]
     },
@@ -19640,7 +18122,6 @@
       "keccak256": "0xf61e875313a3153e081c7e65a57e32f6f71845446e634c58b1ff39e437e79b80",
       "sha256": "0xfce10db81373f84a28fb24fc291577d833d5f67784f23abea906a76188f7122a",
       "urls": [
-        "bzzr://4776fedf92ecdd7fa47bbef374a75148e1d3541a1783cf45d85b919faabae0b4",
         "dweb:/ipfs/Qma1sNZn2Pa5QY6cRKmxQ2F9w92m6X3SZkc9LQA3oob2yC"
       ]
     },
@@ -19653,7 +18134,6 @@
       "keccak256": "0x4afe53c2cf175e0425492bfb08684ee34f987f5c0632eb18780e6a8a9daabe4f",
       "sha256": "0x706a819bc8a9839be03d18995348044edcad79195e1db781af29bb9b12bb6b21",
       "urls": [
-        "bzzr://3cc319a8d595554bf943322db3fe3d004cf7699484e230719027b3893121b845",
         "dweb:/ipfs/QmfXmuopgnKRFDxhZAqixKxCPUfYL2F61qDQcpSwAdVx3z"
       ]
     },
@@ -19666,7 +18146,6 @@
       "keccak256": "0xc76ce1cb4c49cffa1e92607a694339c57966473bdb620567a9c1b9718dd9eded",
       "sha256": "0x15b9af5260a18d14d687ea8ca989acbeae4c45c822c90a14604bb6930e3474a4",
       "urls": [
-        "bzzr://0a1373102b1575ac3373e5ee04e2461482c6e8c4f5996a8c4f3161abf17cca69",
         "dweb:/ipfs/QmPP6k6aHpWN1eVckxHyYSSgyXCeLm2zn3Hh1FBLTWPvc4"
       ]
     },
@@ -19679,7 +18158,6 @@
       "keccak256": "0x1703c69121acf4f64802afa0948de4e6c21fd485c0f935d2525e8c4c041dc907",
       "sha256": "0x9337bdead9f38d7151788fd32d06ada8c728a4bf61f70a74cdf0f545a2f8e544",
       "urls": [
-        "bzzr://07d00bb4d1f466a6d69de7f80c203f1d2c8c88ee547ea4b646c794f69bf77a43",
         "dweb:/ipfs/QmV3pYh6ZUgGJj2RZonkgAJsb78f9NfXFL5bQzAQSs419y"
       ]
     },
@@ -19692,7 +18170,6 @@
       "keccak256": "0xe74266d6da0a00eb43f72a0a6d34e273d06e607c7383e7afacf56f5af97ba815",
       "sha256": "0xe071a28e3f1851efb145a3c5c8c985890b55f4f9ee8cf7cf0164a88fe3066d3e",
       "urls": [
-        "bzzr://77b1a303c06464e3fffc0d13befa29542ed6cf9485d6cb0be54aca83bc41edc2",
         "dweb:/ipfs/QmevoAen2E9fyxGATCxATk3QfXDWYP8EQVL53q7ZVtZxkw"
       ]
     },
@@ -19705,7 +18182,6 @@
       "keccak256": "0xf275ac7267475ba0f703b8440d4bef9ed5ab746331c43b5526557263c27d6ff5",
       "sha256": "0xb16c9cca2b801132fdd6b8d87aa57a98bbc60c01f7847ba38ddf40858cefde74",
       "urls": [
-        "bzzr://b54998bc5631e78f534898b4f54799317d44547847f21c7ad83bb30c3aa6933b",
         "dweb:/ipfs/QmcPSs4NJmbs3Rpth2Au6mHKMt2grjS6Sp6NgL3zxggnSs"
       ]
     },
@@ -19718,7 +18194,6 @@
       "keccak256": "0x3eb0494571b487cae0f8a76e4d7aeee33c28cfd98d063e7ef516f00cc9d71b6d",
       "sha256": "0xaf3ae62d3eed118d0325ae4d6d22c7c0e7fa8b95594da95aee574c13c3c93ee5",
       "urls": [
-        "bzzr://0185d3c1849aeda7e7037e5576c569219277643c6f262724e7e19ad71e1796d4",
         "dweb:/ipfs/QmRAuDVNUzpjiXkKMmbnra8ypJnmrTkYtAsYRSrJDcD7DR"
       ]
     },
@@ -19731,7 +18206,6 @@
       "keccak256": "0x168e6ee344984e57be0552ce5fec9e345c21cec8881c992d32ed8bfe1ff48686",
       "sha256": "0xf464e57a3f197d2656586fd13710a6c6cb8a7627b863b5127844e1a19cffda93",
       "urls": [
-        "bzzr://a02c355c9bc3bd402470931186448c7046a755f04f9b8c715bcb71b2645b1064",
         "dweb:/ipfs/QmPb4FqijHCGqdZfAGhr79h3z9sfYypVtHfRttRQFh39CB"
       ]
     },
@@ -19744,7 +18218,6 @@
       "keccak256": "0xa77ba53318fff3dd6c3276460ae7b053fe5eb05421f7c50caeb5c188b05754da",
       "sha256": "0x46c429945da6094a3f543198ba024f33fd402aeb2ce0e8d9ab6d831a739085f4",
       "urls": [
-        "bzzr://1f0e3e4db978e9ba37afb5ef05a46f8dd536b5097b43eae6473b080d5bbd72ae",
         "dweb:/ipfs/QmQw3grwuvBZ1RUi6u4HsmrWUUqiT8gtVCbKf5EyNNGEiU"
       ]
     },
@@ -19757,7 +18230,6 @@
       "keccak256": "0x3aed6f1043ada4ac8aaab95b2539afbf325a05945751e8dee1459423d595a523",
       "sha256": "0x54f714639e80036c751e742cce6cd107e497d3a0cbda38d8d3b2b37c670a5818",
       "urls": [
-        "bzzr://8a1c6d707f73176b7312630c18dead1664bd7a83b0deea0376e0e359ef2ee22b",
         "dweb:/ipfs/QmciN7Fru2hZTiPZrbksppAQ46SqRgYxTwWRFVDTcvns8T"
       ]
     },
@@ -19770,7 +18242,6 @@
       "keccak256": "0xa606dbdc7cd450ff6765b534e7610d5ada5b75a73780b6ac2929091f4f18c968",
       "sha256": "0x44967c8b45fbecb237d343d37c6d3eaee49f1e66eb82e97b56f902da499c28c8",
       "urls": [
-        "bzzr://330ee319842bc2c604395e62db384468c5607ec47813e1e453baf72276e2b14d",
         "dweb:/ipfs/QmTpXPZUALpL8nGBji77s2YJWvPZN7brbM7centwELu3ew"
       ]
     },
@@ -19782,7 +18253,6 @@
       "keccak256": "0x9a8fa4183ef95496045189b80dfb39f745db89a903b398e40131f500953e5d57",
       "sha256": "0xd82bdcba2c386d60b33aca148a9cfdf097551f68c5e45d8ec01aebbafacf5075",
       "urls": [
-        "bzzr://338117c2130fcb6bce3006330712b6e7ee99875b56ce4bb6182312f76e4a6bac",
         "dweb:/ipfs/QmcKzrqRBy7PeFQxzJDs1AZZzNHKaKbJces6zUDysXZofJ"
       ]
     },
@@ -19795,7 +18265,6 @@
       "keccak256": "0xa0a17fe184b58e44c06432e121b6f1894107adf3ecdd3cd1e54273d6c7d4dba7",
       "sha256": "0x1cb914b2db68469d184e6b47f712fb505e88decda72aa9071d75a1300604fa97",
       "urls": [
-        "bzzr://cc9279c97c6f3b483462db5cd65f4bf931861fa80d3aaee8a15ed63f0a64eb7d",
         "dweb:/ipfs/QmavuBhEgfwqmpi4owJDbQwHemmX9QMCuSKM7AYVdvdy81"
       ]
     },
@@ -19808,7 +18277,6 @@
       "keccak256": "0xeeea4187a71c99a20a33afb517ff7d8cfb45cd4b4c1d1231b8153cdd7621830b",
       "sha256": "0x942a4713f9065fe59c0f220ea09be740cb24958c30cb4ac753802e452564633e",
       "urls": [
-        "bzzr://48f20b5d233f1518651f6c4598bc35d26835fcb95ab9707c04c80424b5e4ad5a",
         "dweb:/ipfs/QmP7WThbsoo2wZab9vCsvZzgH2r2q1sWeL11p2zuQU8Jop"
       ]
     },
@@ -19821,7 +18289,6 @@
       "keccak256": "0xdcb3082c0e6f6c170f7b83172607ef7d693e7743c1dd3afb17288bccf1789611",
       "sha256": "0x5bcf01188e0f4d5b370f93c641c50f090035fb29dbb70c7c978e90491fb7a117",
       "urls": [
-        "bzzr://dabd04e2de4ec8a39a31da89a8de81b17094e18daa4b4e30556a4ef8c954e718",
         "dweb:/ipfs/QmaESASwGvQVXUVw8GYSZ2TotWDAJX4SyrpNmqQqpteYbJ"
       ]
     },
@@ -19834,7 +18301,6 @@
       "keccak256": "0xdb9df8452617323720dcf781aef987beddead893b9cff186c4e0aa8b09a8b124",
       "sha256": "0xfa8cb36df59f9e9b1166e3c65c55e1ebf4482eab9283629c8b7e1a15d2b3833b",
       "urls": [
-        "bzzr://6eb8999e75d51d8c4b55786320afe873597f09e5cbffbf84e0896bfe9533cf26",
         "dweb:/ipfs/QmUCmLH67TqM5sFWjgqvZ6g32YsQazwUyyUtxaFWehnQV4"
       ]
     },
@@ -19847,7 +18313,6 @@
       "keccak256": "0x022fd4f29057f7922b64db19606396dcb5c7aaf99a0f21df42776a5ae3975ea3",
       "sha256": "0xd567dd321f2b6492743102a779984fed874c77411cad3ce9d2327eda539c15a7",
       "urls": [
-        "bzzr://a485dd769917a453f92b298da72cb8c855b272d305f6b86905f7a734677467b4",
         "dweb:/ipfs/QmSH2ya6Xvom4G1vca7JFdfesRRgwiS14iVMn7bu8fjj2i"
       ]
     },
@@ -19860,7 +18325,6 @@
       "keccak256": "0x2be482863a53f0180ccb845fe1adcc7b1ba67ff3d0eb7938692e8abc712f7335",
       "sha256": "0x74bf5690afb14599f47a0567aae5f5bee6baff2f2ac257fcaaa46860eb8b43df",
       "urls": [
-        "bzzr://543913646acb0fe2aaece268c1f56e314986f76beaf0e2f8eeab120cea6a89e7",
         "dweb:/ipfs/QmYiYhQ8K4Nq9SiDM3JiTZQPh5bfvoxXHyVG3Rbf1BoRG3"
       ]
     },
@@ -19873,7 +18337,6 @@
       "keccak256": "0xb9a33a5fe5a95652546c7c9f160e2425f8cad1734618a0be696b1729f34c25ec",
       "sha256": "0x3be70df36b3532d6d05d9b609839fac0bf5263f53472981b1cba8db401b462cf",
       "urls": [
-        "bzzr://cdfa68a5030a471f5eda9fb1b32a9a49cdc14e37ecd0d94d6597c08675e8b59f",
         "dweb:/ipfs/QmPRuoaNpn9WKdoF29vTj7pKfbxsCZSPqLibWcJhTWr9mZ"
       ]
     },
@@ -19886,7 +18349,6 @@
       "keccak256": "0x218ebda94390d83590e4f9f3a1a26741196cdca1b8c503e4036273db44327770",
       "sha256": "0xe00921833838ebee6e941b7cd70f745c73a378f7a4326dbc96173deb810129c0",
       "urls": [
-        "bzzr://d780b5f763cffe7d344d334b178edcd014ea591434f4bd20b5b3442ed69a0c71",
         "dweb:/ipfs/QmSFqY5JK8CfKCJqK1i7QAwE9f68gASxf78MpJWHaHRuEY"
       ]
     },
@@ -19899,7 +18361,6 @@
       "keccak256": "0xeb87a5de2e113ce70a80655a5a7edf1c98cccba8d00ea2f2b9557863b55ad6cd",
       "sha256": "0x2274ff80267a6dc9e728400f5dd7b0ee2af42358bc9a3820a605d2f0467cdead",
       "urls": [
-        "bzzr://09e6981efa3c896db9b7e65a8e671a8fa06d9681f503afce72181d49d60bf0ea",
         "dweb:/ipfs/QmfFKry1c5RyuEoBP2Gqdtwkb9F6XpyuxVPCTzqn9coXxZ"
       ]
     },
@@ -19912,7 +18373,6 @@
       "keccak256": "0x029a0be6d2abd5d4e31c260148e6db69f369573fe4c7c1b3d90acf493e26c422",
       "sha256": "0xa12a29094ba8c560cc5aafd0408cd5fa384333b5dea6e7c8a548832934a8877c",
       "urls": [
-        "bzzr://6cf33f15d47873360ccd07e35463d2b8eca93ce38cb0122d20985aa7e94e6430",
         "dweb:/ipfs/QmX8PujycYxPBbJ5rjotdMhtGfTBfnpjxMVh8Z18zYRQtL"
       ]
     },
@@ -19925,7 +18385,6 @@
       "keccak256": "0x53c2bb492b11cb68a8b5452470c739a68b79e2ecd29a446dc01e1522def5e5f9",
       "sha256": "0x6aa7c9fcb9fea6f0657640db3a62ba447d18fd9cba146add390ca7ba082a5640",
       "urls": [
-        "bzzr://5471d9e89ea73302189a9080c19b24d6aafa2fde79ace44ead9e97493f8f5f24",
         "dweb:/ipfs/QmTTeMF4Cnu8K6sVBSeqgGiZftraCi31sLshLWDA1E2ZVT"
       ]
     },
@@ -19938,7 +18397,6 @@
       "keccak256": "0x70906d179d96d8e3817cd5e9f5b5bf63da9da5110c10d3a11b5c8b53e440dc15",
       "sha256": "0xb8f629f6182ef94ee7ead433fb830c51f623c5071da7d262e200cc34e7608c03",
       "urls": [
-        "bzzr://9416e19647d240f8f972b9e7fe52781e60b30055d22b7b8965a846c35de1bdbb",
         "dweb:/ipfs/QmUT7FfL5Wm3ieBtMCiwNmjNcV5f7QYw7sL52GJyv7HY5S"
       ]
     },
@@ -19950,7 +18408,6 @@
       "keccak256": "0x6be35b86f5656c06ae897ef311c28da375bdcbded68c4a81e124f2cb36adf830",
       "sha256": "0xe0b74e0a16e783a35169f74d1a615ecb48d07c30f97346b83cd587949268681e",
       "urls": [
-        "bzzr://434c17a0cc3bf371e5b9baa7f804b37ffd2dc141a98c59b2ba6021fc419a39c0",
         "dweb:/ipfs/QmPnhNtzrEBeWWQMXdAByQTDPoKXXV9NFXLk3YL4QbghMP"
       ]
     },
@@ -19963,7 +18420,6 @@
       "keccak256": "0xb022937b90bce9013676f9eda3c89d8affcff319c0432b23d0f3f9c63498fdeb",
       "sha256": "0xfdf3b01f4a458a4d24a72fd1cf38b9e7ceafc260fddbf4a797956a2a231a9e4c",
       "urls": [
-        "bzzr://0ff1bd4d86ff56f84452634f350d5c9fb9bb0cb95507d91b6c5e98686a8d46ae",
         "dweb:/ipfs/QmUygpkUtX6EULDjjgJDeWxHdBdEE5FzXZtRgS87uq36Pj"
       ]
     },
@@ -19976,7 +18432,6 @@
       "keccak256": "0xc16cac692ef6f396beef12e95718edaf09e04c1026e6f121416d2f88241dcfef",
       "sha256": "0xe6df7d7e52c7fc677575f600d90a116601e9a83f28a9bd8e62f167b884671cfd",
       "urls": [
-        "bzzr://09ad4324fd18e777bcbe80b917db36d1c48f7a5e6af4e1632a708860338b8e34",
         "dweb:/ipfs/Qmb1QaDjAf7KdN4dSz5A3EMjzVYD6nhTaRYcfdQJ2MWjgy"
       ]
     },
@@ -19989,7 +18444,6 @@
       "keccak256": "0x5ba676b1fd1dd37e4edeb571c1dd24ec73cf45b2cceafaf718b4763d658c9552",
       "sha256": "0x5a1ad2ec42100baa2b3c1a208800a6be37a40abc91387ae31f500ec48cc2bbdd",
       "urls": [
-        "bzzr://a438f91926405117d5874b70eb8f9f3535ac0d01b75e00e1c7d41f10baa405cc",
         "dweb:/ipfs/QmZ4zkzFdqh2NWD2T2YBPca7M8tuNRCriXTfeNq4gohgs1"
       ]
     },
@@ -20002,7 +18456,6 @@
       "keccak256": "0x8925f90d2482b4d3c16e31ac17131cef2c6032d4416b7698d2dc5f479dfa1db3",
       "sha256": "0x3814a37f63eb558f8b54ed69fe748007bceb2121b490a723cf381f0d93c71212",
       "urls": [
-        "bzzr://7194fdbcd837fc3cdf2b51874d5f19aff75c9960d58748c8117c8f6090ee0708",
         "dweb:/ipfs/QmTjLZ65Q9LpHpLzVLgMwkC5FooEUfhd1qKh2qJVYHU7kb"
       ]
     },
@@ -20015,7 +18468,6 @@
       "keccak256": "0x7e696bcf29db84f770f1daa76ffd311594a18daf42c71bb2c86892ec4ef8c639",
       "sha256": "0x4120674cee3b63f93458ac38340220a4ca00dbfaced71562af9bd2da312a8f12",
       "urls": [
-        "bzzr://85315e691079ea0c682e179e14c1ae0fcb66c675347cebb29de17363e9a72183",
         "dweb:/ipfs/QmeF9Whk8P2XbsYA3YfLjaBtuw6DfE9p7Cw5XpSYAhkXZ3"
       ]
     },
@@ -20028,7 +18480,6 @@
       "keccak256": "0xbe822e8998276326adc7e5013effbb065d811b91cecc413a6e243dce49d14a04",
       "sha256": "0x20ca0b899b65852856d93f4db2d8fda79ff9fb737d66c618e7d2469f1e440ce2",
       "urls": [
-        "bzzr://9481860f969ee29060da3dd936b46a3fd22b94591dd69613949da6cd4d4b3296",
         "dweb:/ipfs/QmUqUN5XzEF9KdU2Ncp7UgxSwLpNaskucVdHVqatXL3HRL"
       ]
     },
@@ -20041,7 +18492,6 @@
       "keccak256": "0x94e5ab426cef917989fd8b48b3352fc1508b40054b1d577dc82b084d540f1888",
       "sha256": "0xc89cc3444d7d69bb7bd5b7b2b2f68c17d5b22a09aadf2b6c44d38111e0230009",
       "urls": [
-        "bzzr://bb7ed601171fbd36df658746e4e0a63ba34eb4a5783dd3be9d749a938377ff90",
         "dweb:/ipfs/QmQiAqrggoKaEbnSiqkNCsedCji7mwLFmS4pEaFQpdgL9B"
       ]
     },
@@ -20054,7 +18504,6 @@
       "keccak256": "0x1da6fbdb5a992db858a0669b6f25efa71b8bee8031a288b28d1a6b76c480119d",
       "sha256": "0x4b1af1e41aeeebc8efddbbeefda16ee527cea848b05d34a5fc564cfda2aea5a7",
       "urls": [
-        "bzzr://73e4e5ecdb8be8f4e5a11cd73e70a7a085107dca3339ccb23a4d52e35fa0a973",
         "dweb:/ipfs/QmYBSexPvikrSDPLZPCnGniiDUzXqTiRsETg4Jxi1pEK6m"
       ]
     },
@@ -20067,7 +18516,6 @@
       "keccak256": "0x17b31b62d77010f4dda11c413d187a6aaac333a3e50ac7f6528af026bd455ab4",
       "sha256": "0x78e0f9d56132daa7b438676c4d92732bd4f4e70fbbc21c0430788ea05bd2dbab",
       "urls": [
-        "bzzr://45990ba8a3d6b4d3d88a2b3b918af27ac76044965795a6420c1fe62f3beefb03",
         "dweb:/ipfs/QmeTDtMX4QKQWExeuQc6xFKvxvhXzcEMR1zeiuRDmoNMoc"
       ]
     },
@@ -20080,7 +18528,6 @@
       "keccak256": "0x2c32c6ade030720c1da755292ef07b672cdd957ef0ef07c95c992d612c8e1501",
       "sha256": "0xb897823ce2a85a887c5d248585cf2c221ca075e9575d72fd0eea7ce5705ddca1",
       "urls": [
-        "bzzr://0257de52c86a0d7cbdcd83abd18f8257959dc572d7d720ae837fc80b55cf896b",
         "dweb:/ipfs/Qmb1aGH5dcxnDMcN8SpoZunrMHEK2dtXRayCu7rAZ8GQ6U"
       ]
     },
@@ -20093,7 +18540,6 @@
       "keccak256": "0x30d515cc1a64eb05f8bffcffc790fa52ca95c26fac01a9f902af5cc603943dad",
       "sha256": "0x825560f30e43cdb55a81bf2f874506f2b6e735eee75baddffb4a762ba26241b6",
       "urls": [
-        "bzzr://50c2f9e51f11b1d7d2f7d12e5d3c414cc9b33caa057c62f0c251871468ed85e6",
         "dweb:/ipfs/Qma9TbBmcrCyo95adzvREykhezMnP2MPCXLBP4qj5GmhJX"
       ]
     },
@@ -20106,7 +18552,6 @@
       "keccak256": "0x093407f9f4f75895d88172bca926bd9d0737eacc02de295dc012a043292e0f94",
       "sha256": "0x059d06a672bccc383ff91eb87dd3e4d97c08ab97839ac631c39f428e1dc3dbe5",
       "urls": [
-        "bzzr://c22a67f2884b2dbf52096bcd0ebf92796744b5080f6a45868f1ad8d91f4e11c6",
         "dweb:/ipfs/QmXcvcZD8i9XBa8Cb9YGbLDsy6hVjPk9sfMZnzHiGx4t8s"
       ]
     },
@@ -20119,7 +18564,6 @@
       "keccak256": "0xe54023e175dfa16d339827bf00cac3e0187f6904220a3e327d23efd37a485f72",
       "sha256": "0x846ef32da2aef7414a0f064ae5a5411daea6395714f9d0cf334417268d2f1155",
       "urls": [
-        "bzzr://8e5df33514390d0e7d2f96f141e1bce9216312a2205b8c4dbb1d3d4b54e5e584",
         "dweb:/ipfs/QmVkbKLQbesg9QYLhfMi5cRfdVuwjcEe1WBr99rXCwAMuo"
       ]
     },
@@ -20132,7 +18576,6 @@
       "keccak256": "0xfd9ff8fa8f26661c74d397491e29ffeae75d561cb20a6b8415e32dbfe6c5b754",
       "sha256": "0x0abe41390841840e2ec47cb5795f04704b231b3d51ad31e8cd94a06c2ef6f0f0",
       "urls": [
-        "bzzr://709991f9cf265a2d3debd48c552fd3538f8c608c754e5721ed2f75aac3275d5f",
         "dweb:/ipfs/QmbJejGyDvvH2BMHTrmpuTcnfub75g2xa1zLzoodfP9yp1"
       ]
     },
@@ -20145,7 +18588,6 @@
       "keccak256": "0x3b622afc0fe2220e96f390f067d46abd2ad238d9c5d5ad0f8be2db56cd2ea36e",
       "sha256": "0xeb1df51a49e778c8122cf60c3ddd3a27c0a8705a30dc013693a365ae171a29ef",
       "urls": [
-        "bzzr://68e80318989bdaa299a20e3ad4129b9130e3ae2ede2c1df78429607ee670a91f",
         "dweb:/ipfs/QmYu7sKHiEqWqzeethKu8nzxG1BWii6yMtYLHq24AamcuB"
       ]
     },
@@ -20158,7 +18600,6 @@
       "keccak256": "0xcb1a79b2adc863b304ef5c9da07c24dad34726782522d0fe0b90397efcabdce5",
       "sha256": "0x6611e4bdde6051faf0bc35cd721770c7fdf71be19d0e9677668b00120e7f7754",
       "urls": [
-        "bzzr://6636fa107f38f933d9327ffc97d21f293c338cfad16aec699cddfa9658ef9181",
         "dweb:/ipfs/QmUJ5bC6uT6ZNLsyZpBaVemwSLg64r2fErKJQJU8sKWdiY"
       ]
     },
@@ -20171,7 +18612,6 @@
       "keccak256": "0xef6e4d54c2c94ffc6f7f346a4f91506df478a04ae3a6c6fa44e3a554b58d5679",
       "sha256": "0xc432e1709f4e8059291d195a65746546c9cea35f71106915988fc0d4ef5bafed",
       "urls": [
-        "bzzr://7a08c1611fc2a854fd8beafe37388ad5bab9a7f08a3da41164d4614179f8b6f1",
         "dweb:/ipfs/QmTLs6koHyiBo4xvTdxuvRPQuEV8Hzy5udwBaMQq98deWN"
       ]
     },
@@ -20184,7 +18624,6 @@
       "keccak256": "0x42cda120ee805bb64f5964d980937429726f951f6630cb4316ce4bf24fbad6e0",
       "sha256": "0x5519d88d7c3826cddaf14c1023aa696ad6b4dcf13c751f2962bfb481d995a105",
       "urls": [
-        "bzzr://fe62dec0016fe46a4e8bb29e48875962ce23f7192646a25a60655c131b75dc0c",
         "dweb:/ipfs/QmZw8Aw76ogKztpV1fGKebRB9uP15hymuzQbqLJ9QfL7vY"
       ]
     },
@@ -20197,7 +18636,6 @@
       "keccak256": "0x1f386f035884cdb5e49941c3dae843326597ddcf32933e3fa08b5533dcaf39e3",
       "sha256": "0x1b92070b99095ab0b42c09af4062f475590fafcb222d8044c2a1d7dcb4295ce4",
       "urls": [
-        "bzzr://16badac26dc17d0962b22c6b9322fb6a9524dfee0630e7a43945b4f0f6923037",
         "dweb:/ipfs/QmXCtinvppmj3TGHAeVKdnoXD7qCMCEpbvfA9WXNjn9xd8"
       ]
     },
@@ -20210,7 +18648,6 @@
       "keccak256": "0xd3713d88c860d43a352a1044d4db7067124e125261b6ccc6c0d5dceac9811320",
       "sha256": "0x82568d3fc4355cf75efa1b9df0af02737cc605acbc096469b2f82d0daf5fcfa5",
       "urls": [
-        "bzzr://143a8e4e8ce018b8d556ba59dc7eb3bd70c6fe13a25ef698207ac71e9a4d69e2",
         "dweb:/ipfs/QmNqe1aNMtLDCaq1dRspbiHjwDXXAYBrec2RXxq9zWDKUZ"
       ]
     },
@@ -20223,7 +18660,6 @@
       "keccak256": "0xf79eb9e190b35458ff12804d74cb912c5af2bd7e107a6ed9ddd28cec47dfbf71",
       "sha256": "0x85924a2f3f9be4f5f7fad1e268f07c10d99af2d3d335c3926a52134d33fd427d",
       "urls": [
-        "bzzr://048807e15721d5e125a391f52b93ce18feff1d257b402f643f83f0247be8f595",
         "dweb:/ipfs/QmaUAc9D696asVS8iiErJBf3MGn1TJt8jUSM7AEqKPbdGN"
       ]
     },
@@ -20236,7 +18672,6 @@
       "keccak256": "0x940fc3918c464b1cd1fd82a1c1b2236d193f54960970ce7bb675f149ab350ff3",
       "sha256": "0xa70b85e532000762b0331c446b6472015b5909d0379133e24c34bff8a2e0c69d",
       "urls": [
-        "bzzr://0e34602e476606d958454f9fec1319da3359e0234672351755bf7495a0675fff",
         "dweb:/ipfs/QmevjxojaewRgrXXgxiKJwhrAGpNC22tmS8QpGrecTUqQm"
       ]
     },
@@ -20249,7 +18684,6 @@
       "keccak256": "0xf2a36de532748c92076d4a91dae7f057f4e1c65f383b8aa69fa6ece5ca013eab",
       "sha256": "0x4bc173fbc9f50b7609e190c57d2ffe4cae7a44ef9703fbf27a443062a96c065d",
       "urls": [
-        "bzzr://e7101f960480d289949760956386be34fc892d52b366073c72b445af4f3d658b",
         "dweb:/ipfs/QmYbLwZ7XHxUyz6k3DVEwwAp2TPrzJUDuzvBX1zFkWxoha"
       ]
     },
@@ -20262,7 +18696,6 @@
       "keccak256": "0x9140f79d1d8ea5fe228dbc3bc079c0de484a6e13a9f1a639e6cbbd11dc86bd23",
       "sha256": "0x2a5bc5b8885d869dda539c72df1f5645310636f15febb2a1ddf0ed1b6387a4e1",
       "urls": [
-        "bzzr://fe5f1ec4066f25d2389fa38d6d482df144bfd8464112053eba4eb3844702d191",
         "dweb:/ipfs/Qmczeb11iQRLxkPdfpmdKRiKWXgvzjQtvEYgUQ7PaJrmWE"
       ]
     },
@@ -20275,7 +18708,6 @@
       "keccak256": "0x6e8d875627264ea84f2b4900913cdd362f8455fe87ebbcb4513a49233647f098",
       "sha256": "0x9d851505ef6d7b607f42b670cc81d5914d79574eef9bb16e0121bb723ab1a94b",
       "urls": [
-        "bzzr://bc108644bcf843cb3dd35e87b1ebe355f20f3524f066c2c37da4587431b1b7fc",
         "dweb:/ipfs/QmZMzxvvG36vNjF2VSrGrEc74UiydeYmvC7xTUrKGE73Qy"
       ]
     },
@@ -20287,7 +18719,6 @@
       "keccak256": "0x3a420fa9963772eee5b9221ebb8cf9548eea8f88b09537390960ea9b440f333c",
       "sha256": "0x5c509f760dc110a695c8b39bbc21e08c17dee431aa14d606f59e623d7c3cc657",
       "urls": [
-        "bzzr://fdc05062e4c7ec85ed18ab17b6f04f3274a4b7caf0be483eb86007d708825fb0",
         "dweb:/ipfs/QmciAxUX2kfuoxitmMdkKSfWn2SfxQdieLRa3S5S2munot"
       ]
     },
@@ -20300,7 +18731,6 @@
       "keccak256": "0x5cd9e3e2f785c7d3f879894a7a42b2895398270769c3bc877ce260d8e8622093",
       "sha256": "0xa3dd5d12bc2ffdcafdd2073295a8651f9d757f1765a09e57d3ee9fbedc7bb8b3",
       "urls": [
-        "bzzr://1d26de58a64240cb587ea7fe4515a4344264e17b11e808a3dd54d7f280ed3970",
         "dweb:/ipfs/QmSFaShxmcxHvt1vRWgfTG1wC5PwgL2vdHxdDN3EuFeDN4"
       ]
     },
@@ -20313,7 +18743,6 @@
       "keccak256": "0xd8e1107a91d9f9daa0e7e13274217396616e37a4453c0a0c0c57d8d3411d49c7",
       "sha256": "0x0b8ef9bdb6fd4d2046eb648d96eec56c44af3f12f58d6d6115d5c3cb06a88e2c",
       "urls": [
-        "bzzr://b36fff19ff6157e5e2c8ead2d5c500a133974de2a0f253c229c674b82a00be36",
         "dweb:/ipfs/QmQP6iGZtwk4xVSRERi1zEVoVH1rPpQ1daSTrw9QDyG3d4"
       ]
     },
@@ -20326,7 +18755,6 @@
       "keccak256": "0x9caa0d36ab4194feb0f12fea53a34936755f78b341cf38a1b6f49945bb0ea861",
       "sha256": "0x66274e1377b85d5286d24612b54b8d67af2affaef3957c46f4b23de9aa4b3df7",
       "urls": [
-        "bzzr://1e0fbde87f07348211b268fa5ee3333dc0a62b7cee4763a699e36b5ed3f8e750",
         "dweb:/ipfs/Qmet1gGantZmqKsBgzf5uthBVyV5WvpV7TZVwz5hLJnMkH"
       ]
     },
@@ -20339,7 +18767,6 @@
       "keccak256": "0x7ff44136538c5f5aba3642c38881f3104717a01d41487a67e464402dac2c8cf9",
       "sha256": "0x4bf3d1293d11067eb2d5c0195de65bca599b7069f922762fd96874f232d09521",
       "urls": [
-        "bzzr://ab3ece6d2c18b522d07875ad749b4d6bdc0b22e33c4a69d321264d19177850c6",
         "dweb:/ipfs/QmXppaBbh3SSW3iCH4P5S5ZSpPnRA2Sy2n85MdPyuchyg4"
       ]
     },
@@ -20352,7 +18779,6 @@
       "keccak256": "0x8fd088f3309bdcc807d6f8091dde277f9d07dfa6828677b3882227617f0aa42e",
       "sha256": "0x0ac41b6630198e7a058820f14f30d0c74511da230e886b1121b46898df0b624e",
       "urls": [
-        "bzzr://1d5027217005f6d8ee4b1d1df3a149ed54e5e068b358abd9851ca923653b6f7e",
         "dweb:/ipfs/QmXY925sFbiMHcZb7w8rNNTespL3rQJ2JK3d2FaqGtRcPP"
       ]
     },
@@ -20365,7 +18791,6 @@
       "keccak256": "0x7aa7dc1cf0acc67252c9aed1690d9f0cca939caeab14c08aae280329877efed3",
       "sha256": "0xd5ccf186c984628820394eb31f4ee9be8da5a2ddcd763115dbf3dfd3d4c5c9eb",
       "urls": [
-        "bzzr://a1c1e3f3837d9d8ab986213c39ada523f21e9fa84611f9bc2700ae8da543be79",
         "dweb:/ipfs/QmTJVS4w6frJeyk8ETr3keUqkNoA3bDgAYyX1SM9CLqdD5"
       ]
     },
@@ -20378,7 +18803,6 @@
       "keccak256": "0x51a6e8a776ad2bb12c7d786d2282189e0b17e25aa5316f257e650ec35d80e3d8",
       "sha256": "0x23951e4edbcedc04707414ee5da3bb6f1d3a6d24c31cfba8cf676071d103a791",
       "urls": [
-        "bzzr://ef92fcceddcdb73594b938fd2d0b6b1543be0d8ea17649ec1672b9f4db79d39b",
         "dweb:/ipfs/QmQh4dThHfsi9EwWNNCrv3VFNaQVdguR4FwckpGVNvS4no"
       ]
     },
@@ -20391,7 +18815,6 @@
       "keccak256": "0xbcdf0cba6847a0960d634254da7bcfd7e3aca2a2244fa2d4eef698c93c71f53a",
       "sha256": "0x0fc99e6c771f955082ec19c79c6553014211bf0d89fc7ba91bf753ae5069f234",
       "urls": [
-        "bzzr://7d9d394be21e24a01f9ad7397fd1f7c9d7d64ca6fc97c11991a187dc4d7910f0",
         "dweb:/ipfs/QmTj77ThcbkzSHhYCDk1eeDMbofajMirjPLMrE2NoU5rLV"
       ]
     },
@@ -20404,7 +18827,6 @@
       "keccak256": "0x90af12f4bfa80daa7ea5273ceb62c2e0e96e30376fe72c00b6c2bc7b9cf7003d",
       "sha256": "0xaeaa2a7939ba22f27b9d0b967f7fc13a33496eacc15f18c970eec1b7eed36b6a",
       "urls": [
-        "bzzr://eee3e526d6dda26da0099d7c97fad176c206c270177cc8f3859b5d6810d6dbac",
         "dweb:/ipfs/Qmb7RGuY1TBB5zU4ifkYaLaKiAn6DN1aQmCNDBHQxKn1gn"
       ]
     },
@@ -20417,7 +18839,6 @@
       "keccak256": "0x4499da4c8c82cd41ea94b53433b22d6830f52d3fe2e1b545d899a9e491ee870a",
       "sha256": "0xe82e834501f6382d3db2281757e46ff8854ab02e1fcd304f26fcb01fa0188818",
       "urls": [
-        "bzzr://ccb25b450f24dfbadcec0e558174b2f94a156d3e0831ad0c0d2a26b18619f74f",
         "dweb:/ipfs/QmPwvsZP9Riu1Wi9LWBEMD1RWtRPG8ZCUnwcfDHr5uLJUR"
       ]
     },
@@ -20430,7 +18851,6 @@
       "keccak256": "0x925ebe4a8354cda08514a145c01aa6ef3ead9644aaf531e56ae375cfbb1a9c1d",
       "sha256": "0xcc69eb82ffbba893f03938b9e6d390ab2e2b5338b4760921a5d69d80f4c47696",
       "urls": [
-        "bzzr://923ceab91d199729c77edb19bef8d2867cd4da2f712b440197dbc426af5c8275",
         "dweb:/ipfs/QmbCYR5i9WWBaQvG2KWDs1JFqSGWzwRWmxCtpvGgeBsLfc"
       ]
     },
@@ -20443,7 +18863,6 @@
       "keccak256": "0xa1d75ab6e76a3fb24e549bf27e9e291ea909b27de3b8ac04342477479a2a238f",
       "sha256": "0xeab8dc763f426c55cc436cbf7a90b2ab132e1a12e24c1a400cd0883c3c4db2da",
       "urls": [
-        "bzzr://3efb5e93fc537773574440a47588c84068bdf819b486458fa938d3aa683f15c9",
         "dweb:/ipfs/QmNsj51vyUUVFSrsU2KmZ6DhfZBhoo8rTPZSsaDGFBsgfp"
       ]
     },
@@ -20456,7 +18875,6 @@
       "keccak256": "0x03e87777adfc6b300708ebd3e8070e25507bc288ece79301d3cfc8db027ceb91",
       "sha256": "0x135c6e0f76f4a4be2eec82476f3a31d50a37d36948d280ef049415d7027941b4",
       "urls": [
-        "bzzr://ba2b5e37762293e80b7199774af8a10ca7e0ef438a9717a28b84d047cb4afdb8",
         "dweb:/ipfs/Qmb6werUGBibjwmX643i3BL8K9QdRaMNMjcHz71steaZdv"
       ]
     },
@@ -20469,7 +18887,6 @@
       "keccak256": "0xc148a93ae22bac67b38579427ec914ef9bc25df8dc3783acd7f806f9115ad1b5",
       "sha256": "0xec3f5cfe7d0f11e06f2241454613e61cfcb694c1923a61ce6fb602a26e265032",
       "urls": [
-        "bzzr://0dc02ad9c119b56c518aaa5b399be7c3cdafa4ab7daf501c19bbb739edde62d4",
         "dweb:/ipfs/Qmezh8ww4v5u8EVr7meAfGHoKhMnbQkHFk17DD5XKZ8eTZ"
       ]
     },
@@ -20482,7 +18899,6 @@
       "keccak256": "0xc39b819391bba922ebc2b6d79fc6298fa81239a7afec73a69242f55c0a0919d1",
       "sha256": "0xd8aa079e703058e77c74fe119e8c0aecf79c8586145bb55c796c0a9d66c1058c",
       "urls": [
-        "bzzr://62b7e079ffb20bdb856b60bf3dac1e6cb6c33e4560afb12657f6628a31fb7fec",
         "dweb:/ipfs/QmTP4doBLBQdo1d6Nk4SLT1PUirnxyD8EjqshEhL4fjJSP"
       ]
     },
@@ -20495,7 +18911,6 @@
       "keccak256": "0x6d1865aad64b8bf74b44a84f7d93c223978db16368a12f4c4334d1d86d1ce4a0",
       "sha256": "0x8f75ff7c9f7a6fafb9e85cf47fe27a52ee6555d74b5660b54d26d91c9e69a2aa",
       "urls": [
-        "bzzr://7f371eb22f9f85a3225d5cd99c11d83b0069195ceedb27b101247d91cecd9ef6",
         "dweb:/ipfs/QmZM7jF815W7KrXtYprYSpBjSuygXh3LrhJAtt8GFZhqsU"
       ]
     },
@@ -20508,7 +18923,6 @@
       "keccak256": "0x2149889046e9518516ddec8cf96da33d085a0d5f0e62fd02e2c425879e5a9ef5",
       "sha256": "0xb79523ffd9a60f5219b454b10b93d74622291374faf1aa932f39ad408e82cc56",
       "urls": [
-        "bzzr://317908fa1d88a7bfc3d45bba67a28b3a455cbf3e7d497a03dc56fb7ea07b7e32",
         "dweb:/ipfs/QmTWDN5h9HcKpcJZy8LP1xQvc3ZWHSqRD1BywfTGegG1vB"
       ]
     },
@@ -20521,7 +18935,6 @@
       "keccak256": "0x46b7ab02a02ed5cdb9f29b174da8255c21f4ecdcaf569f0213c78d6d5e73c4f2",
       "sha256": "0x386fbbe3039017e6d9d56219d5b45b5a6a4f4835164d39c1028eeb72e284fbfa",
       "urls": [
-        "bzzr://7c89c16c9acc32a09fd8f6320e95424d0098d261ded0ed874b2e51795897ead5",
         "dweb:/ipfs/QmRG2RKxUwLzHmmSRKzbgZngXdWaFYxWqaihWJKoo6tie5"
       ]
     },
@@ -20534,7 +18947,6 @@
       "keccak256": "0xe69653b5d1d6deecfd90be24a6b4b04afc4a8dd735592d169b0da32a26a5dbe4",
       "sha256": "0x4e836272635ca139811abe71d992bdfa216f4ac3db8fa6866ff37041551fbe8e",
       "urls": [
-        "bzzr://fecc71ae5a6d9cd004443c219970acf2ce0a03e8a19c6c3df7031e1330b334c1",
         "dweb:/ipfs/QmZQWMacGwTTz9C6mJ5fF8vmynM7yCNbuUvkjTKVZXYQT3"
       ]
     },
@@ -20547,7 +18959,6 @@
       "keccak256": "0xf0318b4a6f16cf1f1815368f7dfe580a2e224468929fe874d957b9153ca95204",
       "sha256": "0x7ac8848cd9a4c7e36567afbc8f03ab8a1601c7bc988104c26f9645d1adee502a",
       "urls": [
-        "bzzr://ee08c97056f2e9cda7bf20a1913c57cd17fd4f7c940e55ca0a0e013bc36fc044",
         "dweb:/ipfs/QmajDmgaaXSpkLSH4xa2ccHWWWwQHe72EhdX4P7rgLRz6m"
       ]
     },
@@ -20560,7 +18971,6 @@
       "keccak256": "0x287b1ee0e3c2bb970c44987e3b88098f00ee4a3b3080c3507425ffef50a2b9f6",
       "sha256": "0xd3421e597f08fd43bf2db4514d2a8e6b786522279facacffad97eb2d17e34c92",
       "urls": [
-        "bzzr://a3ea6090578c0461ef5d249dae6369e8106e740b70e297c8f5e329dce19818a4",
         "dweb:/ipfs/Qmcxxbsswcw4qYM7uchNEb4vbnUVj3JVZi4KNwQYhLssoH"
       ]
     },
@@ -20573,7 +18983,6 @@
       "keccak256": "0x11f9e97759414799c11f8cecf40615ac59e90cba964a658b83e5dbe0727f9a7c",
       "sha256": "0xc7f181d21e382a6ca7833b9d328c706ebd3e9c1b0d607fb0578748b72217d3fb",
       "urls": [
-        "bzzr://443f4ac72939a27ce429aa384af795975f41d46e0439a3d55400804de820d4c9",
         "dweb:/ipfs/QmRVMfuyg9CBUh2w6WSUhutbdzhfLRrtVx2mzx5XWMrqXK"
       ]
     },
@@ -20586,7 +18995,6 @@
       "keccak256": "0x663b0e82ff52ba586212a6fce92cca15984a063e17362489c94f38ecbc3f19b9",
       "sha256": "0x70682907dc77f95dfee4c46948c182407e7a9d04348ea19ffd6bcc4dbb444591",
       "urls": [
-        "bzzr://d28cf5c2fce0c208b738935547f3b57eb3b16d3bc222926c8dbfc6de7ab746cd",
         "dweb:/ipfs/Qmdx42Nbjc7Ea4D25RJg51s2mwEtC4RHNwZ1J2z6WBCB14"
       ]
     },
@@ -20599,7 +19007,6 @@
       "keccak256": "0xa7a1238828d8d5e5fa3c9c832f7229e7a7f9764457f86444931c6f651cf147d2",
       "sha256": "0x9e8ee9c1946f38f6e31ac76ae61081ba9bb30d180a88ef79911899e65f0a2d45",
       "urls": [
-        "bzzr://49277d58ad477272f7b0e48bf2a4abb4187c45f0d6b11674615f184e72b6f51f",
         "dweb:/ipfs/QmZdS5WxJARmqjQwi35SL6tXvDz1esuaNTXkiHsFZogmKN"
       ]
     },
@@ -20612,7 +19019,6 @@
       "keccak256": "0xfc4b396ad520aaaa76c45771777e9f69673d901d22a1ab2b38574161fc21c731",
       "sha256": "0xe2ef1c96dcd5a026b5fe81ee323fc3f99e5c6a1a0ba75a6c1a689ca1db7b71f7",
       "urls": [
-        "bzzr://fe04b446c639542d351ac487b9562356d0f3f02a5a572668944db1c06a91a988",
         "dweb:/ipfs/QmVeg2tksfYt3b19rRPg5QnmFc7pUETXixGrrTzzYFMykt"
       ]
     },
@@ -20625,7 +19031,6 @@
       "keccak256": "0x8d33fac0d560f4d4b55e510fbfa6338bfd90dede6c2838685721482426adb91e",
       "sha256": "0xb46fcb9e8513ded735b43ecb95cd0539d5c84d02dcdca17d28742b6d237d1698",
       "urls": [
-        "bzzr://1a9ee2aa1171def144d9d3e48c2aa21cb4b0a36f4bf5ca3c5a55083bba529dcb",
         "dweb:/ipfs/QmNtXdZ7cs86rbCoFFPucikgYS37w4Ci9eZzrGFFZLERfJ"
       ]
     },
@@ -20638,7 +19043,6 @@
       "keccak256": "0x06818f324e34e939e23fe6c873bc7cf72990d0faead459078abe896f2c0e9727",
       "sha256": "0x53defd3e92c8129550bfe7b65e70b7d5373e8358e6da6ceaed4b4dc0309f2793",
       "urls": [
-        "bzzr://81668b607ef0ff123cf161c426505e68cc1b7a2ad72f61d8c327b7a385a4abd6",
         "dweb:/ipfs/QmdWk3SJMNbFHkV41k3GjBLUhHDwfRMeaCbg4akL7jtQ4C"
       ]
     },
@@ -20651,7 +19055,6 @@
       "keccak256": "0x86b7c500b02363a9f3763f67152239dff8c21ccde2f1c0381ca07cbcc898dcfb",
       "sha256": "0x3b06e4b460174af4a5b4bc919f9a1a9dea07061cd60eceea7124fe102d813981",
       "urls": [
-        "bzzr://6fbd931b919e447f9ec9d33d722acdb1b265a8e123db4cfa901fc8b3dc5c3d07",
         "dweb:/ipfs/QmQRUFSVp1PKJw725kEiTBC1Emdnzd81LcRZkvpDhiChDN"
       ]
     },
@@ -20664,7 +19067,6 @@
       "keccak256": "0x2ee8af42d6793451142d0ae4722f2c7c8a30bff62453e48b3efb07d5c7283126",
       "sha256": "0xc640fd2c8b77d36549bfdeb35e4cf5640b31a73a0a21ba177a7152048eea8d8b",
       "urls": [
-        "bzzr://6a93e1e4c2001aaaffaa3789aefef6feeb5d894dd84447c201fca22b5a709711",
         "dweb:/ipfs/QmQA1EfwMbno12koTBYjJS6MAYXXyLHfzqWZvyx37rC6RG"
       ]
     },
@@ -20677,7 +19079,6 @@
       "keccak256": "0x6f999033d5a0925dd44364401e8233dc945ca6a1960fe463ec84d167b8ef432d",
       "sha256": "0x86380b44107edc5981cf0ad979fe2d717c17907e4dd89ca9244f6e18a8ae6843",
       "urls": [
-        "bzzr://5836abee10ba459ef8d0678e15a47cc94538809cbdcd03bbc498c6ce3a2559b5",
         "dweb:/ipfs/QmeX333woXbdtE291jAAqAvqgpxNwa9vWwzikbgJBtRfPY"
       ]
     },
@@ -20690,7 +19091,6 @@
       "keccak256": "0x32a0081f4b0da327effa1f38e702570a729da4c98aa1f7847e3e5bb441a72735",
       "sha256": "0x9179f9b3fc322506cef6802d6b5e57a3817fe450c4e27d7040731f2437f12d53",
       "urls": [
-        "bzzr://e3290b9324425088175d7c444901b511d3a0f5b31a358f622d0a647476230cb0",
         "dweb:/ipfs/QmWbG8d7wGhTGAoz5UtcUwBqpspQQzHKG1mz7UbrwnydYL"
       ]
     },
@@ -20703,7 +19103,6 @@
       "keccak256": "0x0c4452f8112623e08cc888fc8019bd4ccc7c7cbc5ddd7b4e13dffafc255caeb2",
       "sha256": "0xd9690e43650f25945aa07d429484526a621284072586b34e41a22271a2fb8e1c",
       "urls": [
-        "bzzr://c038ee3ff7ad1a20f1ea735b46d792c74e499d37cf2913373cdc9c0d4d51b27b",
         "dweb:/ipfs/QmaEJkzdcsrhzUhwkSRQNxcdMtpPATnT77Q9c1BZ5op4ck"
       ]
     },
@@ -20716,7 +19115,6 @@
       "keccak256": "0x814361be934adc58833ffcc009b9f1b4a8d55f2d184162f94514b082501412c0",
       "sha256": "0x9e155d45036ab313d94f920055542178c7ac7e9099ca8ba824bc2bcf891456b9",
       "urls": [
-        "bzzr://0052f237af798fbc1f20005ef39a8548be4d1e7535a1720e979c2da95bc50ca9",
         "dweb:/ipfs/QmXPboThSfwKkwHtxCmrS5vnoDnkeeuWyprooGpwsWGcyA"
       ]
     },
@@ -20729,7 +19127,6 @@
       "keccak256": "0x970d9b14ffa187c6fb0bb7a3ba88d390f1fb6c222172d7abc43ce24a9d211378",
       "sha256": "0x2b0cf07830912dd6f31334288f721d795dd90a06e6e81a6b34af3e7f858011ac",
       "urls": [
-        "bzzr://bba59ae37f9474a17b5110ebd975932d6ca23e6d0aa4a11ec9c325fda0c1940b",
         "dweb:/ipfs/QmdUjneUnMRuCfGaAuWSgkTMV9uzmuBZB1zFWZHCztECNV"
       ]
     },
@@ -20742,7 +19139,6 @@
       "keccak256": "0x8bb406b86d6860af9a4bb48093c5c1f930d6f513db41c8df6087a63b4335e7e7",
       "sha256": "0x77bfcf82a4fd724548f1e83feebbf48fe93776733257541d365feab2e9c650b4",
       "urls": [
-        "bzzr://e278755f80c5b9a911a4e7d131fcc614725f3f3118354f5a02a433ed5b313eb0",
         "dweb:/ipfs/QmQfVr94gYG8aiidVK5r2wJHBCQ6PkCiL9VPTW3pb8m34z"
       ]
     },
@@ -20755,7 +19151,6 @@
       "keccak256": "0xa555cef67ce627760e1c0940347f88ddc6def87d95fd71645be5b351826095e3",
       "sha256": "0x1b2481cec2f0c9fd943ad66a90328d4c67653d349d59bcfba4e6eb061a36932a",
       "urls": [
-        "bzzr://1f4fc931c75a544f8cbd768c7a2130f11615d9503caa4c4b034e71e128174bd7",
         "dweb:/ipfs/QmPp4HLeFmYp1XAP9af6nMatr9zXxhJDhYXUJDYhqr86fx"
       ]
     },
@@ -20767,7 +19162,6 @@
       "keccak256": "0x370efd28e2d28b6d0ba55e20d8994f3d286c3772552ed63586b5fe157c0d3c57",
       "sha256": "0x45bea352b41d04039e19439962ddef1d3e10cf2bc9526feba39f2cc79e3c5a17",
       "urls": [
-        "bzzr://5e66947c220c91a6cd39bc22965dcf861015b8613a6e09aa7fb7dc10f367b5d7",
         "dweb:/ipfs/QmXLgy6oexvCBWYS5pTpJWohsDNGqgdNFLRKX7JrE3NxYt"
       ]
     },
@@ -20780,7 +19174,6 @@
       "keccak256": "0xf262ebabfd335f8105ee082d28e4c57fab70bb9bc4dc2b16c50d14db70ad68ca",
       "sha256": "0x1fa47d5555d0710bcfccd9d399da2d9888eff486f7b267723be86c005dece559",
       "urls": [
-        "bzzr://5d7ef9c3f3512883714812736b705e224e16295ad343a0587ddacce6ff576e0d",
         "dweb:/ipfs/QmTv2kfj3xS8GRjAremZmm7saZTMJNMWLy4q1qh9BpVwvy"
       ]
     },
@@ -20793,7 +19186,6 @@
       "keccak256": "0x066798d154d229b0ea73818866adca5f35fff7f20510dccb88046c5d663b8c74",
       "sha256": "0x2ff4c95ab718672f711f540144e625f62b19d33fc03e102a5c8d2a4534c7cfbe",
       "urls": [
-        "bzzr://d2373ce262f7c2de9a976c40134c344ee212eefd59bd83a9ffb638cff684134b",
         "dweb:/ipfs/QmbdvR38KHy7FWWQup5XqfPBjgU6U8Da78f4PXNyzRzcQJ"
       ]
     },
@@ -20806,7 +19198,6 @@
       "keccak256": "0x09c50fa889bb9a7ab07d949e4e46daef1a537f83c5d49c8779aebcf3f92b43fc",
       "sha256": "0x316d49567343c90ec40311249efa1d93573a6a9edd82d332a010d77a38e87cfb",
       "urls": [
-        "bzzr://e9bb5e10f9ffe5ebb9578a4ebae971b31786d576fc4acf91780a8995b83355a7",
         "dweb:/ipfs/QmYwVYYSwduNnesUV9RCuLmgrFwoi3Z8reXCFxdoZacQVS"
       ]
     },
@@ -20819,7 +19210,6 @@
       "keccak256": "0xc4b99c23a63f1a7afb248fd21c8bc6575233f86e95805c714d90d5565e6a0a97",
       "sha256": "0x217851f8822c6a69b87a3e16beddd8d20bc128dba594c220181dbc3471286294",
       "urls": [
-        "bzzr://46f03d20d7631ed84e94619adda87aadb00801e78f43d40ba4ca447daa62c1ad",
         "dweb:/ipfs/QmapTBV1RRJWVwVHTPkN8Qr53Wv8PPms2kENsnpC9n5Kcc"
       ]
     },
@@ -20832,7 +19222,6 @@
       "keccak256": "0xef9d502d731899b3d70f85174e9f7e37da1965b2121bc3e11bac2a9abe7c0361",
       "sha256": "0x5cce89cae5e57879527c6a5dce299106ca6ca51e792bc47adced35525d30c8f7",
       "urls": [
-        "bzzr://1889b9b10e091389b5081f9cf3a3802d9a66dc1b7ad48638b18a37cae49f9898",
         "dweb:/ipfs/QmSX51pYZQeyzCuMAjuLc1HAVxYSxXHHuueC49sh7b7WeE"
       ]
     },
@@ -20845,7 +19234,6 @@
       "keccak256": "0xe3f6706b001c5724f51e7537e31c6a9ae11f5849e4cb396fcc77cb1ae25a0128",
       "sha256": "0xab4cdcd0c1e3496c67c33257886b902fae43b3e0b2f29615f27183b0baffe4e4",
       "urls": [
-        "bzzr://a2e52b19059428a7c046590fcab2057f8c8e6ee86892cfdffc1b9c895905a12c",
         "dweb:/ipfs/QmUhYkKvQYWcGZpX7Zz2zXs6ZgURgSXtwSTNh4yyneX6um"
       ]
     },
@@ -20858,7 +19246,6 @@
       "keccak256": "0x567a6bc3e6b8f6a1718715881d112d0188b6f403995efd95bc4b835f52d2e3b3",
       "sha256": "0x0c35b3f7e9739a1425979f4c8bbeabe78ef7de5b8dae1bd3f779692d6239c170",
       "urls": [
-        "bzzr://df0d32b697283cd887b1a253e1a9da9d5ca08233393d1446dea307b256963e6c",
         "dweb:/ipfs/QmcEaQrffe3sxhyLFPGonnnphdE4rQYn5zE3X7Kf1kghkt"
       ]
     },
@@ -20871,7 +19258,6 @@
       "keccak256": "0x1efdfd47dfc4c052b8ff7c8810f797e8df3f00cf6978eca1750a2d6588257296",
       "sha256": "0x14cbe80a78401192bc5858d9d45a4fd4fdb0dd4f81d0a09ed62dd92c9f4c7707",
       "urls": [
-        "bzzr://27a0fd0a6495b0970c73867f788689535b77a76d993851a304a40bc949fd667d",
         "dweb:/ipfs/QmSVUbEbdgUrG6fbqwC6g4i94KHgo2SnSozUTRLJWPmGTT"
       ]
     },
@@ -20884,7 +19270,6 @@
       "keccak256": "0x31ba5ee56958b8eec425b98276f4e7fd8dde3f605af3552d14e6f683a9934e35",
       "sha256": "0x24971f85b268edee9f8293e27d2d56cf12e263f94d8c4f3799ae054509b4ee33",
       "urls": [
-        "bzzr://ae24a08231cb66b35b0ec8cd65f229198ae8e5d6007bde647981a0fbbf0995b2",
         "dweb:/ipfs/QmaBCVABsacsDXMXNGKAjQRNreEsCfewm18G3rYi7uWWqe"
       ]
     },
@@ -20897,7 +19282,6 @@
       "keccak256": "0xaa89fe1fe9955a12dd3950f70729c1194954331976352f7d75d71c40e45eb034",
       "sha256": "0x6f35c5402031edb7478834b885ad852db79fa5807eb9f0173cc9c593f76b02c5",
       "urls": [
-        "bzzr://cf7ddd2a3c357752383310528caaaedde2d4c52eb5ba035af27b48701d7ff357",
         "dweb:/ipfs/Qme2qK8xA4t7nnYKaEd4kUvswYU4T68jdkxhwk7qnfzAZc"
       ]
     },
@@ -20910,7 +19294,6 @@
       "keccak256": "0x9d68af9846fde14ce1645b56a3b30ffe6a30c04ac3d361357245785726c38a6d",
       "sha256": "0x1c4d7c83468617ac00c9c92bda932a1345b041dca1ff3e901bb7c0f142d3c029",
       "urls": [
-        "bzzr://2f52c027242dbfd93a84329adaca2808555c8d8f8061e728a2fb2fa294456e98",
         "dweb:/ipfs/QmW62knPp3v8fveNkAr56E6JuXBCQNFeYrakw2rGqaLE5r"
       ]
     },
@@ -20923,7 +19306,6 @@
       "keccak256": "0x26affe8fe1252ca61392799cf18370f3cc677e1db5557265e320b7e1f9f5ba04",
       "sha256": "0xb90c4e9b70e8d8cfabbc7b3926877d9be09553923679247739ec1e3bfca6c553",
       "urls": [
-        "bzzr://63112f94a9f324e59b6d507fdd02f866150f02b4fd0c70637ebc24a89b31439f",
         "dweb:/ipfs/QmcvUfUX7osn2iUQkBdVLd7hdqSa5aZz5oaLMAw9cqeyGV"
       ]
     },
@@ -20936,7 +19318,6 @@
       "keccak256": "0xefb23a681df47e647643f8b38bac7579939b92e8f61a87d37b497e0f4c338308",
       "sha256": "0x57348115f66b2dfecfb473a8047f687811918d3120f6475f933fc4c57075b5c4",
       "urls": [
-        "bzzr://045f103d9e17dcca29b7e1fd884ceac24df2202ae5494e4e9f627dda3b3ee8f7",
         "dweb:/ipfs/QmNsTmY6VGBFmU9M5d5pRgM6UdrhTcqftpdiLZFHk85RsY"
       ]
     },
@@ -20949,7 +19330,6 @@
       "keccak256": "0xd5738311e9237c55d08fe10585e00c87f2541d1ad6432f1dfc813865d733e3c5",
       "sha256": "0x2c594cb3ec3b9ae01b8669ebb1b2154fdeecd5668b09d073d6fc67773f032f09",
       "urls": [
-        "bzzr://6a62ecc683a0fd5879432aa9088fe92f558450bbb5ecf691c81d1b42c1a2f6aa",
         "dweb:/ipfs/QmXhupV976Pmzh8gRxDbeYMBfbrBRpqaNr9Xae7ZXY6vxC"
       ]
     },
@@ -20962,7 +19342,6 @@
       "keccak256": "0xa396d8c1ec83720ec7090acc282cddbc070e899bca6cc7f66d1b0aca602baad1",
       "sha256": "0x616f00d4286d32fe6c5d6cf70ddd82df82a7f938592931fc5574877899618388",
       "urls": [
-        "bzzr://0c9adb926bce37831fb2b2d59f0f1a1571debcf5a8f187f8890b8e1c666e1ca2",
         "dweb:/ipfs/QmUNvSV4qFKDZL6X8XzMb4bg3L7eW38Az26Yt83pKZCLDv"
       ]
     },
@@ -20975,7 +19354,6 @@
       "keccak256": "0xca81551d783d42dff1bad96f76a3b6347eede24aae49494c43e65ba6137e0be0",
       "sha256": "0x8b7b6054300ad835bce875ab7a75ff5ccece374744464f7ded210b02d075fafd",
       "urls": [
-        "bzzr://defed0b617ab4a21e2486504212e75f7c1fc3dfb2334a8268a901040182e983d",
         "dweb:/ipfs/QmRgZXtDPGpn1qiDRCWUcmsXDQEM4G9aigyzxtRwznDcNi"
       ]
     },
@@ -20988,7 +19366,6 @@
       "keccak256": "0x2178f8d3cb3d2ca4caf278138a06cf8d73aa4fe62b617fe33ae021496cce2512",
       "sha256": "0x56325cac8c5b46c520637e338d2ba443dac08c325fd85cf782215ab4ea929bb9",
       "urls": [
-        "bzzr://f5aa2b1c0cf916c9b687cc039d8b3859f27c7057eeb7dc13bfca699bc6aaabe3",
         "dweb:/ipfs/Qma9ApHBdVwwHi5io2rdLLus7cmgGKuF6EmMk8dYf6bPjQ"
       ]
     },
@@ -21001,7 +19378,6 @@
       "keccak256": "0xba455769276772a1338bba033bf64345147eb6d0bf798309f5af154303bf31dd",
       "sha256": "0x792f019887731349f11ba2c3ec37077cc25bad444e07dd988e9fc52e8fdcdf6a",
       "urls": [
-        "bzzr://4ebd666196ab66cc80ca80400a16007a995ad42b265ac6faf4ca195aed1e18b7",
         "dweb:/ipfs/QmbwAxoNq6Ut3TusX9KC5Wo4ozD37oaZktdGKURoVTRo74"
       ]
     },
@@ -21014,7 +19390,6 @@
       "keccak256": "0x994f157247dff78d9cce23499e3dbeece544703b1552c309f0fa9efa90efd4d8",
       "sha256": "0x9a5c5c9cd13dcb76f333d928bb2fc588819f25a8a0d247def9fd4a1e516837aa",
       "urls": [
-        "bzzr://8a61627e00755b1bab2a81da578444b6f706a4b63b122b73e54baf3e97cfbc85",
         "dweb:/ipfs/QmNojpMD6SpMs6dwqatVqxdhcvrRd8JLpv5vk2SCiDmhzG"
       ]
     },
@@ -21027,7 +19402,6 @@
       "keccak256": "0x1776ac3dd53f9800221aa19f1777268867ce4d4350d168b864b7635c474ce85e",
       "sha256": "0x8128bb479f686688dc1535243ddfee4bab108eb5c9d12634c481f2e01b7b2b3e",
       "urls": [
-        "bzzr://d1e148da667aad0a413491277fcbd7832f0dbd3c41d1efcdf630e59e49301d40",
         "dweb:/ipfs/QmW6sos9oQpTftwgJ4qyaLje2aYike1QS5LZ7Sj3hfGNsd"
       ]
     },
@@ -21040,7 +19414,6 @@
       "keccak256": "0xa80393e27be56bb7bfc5e25344fbe2508ae92a93cee2a6cd042c41f5dbe1fb96",
       "sha256": "0x95f73939a4639a42dc2e2c23dcb86df29d497fe6acebb67b27f3dafe8a09d119",
       "urls": [
-        "bzzr://a81f67347e2f9cf25318b63d4a3995af2137b7cdb59baf3d9db54f652e170c28",
         "dweb:/ipfs/QmXREjhBouPmNytjuUqnHMsPHxuVP5oCrJCq6gr6oo534B"
       ]
     },
@@ -21053,7 +19426,6 @@
       "keccak256": "0xdb7359baadba99fee1d63d0c886aaea26347b8c41b33f9898d362fa4b1275e57",
       "sha256": "0xef556e6bfaebf79dfc9a8757cbcaa163ee6303413343cf6fd4bc499a3fb1324f",
       "urls": [
-        "bzzr://5d33d1ce9a3ae4a1334cbc5f5bb2019b5d267da75d3d6cab20afb42f33cd0121",
         "dweb:/ipfs/QmRRbHGvjK7YL2U574oKC1bTP9hv2HRNwtviZqbLcDH7k1"
       ]
     },
@@ -21066,7 +19438,6 @@
       "keccak256": "0x98e3c2f7aaa254bc5fe894cfc222073861276ed7c1209b3ef87e5b9463e8db7e",
       "sha256": "0x44e896c674ee8843011df1e93bb8bbb463ecb6d1070509a67affecd56f1e8fdc",
       "urls": [
-        "bzzr://37db8d7a95a0605e18ccc8a09d49d47d6d7ac897ca2a7c9b05c48dd486db6c8b",
         "dweb:/ipfs/QmPeKZ6Uf2WXWB1xPaYJSMPiLHeZZkAx14pRhjmN41JWA8"
       ]
     },
@@ -21079,7 +19450,6 @@
       "keccak256": "0x44bfd54059d5ffff0edd0aa4b28bf66ae3976df5064c1f2902f4ce1e60897728",
       "sha256": "0x73180d12df604ecac2749c07ab2abe12fbcb69d8469a6c0123e0c56a8df96f27",
       "urls": [
-        "bzzr://241c0d22629461858777714ca3e0612801fffb5af6c6534b0e73b99b25e96870",
         "dweb:/ipfs/Qmesv8ZsLb25BnM4C5QmM4MtB2xgVw8z1pwgMfAVTJYUTg"
       ]
     },
@@ -21092,7 +19462,6 @@
       "keccak256": "0x8616a9aa0f7ff576cc706730b00243da04c71a237d4c8b76990ddfcfa7c3a7ac",
       "sha256": "0x2d6ca2976231ac2807ffb69c4c82b0bbff75f16f1a649d5099757ddcd13226da",
       "urls": [
-        "bzzr://3d69c1fb475a5c61bef6df93271009c6c28d3051e7f6e349374a48491a47e7be",
         "dweb:/ipfs/QmRn7Zuf6YE7V9SToMiky1ZzQzmQrLDuPpw5epX1TQYLBz"
       ]
     },
@@ -21105,7 +19474,6 @@
       "keccak256": "0x65dcf3f8bccc6dd1685575262baa05342b6c8192fa228fa6c399443b9fdf4ed2",
       "sha256": "0xca311b2b95a1dfdf17b3cb2c0a58ed8272a80609f48b997868861695bce9e0f1",
       "urls": [
-        "bzzr://8585073abcf5374f7acd0b1b15361a0841cc47b6d4915b7926193b9f2cde91c5",
         "dweb:/ipfs/QmScMcQNAPgVgJtEyLrZYFYGqjgy922oACXA2PEB44Nyza"
       ]
     },
@@ -21118,7 +19486,6 @@
       "keccak256": "0x284309f89bd4e06f510d27386a7fa16892b59e9789daa1ff2089e07da782ba65",
       "sha256": "0xa15b63530ab3a3f4f657ba472b9f39d2297cb48514f5431c0830f85da63b3c5f",
       "urls": [
-        "bzzr://b3f5eb81afa3105b5e1ee3d19f1ce6a7e1a03ffe85d2092aafe10782622c82bf",
         "dweb:/ipfs/QmYzUYKWM6pjgoejGAswXbPEb8AWq1ZsBrWuECvhLJtLf3"
       ]
     },
@@ -21131,7 +19498,6 @@
       "keccak256": "0xcbc4ee61c7f1df910321fec1cd415c9fd18661b74de5e7441e5b0cf80bafa9fd",
       "sha256": "0x20075108061a58d00c54eed34d26635269bd94a8331c06d31f4d01b40621a31c",
       "urls": [
-        "bzzr://b423c124cf396902340b8cfe588ddb68e500f605bb8bc4b556abfccc5cae12ae",
         "dweb:/ipfs/QmWPU3WrZwoqkRHocMEYwhGExc3kfLbMqeX1i8q7dncNbh"
       ]
     },
@@ -21144,7 +19510,6 @@
       "keccak256": "0x9e5bac57531f5a2172b646136a6fe1a0b32d6888fa2f7de9c153bf6288f6c32a",
       "sha256": "0x7b68b02515ad2ece2e10479616560a5fe939cce3a4d5fbf0fe1f122c076940d9",
       "urls": [
-        "bzzr://c3440cda24ba30612851616bdeff9e16481efb4c41cefe639cf11a05e022dc7a",
         "dweb:/ipfs/QmUyUAhHJonxfWRGy45f5dxxxNWkPzMhguWEYsfihhMErD"
       ]
     },
@@ -21157,7 +19522,6 @@
       "keccak256": "0xb53fa1b520a1682bf69f20bd1b65d3e1ddc87233baee7563d37fa0e1f166da56",
       "sha256": "0xc6042ea5caa7e3367058759a80b0ef66713f85966bebbb09da67cc494609629c",
       "urls": [
-        "bzzr://9dc3a07fbbe4586327ca88dfdf955e2a43eb9ccfeae0acc306f94c5d6aee4d86",
         "dweb:/ipfs/QmYSncevAwnD3UX2kSLoEY66UYXBk4c8eGtGB1fX6yimG3"
       ]
     },
@@ -21170,7 +19534,6 @@
       "keccak256": "0xeedd2e58412dfc8360ce3ef13d1e3507e4d244c15a01659dc3172f051a69ad6e",
       "sha256": "0x8d9e2e9c43d8d9be986802eea98106f5889b72dd964c4ed1e79895d34408d118",
       "urls": [
-        "bzzr://378422a60a769772443880f618d22cec3f9475dc0bf372942edc7bc37bfebd42",
         "dweb:/ipfs/QmNV3mUC4RPH9GrT8A5TUhYrDRgFvurSqhoFCjAM3Lp3ER"
       ]
     },
@@ -21183,7 +19546,6 @@
       "keccak256": "0x82b59c65d37bf13eed72423e60529059505c42f666236899bd28bb02a2f667f1",
       "sha256": "0x603729b677f94bcee7bd94d187130838a226a04c06d3ee103db6ec44ed5c41de",
       "urls": [
-        "bzzr://07cd179208ff1f8307382bd7554a3b0e14e673f900139ef1d8d6442c6bddb626",
         "dweb:/ipfs/QmbRcLadThghK1pRSb8FLV1ZCCa9wMRQrBoosBdtbFzdym"
       ]
     },
@@ -21196,7 +19558,6 @@
       "keccak256": "0xe16814b2717e3b08d6da91a023e2b4eb43969faa5549d4094de22f53d259c753",
       "sha256": "0x92f40dcf37a60652431505de154c401f999078e7f53cbbfda57ece46e9598b79",
       "urls": [
-        "bzzr://5e17f8c8cd338e5566c94ed4f890812b38e5da97e5d4af2883feb31e2807bf61",
         "dweb:/ipfs/QmczQMV9AhJFHGfREyBcsQtmURYQoSVkDtkUzbypKubnig"
       ]
     },
@@ -21209,7 +19570,6 @@
       "keccak256": "0xb951f73ea237eff4dba49689aac018d45d4d5ab75e39331bab4992a7e7693846",
       "sha256": "0x01fa3ee9a351652f3b129e178d900cb4cf0af59eeebaff7256448bdd31277e04",
       "urls": [
-        "bzzr://1cc8227d0111a62ce499edff23bc3c8073061db0b0e17c69de0aa03b04a4a61c",
         "dweb:/ipfs/QmVkww3pzn8zYVwqVySkAcWSz7HvKPCbikLKUkvjED3Uaa"
       ]
     },
@@ -21222,7 +19582,6 @@
       "keccak256": "0x3c40b14e1200cd4047a7ed898609f216dbef4bb6c434ec6884a8015355457dce",
       "sha256": "0x7a618a91e84570ea68b5be1a9420aad73efdd6dadc6759dea85d45fef5eb6319",
       "urls": [
-        "bzzr://27ae22f0a174fb3fa356c6b6e1cc63a293101b7bb4f03af98ca04b7e88e5ca75",
         "dweb:/ipfs/QmbycGRrtBdbt5tZzvSbHXNTikfFuUFMzoXSWnacYnbM7t"
       ]
     },
@@ -21235,7 +19594,6 @@
       "keccak256": "0xcc5038c863ccefe434b2b3056c79cfe1b0c198a4e46e33d9e0a5a572f778b199",
       "sha256": "0xf90de77c1f8ed4693984ffb2ea3ebe4ddef6d11b3a8d5fa22989f9a1c338e452",
       "urls": [
-        "bzzr://1edadf32f7e6f04c0fb3994ce970b986842e46cfea3a03613bdebb1080c6b575",
         "dweb:/ipfs/QmSSVUWStzhFxV7mQDrWH8UNoe7MhiDvpTtpkD6yLTVBfD"
       ]
     },
@@ -21248,7 +19606,6 @@
       "keccak256": "0x6d04b866868cadae29f54502784ecc73623c2d9f3045eaf830fb6793e07510ed",
       "sha256": "0x17c857151c7ae90e37e8162f73a6a081e40667f3d15848afc83f085f70a28b90",
       "urls": [
-        "bzzr://4e10135f1cbe24475508d69c7f8abd86af7beb0a2a2de19b13880bb08b675edb",
         "dweb:/ipfs/QmP8CdurCswNhbCJTvh3EfbfPMTeo27vD76GsjQGSKfbRv"
       ]
     },
@@ -21261,7 +19618,6 @@
       "keccak256": "0x6b4b33ba6496817c57d60407f8e1de3ce211dca1d6c7eda4f3cd5ffbf23c81d1",
       "sha256": "0x9f8d6ed00c769a05154fae490f9292ac597e25655b04efab06e8e994e3a3a0c0",
       "urls": [
-        "bzzr://239c7d760256960900a459dd3560916c6c2b1009fb7aac12d100f5696ed28c56",
         "dweb:/ipfs/Qmd8vM2EEvaPaeBBwL1MNRtwRbWBdr1Qn52pjYnV8Vkokc"
       ]
     },
@@ -21274,7 +19630,6 @@
       "keccak256": "0xbcf01ecc97bc161db2aab16977e04ffbfb4ca078e464286a7aa4fe3311af6aa2",
       "sha256": "0x5529f076409dc7e493d5150a4a45b9ab9cc734e4eb47af705ec8d8b0f85cd282",
       "urls": [
-        "bzzr://89df55caf246214e6c236a506282e7c92023379dedb9e2c44f7a8d0bc5696f70",
         "dweb:/ipfs/QmTCP4wYuAjiVNnwAgpSCVC2pnxjn49edw2pEMgvEeMv9C"
       ]
     },
@@ -21287,7 +19642,6 @@
       "keccak256": "0xdeb417f342ea675f3e4fa9ffca98a2bbb4a041d3a82b09839430a5f6418e1ab5",
       "sha256": "0xb49a416a7adf95c4918f2e9d299e3361ad3e267a10da5ff96df576e458d5b380",
       "urls": [
-        "bzzr://f43662238d6e36e9b0c9c49abfd5c038be1f6280864fe852bd88163ed9b52854",
         "dweb:/ipfs/QmafwWXCPpchgtEqtuYXotMHJqCXcvKNh9F4dVBq1j2jx1"
       ]
     },
@@ -21300,7 +19654,6 @@
       "keccak256": "0x751b7b91cfbaeb698f75c2bcf151c08d3be59a5749105dabce26b758964fbd96",
       "sha256": "0x052e8e081d16da8551aa7656a14a1662c3f97140db63753fe310ee102cff9f63",
       "urls": [
-        "bzzr://bbd077b23f880c2e6be25d9afdaaddc6289dca202a521c32e22456c4d87154c7",
         "dweb:/ipfs/QmWZcWfWj9QqzoPuH9RGPmEDWq5JfN9nrsxqiSRZ82odLT"
       ]
     },
@@ -21313,7 +19666,6 @@
       "keccak256": "0x62007ff83d6686f09e316dfd3246cb7f10a651294ff1e8b1b7342a6ab0f4d4d7",
       "sha256": "0xe341402de660176f0e30609d145bde6636228a99b3fe35c8143b561ca487ee20",
       "urls": [
-        "bzzr://092d21a09db2347c9523751c8dfa20f237299463d9ee1feb30fc738e3fba3269",
         "dweb:/ipfs/QmUeMwpdqjQy2vX7RiWMD7fS2t5qCDXiFGetv16QrGWWPn"
       ]
     },
@@ -21325,7 +19677,6 @@
       "keccak256": "0x907eeba6e6e0d6977ac5a8f50e4dd2762539ca827ceab1afb1f5a4f0f3ce3e0c",
       "sha256": "0x92d283c545395b91a656fa1ec94d567a464bca55aebcdbb99debf42b43026845",
       "urls": [
-        "bzzr://63ec828814e2b57db2a7a146061a96cc39797ba39a0063a7b664421a48f21c00",
         "dweb:/ipfs/Qma6o4e57YtWj8cQLQs12r2Enx9qmRA7VHtupCauXjYTAk"
       ]
     },
@@ -21338,7 +19689,6 @@
       "keccak256": "0xe290842f0d586502cc70fcacb8366aeeb99a2d9daf98dfec10dd162cc78626cc",
       "sha256": "0x865df98d4f3f2b9b94340c933f9d3aa173db3927c3aa83a45cf971d9be6c70dd",
       "urls": [
-        "bzzr://8afe23f3850d86aa51dc2cfa9d483e72ed61e8f353d038f81d823149187938ba",
         "dweb:/ipfs/QmXwQRbPT4mRFnkEczPBarPnTKr9MVcy77igQiqEtP2Lwr"
       ]
     },
@@ -21351,7 +19701,6 @@
       "keccak256": "0x769a5a72aa37d90b4995dde0a5c5c7ebd3b0476c54896951887a8d63bec3553e",
       "sha256": "0x77a23a3d2b8326361628f9b3c2d67c5e125a40dd74921a4d4227db2b6b323458",
       "urls": [
-        "bzzr://bc4f18c3cccedc867bf7a5263c95248d59f73380d26f8d29736bc0aec1e928a5",
         "dweb:/ipfs/QmT4mn4umPgqvgfaKr1T7QmQiAc7h6yoRW23VxCv4R5Kmm"
       ]
     },
@@ -21364,7 +19713,6 @@
       "keccak256": "0x4d16fcb61797c6955bc35937f9c9b4ecc5f478fb0a2cb7b80a1b85aa615cd7c0",
       "sha256": "0x03d6ba782195b60d92bd5b5accd228d994f0dfef2182e2dec94368993a51003c",
       "urls": [
-        "bzzr://e013cd4304cce47432b35a7c7b7667be9bdf7c79d6b67010b03352a691dadbf2",
         "dweb:/ipfs/QmTT3kLmWoEUay5U44NotAjfGGNgWhC967dUzZjmKqvZ2H"
       ]
     },
@@ -21377,7 +19725,6 @@
       "keccak256": "0x26fd4153b2c5ff7289983d78c08511887e98dbd2bc22b9c6ce84ba426a6923b4",
       "sha256": "0x8b1f77bd575b48de8f419864511672bff3732d5e7175043237d9cf17314ef4af",
       "urls": [
-        "bzzr://87bd01b9546b3aea8d25af2f6bf5a2a820214c1739d0d4ad6c152638b5e17295",
         "dweb:/ipfs/QmQExjj7Qecth7zAtYAqczDWpVC7iDJ1WMRSqjgt1adnjX"
       ]
     },
@@ -21390,7 +19737,6 @@
       "keccak256": "0x4c5f3de142bf0c332a73c93b0385d83bc4b8498e7ffcf9d11b65dc98ef095e99",
       "sha256": "0xbef507947f3fb92ff3a25c1269aab62d1fb775af0ce50dff5e39fe0e5dfc8eb4",
       "urls": [
-        "bzzr://a42dc71ca1edcbbc03cffce64737cd50de1c20b15704396dd7cfc1f8f1bd982f",
         "dweb:/ipfs/QmZiebQWGpwFW1FHQXibbX3bmPiTtvWCRtr7taSVutJoSg"
       ]
     },
@@ -21403,7 +19749,6 @@
       "keccak256": "0xfb1230a7cd4ad503c5a68e881e20b17b320c57195f3b71b31f04328c4bff35d8",
       "sha256": "0x5f824d1262084e06c7088906f085d33cfc04ccd9a7e048dc5c790a548e8197e8",
       "urls": [
-        "bzzr://460d178c2020f7517d42c10b9919eecaf0727780b266208dc9a1a6c7e2b3ba40",
         "dweb:/ipfs/QmbUNMvzVzTK4yFeD1bn443K4yXAwFK7qMoj4wAA2FeUj9"
       ]
     },
@@ -21415,7 +19760,6 @@
       "keccak256": "0x743aaafac24d9740a0b71215f55a132f89336a662487944767ca4bfd66400769",
       "sha256": "0x9c681b165c8647867589c0a5ecdc8692637a935928a2b1bbea2ff4a1f4976985",
       "urls": [
-        "bzzr://6e70fe6bfe8c3fc63f8a3eba733731aab129e6e58828b78058e53bb50440709b",
         "dweb:/ipfs/QmZy5ho8W943FMGwppXZFS1WFrVwV3UXhUUwcD7oH5vrYe"
       ]
     },
@@ -21428,7 +19772,6 @@
       "keccak256": "0x20400f16c9589f51688acc0e952c255cd16e210801ccfb478cbbb4c255d4ea2a",
       "sha256": "0xcc8f5ad0f1c65a7377ac8fd29bde5fce90854deb2ac5678edc73f87f9d332e23",
       "urls": [
-        "bzzr://e506c0790a87c85ebf0120a4bebcb9a7376b3579309898f9f06c561e02fc164e",
         "dweb:/ipfs/QmQQ2htu5oXiPSU6V4yPeBjUm6iFKZXG6LrvV9GRrxfrax"
       ]
     },
@@ -21441,7 +19784,6 @@
       "keccak256": "0xc54565fafc4b4783b595a1fed6f62a4a078642698f76880b34bdff4b8f5f3a7c",
       "sha256": "0x59232b989209f601c545383c18331dbf3727bef769f4f8a3e5bb9f323fb37f2c",
       "urls": [
-        "bzzr://707182524790a1bfc4c7920f2053384965729aac02743734a937b62a92409be4",
         "dweb:/ipfs/QmPgnsAGqtgxfy558mb7SHv1XYJ8AnNAfoDsu7XvthVwsG"
       ]
     },
@@ -21454,7 +19796,6 @@
       "keccak256": "0x24a108d5ee6b230c57746bbd2a97d1998acb120e4e7eab303a55f27cf66805f6",
       "sha256": "0x91a7f183aa5f069d27ba21a90a8824288a9a1f6558b264f3dfd62564b3d65540",
       "urls": [
-        "bzzr://43ab75a4da50ba0e295b652b215a66a60a9c20204a805e2ee18d36cf8cb025b5",
         "dweb:/ipfs/QmUM1NTWNWhZ63SrvGt7p1vUNejN9or9WfUCUyfkwwAQHx"
       ]
     },
@@ -21467,7 +19808,6 @@
       "keccak256": "0x643b88c6e8cca930f89179a83d5d71033f6d5a64bf287c17064bfe0b0a1f058a",
       "sha256": "0xa31efa308cd14d74ebdd70afd4464505d8a60a958e6b241249213f6a4fad3460",
       "urls": [
-        "bzzr://97884ab67a7a59d7c7af1d5c3f31f5e709c924d99b8160f038828e14d009703f",
         "dweb:/ipfs/QmWSY6PtEa2ztgkgGRvRNDwsj3wisJnsL2CcnWZc9BHJk5"
       ]
     },
@@ -21480,7 +19820,6 @@
       "keccak256": "0xd5c3e1948aea24c219087de51051fc89c069fe91444bc62f7b03e0290362b180",
       "sha256": "0xdde21b910de55813d45257e1045848d6ccc3d2c9013386ee252713383b61bb3d",
       "urls": [
-        "bzzr://7495935ec06b94eefd48c44d340148532614bb62b5b8bf69aabe5ffba91c8f1a",
         "dweb:/ipfs/QmYrxXm52j9Q1qCaN8erAuxv2MFRAPPqQs7rXhkMWKfCqT"
       ]
     },
@@ -21493,7 +19832,6 @@
       "keccak256": "0x1f473e3bed886bc67f806dda01328ec1dea6e166a983e295e4499460e608d591",
       "sha256": "0x9cd57944343ba41121cb2cb62e261f76e70338f071088e7b4ef57fd57a2d06dd",
       "urls": [
-        "bzzr://eeffb0b2f1e7c270d6e88396eff1c71fcce82821f03998b1c455a097bbfaa14f",
         "dweb:/ipfs/QmRVJ7wPD3rUmCZdJF3itZjS3t7Z6HcDuhenrQeybzvXUb"
       ]
     },
@@ -21506,7 +19844,6 @@
       "keccak256": "0x1ae4825fb98a7ea44fe40660c8d5b5ef4a776a6223241d55d53dabbcb379e397",
       "sha256": "0xe902992367024fc1551b6f5fe06f0d8ce1b0f3afe6f9d61d0b8cb34b784bb2c9",
       "urls": [
-        "bzzr://4de0020d9a6e579fa18e52551841919c68423e950f99f3539f090ac81a401d87",
         "dweb:/ipfs/Qmb9thhWTp9LW5arwbAx1rYCDsorq2hCRLUZcH3ytnnjxt"
       ]
     },
@@ -21519,7 +19856,6 @@
       "keccak256": "0xbc8b190c774ed25436ba4f61a84bc6b092083d99c5f18419c9138441bbba6629",
       "sha256": "0xaf4645dbd08bf406dacb3a49c0029cfb87d178430bd0c62bc712752c87e1209b",
       "urls": [
-        "bzzr://440b7cbb6fc74820eeccc719f6e2222854edfaed68f6bcb91e632024aef9f068",
         "dweb:/ipfs/QmZeruMF3C17Dpfeb3edN22QfjKc8pAwBBJn3hTkg3FXoV"
       ]
     },
@@ -21532,7 +19868,6 @@
       "keccak256": "0x4fd1b630026b374d2a66e3b8c987cc6b45dafcfa7c2d08fda7ba5a1d25aad4b9",
       "sha256": "0xa1e9f1c731dbbb620a2f24262f07aabd5e04460dc716d2eecf839f59f740372d",
       "urls": [
-        "bzzr://32c83f38c0f643650ba1dd668571d80642ac004242bf2e716e9410869828ace1",
         "dweb:/ipfs/QmTaDpfEKzRDXDQrvG8pMPav7rxpMWXRhQGkKu77YTAvLq"
       ]
     },
@@ -21545,7 +19880,6 @@
       "keccak256": "0x705d8f7fd50bc6eabedc128d4090fa953d6734ef049f4bf602834bbe6a52b3d6",
       "sha256": "0x910f7906b039c06f3bf6192d1f8ff7f36760c785b146d63440b6168d70487fbc",
       "urls": [
-        "bzzr://40486a000a97a4f32553663fa89e0d374507828924fe80cf34cc191bc2639edc",
         "dweb:/ipfs/QmRfaJxGcMxYpXtYGy4CqhTAtQpeLVJWr7oBdP9hXumpSp"
       ]
     },
@@ -21558,7 +19892,6 @@
       "keccak256": "0xe17230232188ccd12b339949ad5433362e21111456147fc15fad587c95f43162",
       "sha256": "0x493f49f089e5d07184762a3796236064fcc3b42ab9e97141d2bcfd65680a6cf3",
       "urls": [
-        "bzzr://ffee706a51801b138791daf0c0d06ee5c301005e94e53fb7fa9c8672b7bdb658",
         "dweb:/ipfs/QmaSdjobpzXmAF3yCicY5pgnNzVnhYFwVnQX6LMEVfYshm"
       ]
     },
@@ -21571,7 +19904,6 @@
       "keccak256": "0x73f43e2c452fedf325e3659673c2d01cb418967a620b6c6264a423c008dba7f3",
       "sha256": "0xd86ca035fc99fc8aab67195bac9aeb523d98ee5ba0a6f9c7020f7a30b5ad0086",
       "urls": [
-        "bzzr://2a51d6a623c3f968ba7063a7383cf5368c73f7e5142aa0b9ad56c5f4cc497170",
         "dweb:/ipfs/Qmf9QinEkKU2oTYYWCnQCmMW2iskky5bT1arkbydtmWo1c"
       ]
     },
@@ -21584,7 +19916,6 @@
       "keccak256": "0x7cce665ceae12aeacd45cd96a13c9132e8177fc48a7b8e445d4a35f0c93e4fa8",
       "sha256": "0x914b2c9887e6b9098b25884a6046127500232636e65f3c8a8c7872ec0a1ab743",
       "urls": [
-        "bzzr://fc4c88cebefa8be420153dcb0ce5be3782605760085ddf958774dbbdbd8399bf",
         "dweb:/ipfs/QmWeEbiyxZGtAMaoRpmyTwDHimBGZUtNK5HrbtbnErsAWK"
       ]
     },
@@ -21597,7 +19928,6 @@
       "keccak256": "0x4e338d499a6211607905ba5c941124bab94931bb83a48d23928895585096850a",
       "sha256": "0x41b2c745903faf233eb7f1b1ba8ec49b76bdc8e3191db60fa1ed138bdab03b07",
       "urls": [
-        "bzzr://f13f2538c4559ad4f45099a58b6fca1033e0e9c9b292813b91df7ab72ef8a794",
         "dweb:/ipfs/QmeHRVPzjLYdyhKk491QeBBVwrbtcX3KAhnA26Jw5AK8vS"
       ]
     },
@@ -21610,7 +19940,6 @@
       "keccak256": "0xa727e0decc6c3e4dffb8605fe75f98f0667be745ef9a559555bab9ef62193c70",
       "sha256": "0x2db5803b208b97a8a6997b2e02272bcd975607a6b8c5ae97417e1038ce4fb7be",
       "urls": [
-        "bzzr://70f44a0e1c62763190fa506fb216eff3fe1694e37b33c14782200ed375b527f3",
         "dweb:/ipfs/QmYRMmA8BiTXsVfMGSDu9kMryxjGfT1ctQZjoU9PbkuQxS"
       ]
     },
@@ -21623,7 +19952,6 @@
       "keccak256": "0x5f1302c0f1c82fc484e14490060ee906b866cf92716c4503ae98797e8ca368b9",
       "sha256": "0x85ec94514b4699baa50a39c9856a59d455308a5a7ceff41b9bf5e7b15ee0c75e",
       "urls": [
-        "bzzr://996443f1ad6d14d8c990e65c0368e8b76e97e837cebb4e0e035a5ec067aa62bd",
         "dweb:/ipfs/QmVK9yuJXgNkRwm632dMxwuPotDvrBu6H18mRMMrQvDMKX"
       ]
     },
@@ -21636,7 +19964,6 @@
       "keccak256": "0x3eabf112f831269c0afd4045c03ffaa1d6c191c3a4a317b66af1a19e88957e48",
       "sha256": "0x56270483312d0f6d1036ac757fa7b5f0b813a5915ea1970b834ac1b401794b5f",
       "urls": [
-        "bzzr://ef3a75be8bd16b937efc30c3b5e434c3fc5ffc62f658e752ecd760586cd99df0",
         "dweb:/ipfs/QmaGmBZX9tfHTUWbh6LcBN1JrkKKdm59SigRTFHE3EAx6f"
       ]
     },
@@ -21649,7 +19976,6 @@
       "keccak256": "0xf3e09a3b245fd86c7f3b73a1e490f1202aad63c0dc3d0846cde698aedc904002",
       "sha256": "0x3eacc3f692f4845e5ddd52c384ceee865148806081449242d47d559ddefc10d9",
       "urls": [
-        "bzzr://2faafa3f1bc38ae20972bc468e639f53bebd4a48bbab6f71a4f05e28b42b7542",
         "dweb:/ipfs/QmZ7vqMfZ5QZ7DV4fEt6cYFsfgybBP6fha6Uos1aVA8Mey"
       ]
     },
@@ -21662,7 +19988,6 @@
       "keccak256": "0xdf9f4472467b340739f3e1a888e67b20483459b9948f88daaf7732f2545e42d2",
       "sha256": "0x539993fda45221f74be43f493b5b0fe18aefa70d17cf6dde75dcbb4d98e610e5",
       "urls": [
-        "bzzr://354c3073434c44c113c017d343f7832a65aa20c12507a2d3285e6cd022d31d3f",
         "dweb:/ipfs/QmdvXmCYsSVgKxwU7EwBZcjhoP5TWTmUTcq1V2a4V21kLi"
       ]
     },
@@ -21675,7 +20000,6 @@
       "keccak256": "0x9048ec0ff4579f0f756e81923a797083420e819a2ef4a419171d9e28c9ef180e",
       "sha256": "0xdf5fbb25453c3f4438b999333da363faaa38984f06c025e28ff28207290aca3e",
       "urls": [
-        "bzzr://e3fef09f50bcb58103534883f537ef7b57eb202dcc7010276118e669c1f0badc",
         "dweb:/ipfs/QmVGhPqHPCSsHYgPDs5CbJdFxDQVQFxNd5omMKqAuRbvqk"
       ]
     },
@@ -21688,7 +20012,6 @@
       "keccak256": "0x820f5e75c9d70e5a65cfe5ac33884f0698c2c183c7173b10b663eab0f621880f",
       "sha256": "0x77c3214bcf4dca7566725fe505c2fa1479f7a3001251b90588488c0837df045d",
       "urls": [
-        "bzzr://21d3e0d44a4669a52636090b4d30e6cb646ddd2f6f063b9320faa8546edc6478",
         "dweb:/ipfs/QmeEsBL3M2bywtdXrEneDiC8sktvt8UxdqKqFs433PhTkV"
       ]
     },
@@ -21701,7 +20024,6 @@
       "keccak256": "0x07950537d43dc739c9825a12089612717e4f130f03a56d3d14422fd434d876a1",
       "sha256": "0x434564a0382dae542e273bc901599f2e825a1bfbb6fbbb917cbd62d42acbb4d1",
       "urls": [
-        "bzzr://ba73949e44c1ea4d06d53cd70969beda52868ee419ef843ced14534106bd63b9",
         "dweb:/ipfs/QmW8gMrtnj2HTws1HdMUonYBtrJBikgL3fe2xdLUurJ7hb"
       ]
     },
@@ -21714,7 +20036,6 @@
       "keccak256": "0x1526ba9a63f3ea74534cdae956b5c14089d1a5d07650f67238415c8fb1576f73",
       "sha256": "0xdbb0838f5d4c96be011493ea9b5a5c4df79b86ef1093e14b6786361c17765630",
       "urls": [
-        "bzzr://ff10937122eadff2ee396a79e3de7d81e03a21e4b15ca4389d86faf6056b0835",
         "dweb:/ipfs/QmdeS7q2u2WUxJZBtFAxKRnjNcwXjNsv1P45rAmqC58aSh"
       ]
     },
@@ -21727,7 +20048,6 @@
       "keccak256": "0x04aa1dafaf4043889eb79206165edcba081b5a83fa73d64ade6f617756f25d7b",
       "sha256": "0x9bef0ef9bdf4f907147cda445808e4fae0b592e66fcb4766541047e0f29afd76",
       "urls": [
-        "bzzr://f96bd997ed7592cf2d3d5ab9226373448e729ed77586b488a75af7e03d9fc040",
         "dweb:/ipfs/QmeFhaEqJkUkRXvhxVBtYeWBeV3GxGBvFN6nUGk6VaAJFM"
       ]
     },
@@ -21739,7 +20059,6 @@
       "keccak256": "0x1b6ceeabad21bbb2011ba13373160f7c4d46c11371a354243ee1be07159345f3",
       "sha256": "0x11b054b55273ec55f6ab3f445eb0eb2c83a23fed43d10079d34ac3eabe6ed8b1",
       "urls": [
-        "bzzr://c604bdd6384bf73594cd0e5cfbe979048191549ebc88e70996346f3b744c0680",
         "dweb:/ipfs/QmW2SQbEhiz3n2qV5iL8WBgzapv6cXjkLStvTMpCZhvr2x"
       ]
     },
@@ -21752,7 +20071,6 @@
       "keccak256": "0xdb11be67a4626c58c1f1009ffa8a9cd7ee6da3875c9ee6449e344509cd2dc5d2",
       "sha256": "0x0c3fc3863dc13a5dca4a9f2819ce724840e05e0dd70f980f5af315d127868d5a",
       "urls": [
-        "bzzr://706e9ecf4361fd2e5583b164bfb48746f3fc104d000c4f4e3b6ee659892a7ac7",
         "dweb:/ipfs/Qmf983ziFiqUoVTfyvofGC1UfzoF31fcAj1M5CJAsH8XLP"
       ]
     },
@@ -21765,7 +20083,6 @@
       "keccak256": "0x274fdf67ed8274ffd0e666abae02aa9cc0dca488b7b4e738f1a63a6d5c536908",
       "sha256": "0xd2c12275f0b4a32bd84f13aae148640fe8944d50b55707e077855ab44d1c2ab3",
       "urls": [
-        "bzzr://7d7f7f21816fd9a8baaff4e32bf514ce75ad7f581ae31308d3cc7d6d80d9ed1d",
         "dweb:/ipfs/QmPRraNzNspCDbpaBz64iztT1foshEjRJNer1WkzTk3kgC"
       ]
     },
@@ -21777,7 +20094,6 @@
       "keccak256": "0x4639103a26b2f669bd3ecc22b1a1665819f2a2956f917ab91380bd9565dbcd01",
       "sha256": "0xf8c9554471ff2db3843167dffb7a503293b5dc728c8305b044ef9fd37d626ca7",
       "urls": [
-        "bzzr://d201e60bd46193b11382988a854132b9e7fb0e1574cc766cb7f9efe8e44a680c",
         "dweb:/ipfs/QmdduJxmPXungjJk2FBDw1bdDQ6ucHxYGLXRMBJqMFW7h9"
       ]
     },
@@ -21790,7 +20106,6 @@
       "keccak256": "0xe743aa061cc39fdc634a211f0a9dc9e1119c17529bbc727160880f4cf2566a58",
       "sha256": "0x391e10924b1747ea175f656ef7570439bf252c4ae720823c2fd2856c9662643a",
       "urls": [
-        "bzzr://bd68d4270770ac19a24a82c6e2fdf5d76ec035961fdd1148e5c85049239967e3",
         "dweb:/ipfs/QmT8ydNNBJcBu5woG1fZcwy2o58ccF6FUAuUqE9FydqfxH"
       ]
     },
@@ -21803,7 +20118,6 @@
       "keccak256": "0xcb3634767d0bd64f0be6024134b770cb7669f134c4c400c08fa26e14fc484a92",
       "sha256": "0x427de720c7a30b021ee5aa54e8811fefe59f455dc15987ab6cb8a9a72e6a8a1e",
       "urls": [
-        "bzzr://9c922d4cf3c014ef383eef9309f39591ec73caccae91fff6970182e89b6e8990",
         "dweb:/ipfs/QmZx5UVXmikddMVmLVKKtGpNPVp6c9QgytwGNj6oAL4v4E"
       ]
     },
@@ -21816,7 +20130,6 @@
       "keccak256": "0xe3d46f9b53de76e85a8132724ea835ff860894e0f31d34ccffe48c47a8b96f94",
       "sha256": "0x0a9f9ace5eac4a9fa17823c1675aa1f6cdd6ce2ad22f778c5f43b5ab85fd9c92",
       "urls": [
-        "bzzr://b1771e60dab71a0d74880e752c6ed5f5e6dbb95dd3fc64b7a0c6fc3885eac566",
         "dweb:/ipfs/QmNQyBLLw88CuebqSN6LDqLZJXqHckcdrJ3q8G9eSeCuLx"
       ]
     },
@@ -21829,7 +20142,6 @@
       "keccak256": "0x74d69c368861623296048a543df77b563501e51ec6f8a651aee203458bc2ddc9",
       "sha256": "0x727d69d2be142a8e426bdd16fb9c927e5172599c347718a1107533c928312df7",
       "urls": [
-        "bzzr://277e98a6f3042de4ef63cfea9f7278e33478486b7d304d5b938731fc58b1547c",
         "dweb:/ipfs/QmX2GmL1yj7pGDe5zcZQmgkh6UP3aVgPeXJXp7rbqqrbTN"
       ]
     },
@@ -21842,7 +20154,6 @@
       "keccak256": "0x5609087e374827a848e87472459d6a0df89cd12c2a4bcc5dcd741c1756f9899b",
       "sha256": "0x7bfc80d048aafaac491392b2c14556e0344f364993ff69b1fcbefae85dca2428",
       "urls": [
-        "bzzr://e883f3e2e0d303fe444a07131e9607209b79a2b8f613c6a34dfff6be11e8c31f",
         "dweb:/ipfs/QmXN7xgUroGL3AHrXWeVR87grNS9pdRoy5vKzPUP6H2sNN"
       ]
     },
@@ -21855,7 +20166,6 @@
       "keccak256": "0xaa2e92d06ef52b09f92af9d6f17d0b9ebad9fb8dd329b268c01b44b25bcc94d6",
       "sha256": "0xebe1c24d96a46d26ca84df7a118b628f52227f8f98b2b438354cdfe2f1956700",
       "urls": [
-        "bzzr://cafc67fe799a3cfbdf4eeeea7343ea5172dee7fda9aecd9ce5d789b6a7321a55",
         "dweb:/ipfs/Qmf6d9hboxKGfXo3kxvqsce9GRNjabH3UrpjS8ZxtqE8Qs"
       ]
     },
@@ -21868,7 +20178,6 @@
       "keccak256": "0xd3e0c934c9cb6c276c3bc57cc1446d1cfa89b046cbc15c86f702ed0a406ccd3a",
       "sha256": "0x7a8e1eeb253862c43812489fbb2881d7071854d46eefb73a9e7a3debc607b29c",
       "urls": [
-        "bzzr://e2162d6078f02276f41e428d5aa6c91ec967a546f71338efaec19d282d991bda",
         "dweb:/ipfs/QmP4ZNMebw9Ag7ZK216Rf1E8RNe1vD6RemfX4HPqnEtw6h"
       ]
     },
@@ -21881,7 +20190,6 @@
       "keccak256": "0xc13c247492c529f355d3cce4f76708c2bc8494ae8383cb3df285f7403da8df7d",
       "sha256": "0xc372c1aaf3aace12fe497987b070240dcde9b024cbb40429509469f6d9fca655",
       "urls": [
-        "bzzr://761349505ca2582269c85f6aad64cdbadde23d7639c48f6b790b5ecde4921dd0",
         "dweb:/ipfs/QmNXkHsWSisGKR1o2Ukub4mGLdXcePW72mhYWNscsJinD6"
       ]
     },
@@ -21894,7 +20202,6 @@
       "keccak256": "0xc302bb744be903a28b81453e2335c964e3312b158f0f242f7afae03160004f54",
       "sha256": "0xedf4be704e3f30c4b4e6d5fc31ffac4672e1892ee80cb781c2ce12f053fd8bc4",
       "urls": [
-        "bzzr://b67acc37f0cbca8e5b7f7b8cc8f8ecdfe48599a13633e2452c6df369634b5ff8",
         "dweb:/ipfs/QmQKqmZieFuJQWtBgjdHFR4yvLuyNpBHJGXKxPhuWnKL1j"
       ]
     },
@@ -21907,7 +20214,6 @@
       "keccak256": "0xc8afec313a203cc874fbc988ec76b339ae4e8c802518ef600e2ae14bd03d1874",
       "sha256": "0x19a63c3106f5effab4c7d12ebbb935b5ad81119047c4aa86e7829e1ddad4c74a",
       "urls": [
-        "bzzr://ab4d01787239af8956905d1ed64ae07d65f38ff422f11c073e003bf67bb10eb9",
         "dweb:/ipfs/QmTeXP9SMhWA4k4beNrbhYeVSEZVgdBvHpYvpgmcCwiw35"
       ]
     },
@@ -21920,7 +20226,6 @@
       "keccak256": "0x902a3de67721a2673c16f6ac8dde41ce5b1fb7ae28c565578109944023497c7e",
       "sha256": "0x8736315d5d5a010a14e91d89e43db08d679385a603d1c1d82b2c72287f0b8010",
       "urls": [
-        "bzzr://2acf6730e62d7c1c10e0d0c41421f345589a3b50f4451f53975e931a8a3969df",
         "dweb:/ipfs/QmQtVWrwNU8TqeDT5tGSKV41SCNrLecn7woqU2SjXqTHtg"
       ]
     },
@@ -21933,7 +20238,6 @@
       "keccak256": "0x365fa6a5b097a05f10a397eac1ba1d56926a15af6da64f56bdf0bd8195e6910a",
       "sha256": "0xbe178915e9a74840e191b99b33159a6b3c196daee58ad7ce2b883042925f047b",
       "urls": [
-        "bzzr://a0a373d2eaab8767524614958831fb54902dfa655bfc0d05208daf339c1cb732",
         "dweb:/ipfs/QmNqeAVUw3k7r4L3SGXBcLTttH6CuP9tZUN8q8DnCatW7q"
       ]
     },
@@ -21946,7 +20250,6 @@
       "keccak256": "0x6ea2230a9b09e4767dca31d1782b28509c3c5c4fe63b252b249b84c6c3717ebb",
       "sha256": "0x4f79851f5890ca73b713c1a7595c9bb93d35b400c1bfdfb176125bec7dc93e8a",
       "urls": [
-        "bzzr://1623cca65658d618f5358c9ad13826424e4f8ceb3090b6731a577f4d657b1198",
         "dweb:/ipfs/QmaKjUKDzdDZzTwYBf97RZ7nokAtzbPZDc2x7wuDUPszXK"
       ]
     },
@@ -21959,7 +20262,6 @@
       "keccak256": "0xf6e7e6edd0879f4c53e592b1a687c391d5c24dd068f7fa62d0a34fada6a8d34f",
       "sha256": "0x1fe0c7df82d54c272af555124a146f3d658dc0e87374ae49367d374d8aaee7d9",
       "urls": [
-        "bzzr://4c8a85e56b298470174cb77f440e7cfd9893e1cd739bc36d171ac465e343d43d",
         "dweb:/ipfs/QmW8ugByxLvnfDXfzcTTLzTGxbNPFAxH4zCytma7U5npUq"
       ]
     },
@@ -21972,7 +20274,6 @@
       "keccak256": "0xf089599de7598106cbe518a03cc532ceaec68e3bbf355ee20f8e0d9d8c3075b6",
       "sha256": "0x7dc0f7658274a51b002dfa4eea3a5551965e47d729c736dc89df33120e7bfead",
       "urls": [
-        "bzzr://9f1acc60a6ed1ba837c9f651ac9d17941c1906b46613cf55d3daf6c386ae1cf8",
         "dweb:/ipfs/QmXKuiM2oBoKY6m9UDHPNnxQMQdKBGyTCYSwKHdK3v2Fta"
       ]
     },
@@ -21985,7 +20286,6 @@
       "keccak256": "0x946d409ea437b9d076d88468315004b51f35be785d2922e4f99572de054cacc8",
       "sha256": "0x94b6e29acc94dc00b8adf156aec4f74341a191d976fffbf197deaed34dd21893",
       "urls": [
-        "bzzr://9077cebb5fbfdee89eca9c044178c13bc2cb152ffbfbe80ea3f21ceb51ea17ba",
         "dweb:/ipfs/QmXe65tJGMisyV7Ktf1TEEkiQ566EVLLdAEvucTAC5er1X"
       ]
     },
@@ -21998,7 +20298,6 @@
       "keccak256": "0x232db20d1e70203853fdeaa57dc1debc033e2822e8ecf05637a2d608c7280b4c",
       "sha256": "0xe344af94be7dceaa7a2c7f52fb7f21e21cac3e2f466951af410eae08ca3ab7f7",
       "urls": [
-        "bzzr://6559ab3e1168d17248a0c2de6362c70653098e9165c3a34d325140da73909aa7",
         "dweb:/ipfs/QmRqpYXEUCeLhxnqDqcdBf964Lx1HYgS6fw9EiDdsb2REx"
       ]
     },
@@ -22011,7 +20310,6 @@
       "keccak256": "0x895914843eaca0b3496e89dc5d6d381ab901d34dd7dc6caab9262f8b903179a7",
       "sha256": "0x7271a854883fc21fcc4bdb2dbf6e6bc51fe2b6dd6ddd0f07dd284445daa43041",
       "urls": [
-        "bzzr://f39b8fe241ddb46e6743ded0650432c20fc1590baf826f09183b11ab7673800d",
         "dweb:/ipfs/QmaXSHSwyob3pvatGAaETg9zLk2vomib6mN5cZf6uuvDau"
       ]
     },
@@ -22024,7 +20322,6 @@
       "keccak256": "0x556c1a5ac563c4757cde4ae78b640bb9cf9b63fcc84439d065475a6cbb00e879",
       "sha256": "0x8fe98a568e4e36b44266ded256a1429a0d33dbaf7401660becf54a7080958e2f",
       "urls": [
-        "bzzr://2f1a10fa3324b0b2b089b67e56f295d40404700307b4542d5381396b52864068",
         "dweb:/ipfs/QmZq2mfqrgcppmVWJyoVbDroU2CXaoS2aG9cyjhqE3jvcx"
       ]
     },
@@ -22037,7 +20334,6 @@
       "keccak256": "0x535e7b36f19719ecf8a12edc65ae9a786ea525a80992cbafa2e78f47c89bc685",
       "sha256": "0x8879439a52444e76a3e0514490df395b22fbfc7654add27ec16c4be14b3d4639",
       "urls": [
-        "bzzr://5d940d5e774559633f2b3f6ed82ac68b41799276c7038e56311f1922ec56a9dd",
         "dweb:/ipfs/QmYWiBsGi2jYKw3QktXbdpbYkZ9czPvtKm1uFtdHPTGy7b"
       ]
     },
@@ -22050,7 +20346,6 @@
       "keccak256": "0x1f1fa079d4552a2963283da0f722ab9e581a2ac7872dcfa8f1d4567535b0bce7",
       "sha256": "0xa26e0d3a78607234e447d83ee0ac7e7320fc60a57f5e561dd8e8afb2b10a2ef3",
       "urls": [
-        "bzzr://5b9b34d5ae46f6097c463211d139c629ca180fa8583fe7cb20dd41a6403e1c64",
         "dweb:/ipfs/QmfCD5hbmmxivSyjhymq1s4R54ZVc2CpHYxwXbXeSxecFC"
       ]
     },
@@ -22063,7 +20358,6 @@
       "keccak256": "0x9065354c2beffb1b133cfe3200433c417a920f903e562c5c3626a4ecb6a43c87",
       "sha256": "0x212785e0a6787ac71a4a51d713d976a42a5ac0cc2f87e2b888ea70e5acad6d0a",
       "urls": [
-        "bzzr://b2a997ead3de5c78e7c9e9445b7297f0d454421bd3020a3a0bf72b0417e167d8",
         "dweb:/ipfs/QmcmvHHQpMKNeE5QtgySv2FU8JpReaZNacdfWUJfbCcYhD"
       ]
     },
@@ -22076,7 +20370,6 @@
       "keccak256": "0xa4bf55453307ceef8bd9bddb2ae4522da69809b48866c4fdc1cbbb4ad6dfb6d3",
       "sha256": "0x3ec83a168a5ee165358814adf6db10a628885709493965cb9aeb7257b0dd96b0",
       "urls": [
-        "bzzr://d9803d551fb1363803286c9d6b4801aac24f2c1cc250c8bc4059b812c4da3af1",
         "dweb:/ipfs/QmYJ7w3Yh4H4FHSpKVY7C2BDcs24MfjXwb8e6YhEng335H"
       ]
     }

--- a/emscripten-asmjs/list.json
+++ b/emscripten-asmjs/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0xd8b8c64f4e9de41e6604e6ac30274eff5b80f831f8534f0ad85ec0aff466bb25",
       "sha256": "0xfc54135edfe07d835216f87fa6c3b9049e1415c2825027b926daad018e09269f",
       "urls": [
-        "bzzr://8f3c028825a1b72645f46920b67dca9432a87fc37a8940a2b2ce1dd6ddc2e29b",
         "dweb:/ipfs/QmPPGxsMtQSEUt9hn9VAtrtBTa1u9S5KF1myw78epNNFkx"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xa70b3d4acf77a303efa93c3ddcadd55b8762c7be109fd8f259ec7d6be654f03e",
       "sha256": "0x7ad9fa9de246a33c5e5472127b6e0b6e713f3900c7ea360c7c2824f6e9202a0f",
       "urls": [
-        "bzzr://e662d71e9b8e1b0311c129b962e678e5dd63487ad9b020ee539d7f74cd7392c9",
         "dweb:/ipfs/QmWRGd4p3EUkvPh7QfFVoF829SdFFF2mhtsEsK6exaqdB4"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0x39ac3bf19dd7749006b19243aab5bdfd1e92b93133a2fa236e9d61af957dd444",
       "sha256": "0x1a806813a02d4925b180737aff1d58d6ee9bee38a528fb49dbbfd3e676d00a1c",
       "urls": [
-        "bzzr://05a3b37b2d7823363272c5b5648e12f3737457430a1f4e4477f6c3467592f7df",
         "dweb:/ipfs/QmeAjv4azyWQy7nZnPRChtGx3Uys2MygDc4LgzSsWDnWig"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0xc6b0944a8b55b534eb4eec02d3be54d26791ff60c99288ed5b2dc9c78ced32fe",
       "sha256": "0x34a1e8b62b5eae88ee59e572c8f941a375d587a7f3c21b6d24f415452bdc7a15",
       "urls": [
-        "bzzr://4da68f33bd6bf02fff03670b9501121f5ce75cc4a2a7fea657c22d3f4a625d57",
         "dweb:/ipfs/QmXuvThTcmHUAH9uxTLzYqMN3ZSTGrPFQSmMgKfhwajVF3"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0x9639c043ae6df7267b0d904c334342e83c95bc3786dcb2b7d2a7c15c9f6ad916",
       "sha256": "0x6c9bc5397f56746f928ce1d4e2522d2865052348d506f521b4f731f98f99c6df",
       "urls": [
-        "bzzr://c6533d87a48abff42c084159156c7fea1fe4fc8c7ee5fa64edaaa944cfb55603",
         "dweb:/ipfs/QmYpMSkjoHMGihr7xrzSzDCMJyXxBoeB8QqCyM367x3Twm"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0x08610325fc49fb7dc244cf5adfd60a664c3cfb9d4845c90b30ef6f6abb748c60",
       "sha256": "0xb2fcb4f707ad6545c8a65b70164c59d4555cd607b97204844d51a803917a4549",
       "urls": [
-        "bzzr://e6eca935f031f31758db12507e10fe82d576a293b210caa3775c4246bb9679f2",
         "dweb:/ipfs/QmZQFLgDnwS3jpR4KBAnWC4ihTixXmmCUdoBKGooJQDHJ2"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0x90567736ca352a90da3bb8cec7e9f7c5793ec6a77686ed4a87f373b456781e09",
       "sha256": "0x41a0cbd38f6fb957ed3748688078f6e6186d9a2e8b6706de9a63dbf65c62ffd3",
       "urls": [
-        "bzzr://84c85953cb16cfb7da8f75b09853ced60ddc3b36de6b2570cd66032a6fe0e802",
         "dweb:/ipfs/QmQKXN99fA1rAi6B4wEt6vBDqEjXsZbepuTBxkUeLdc6Cf"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x7d8ea0312905d250ec7554bd84526c3d97d05f6d5748888e6ec00629bd3ea7a6",
       "sha256": "0x0fa8617f2180be99751704256f2a50f05321a99a5a1aa537543c4fa7516dedfb",
       "urls": [
-        "bzzr://0848ea1ded5b47cbae17d915810d1bf0857d9ea625cb332a0da68550cb27c699",
         "dweb:/ipfs/QmSBMT6wATobR4wsfGiAEZnmrWYbWT1od2DCufRe7nfR8E"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0x7067e5792a88111c06a7078a23358641a64d0fa273b5220bfa5212029352dbe9",
       "sha256": "0x1f954fc43414ac9012125c6080e007508bd8502bfa180d23c3033aa6943c4550",
       "urls": [
-        "bzzr://5b84475c0815ab9cd44ca5b4dcf4cd14d5f7db0bf3077fc825234b648305b277",
         "dweb:/ipfs/QmZhD1pVi51kF63twouEb4ZGGtPQt8f45fPcoVZHZxWuwq"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0xd7b4eac4e3bf9a128f4729fa44f2efbd865739d1fc513ad3a21129fea333502d",
       "sha256": "0x04f5e3c386833a5a0e15e204dec859a2499c8d7da69b89544e475c25004c4602",
       "urls": [
-        "bzzr://18452b4e52d051af96e6b1331a5d123bbe3bf6c52592b59b41325502b5eadd7c",
         "dweb:/ipfs/QmbKmiNg1L6SBeETW2CoszXW8XycbX8EcFbsUbToSy35Ec"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0x454d35224a9aa036650acc809cf01f1f161aac5387f57e597b6e543eaf03ffd8",
       "sha256": "0xd936d1b755582da12f0d11acd3bdb85050c40dfcb779d736d8929ca2e50de9d1",
       "urls": [
-        "bzzr://23b5bb211fecf22617061fdba5037f1b82ac1e53e7cd031684fff8d16722826c",
         "dweb:/ipfs/QmVGkLXrv2j8ps84tX7jQfBD5ESFYMGo9vhwEAbtsQsKHA"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x17b583f06e82c007ca0daf40344a12b5d93e85dd31969f076ecfe705db6d360c",
       "sha256": "0xaa7c0b18821a2f23c09da479d803f73976011445d2b512cf23e4a31d1a268bd5",
       "urls": [
-        "bzzr://2b86d6491012ec3289a22ee1c2fd6a093e68dd0d93675177f9a92c1f795b9415",
         "dweb:/ipfs/QmZiWoPyohpifswK4QAyBHubCAnqXHzXRxiv1Hq2bB3iyE"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0x44064048f215bd393fa394964d6c7e29d31c98053312b0536ce4ba3c5948c25b",
       "sha256": "0xa6dd551109f4f316d9b6a469fa5066f94653db9682d28058eeeec49ae0eadfc4",
       "urls": [
-        "bzzr://b14059a11e929ff53add0629e12162b3071135da21d86d1769f53a1cc224c6b5",
         "dweb:/ipfs/QmaUBG4aatMXVivmBzEjzqGtAQhD6zNFfmnaqU8fUxmBy1"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0xc7e1f69fc0fd67be01a07ac60fdd085425d0a93f04affe696e24d2f9145ee742",
       "sha256": "0x91a9569b69fc7f6676014bbd265d29efb09338b96d5880943bd6f1836e213b0c",
       "urls": [
-        "bzzr://046fe63be520a7cbfe99a031fe6c94bdfef8c1af66823d003c10cfaa6a645c23",
         "dweb:/ipfs/QmNhg5AjrnTzG7PZV5ASUWpm68ff8MUjB8JdsAuNHua4Zd"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x14496dd7e58f65f6d1a14efe54f0ecb45d4784d0f7e86f64b6ae09dff054bee6",
       "sha256": "0xc49cc2e003871c9255dfdf4afcd79b8d5b30a46236b71c7379ef442d12ad2fee",
       "urls": [
-        "bzzr://ea06d3e1b3607b098a9cfc0abfc1df872d2734a3671d6212dea100089cbb2216",
         "dweb:/ipfs/QmRUQpExWxf5R8FrUUCi11jguqhKNiTETKiXmK7CZ2tCtf"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x814bf4e5eacbb1849ea12377f5935b1fd846ff1af5ffa2afeef2619f94273994",
       "sha256": "0x3af892fabc38b975b96a242b13e0b6465d9c09f505ea11932c60b982c0d37705",
       "urls": [
-        "bzzr://18acaee3f543de385d445ad0e0f96b506a5a78ea36feb22e79b984f0ea9500de",
         "dweb:/ipfs/QmaHD5nZjQLVqVEdPyHJyaxEP46BAHSdYBXeeFtUb2bK82"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0xca308f787d878ece018898f1a731de2760c23d95dea77345263d28a286010e22",
       "sha256": "0xe6092a90398b8519fe2ad7c582074b806e365ebd55fc86d7d2d5c27513732373",
       "urls": [
-        "bzzr://980e9ced0a6e1c174fa9f2244536f1ef1017b1cb2758bfd5993c54bc6c0debe7",
         "dweb:/ipfs/QmXcSiETZMMhrxqN5BMNS7hCAkxJnPN2PAZEGnPgDKdAv6"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0xf39fe2338b22783588c6f69980ed87783808e3f853e976b46f4d2ad8570b5887",
       "sha256": "0xab1feba0069ac1adb8d09998871bce9af96fb88ee88d8e39235edc80a448afb7",
       "urls": [
-        "bzzr://1cb0fa22a5e12c6698b4dc03cd6e98bae2e3a3dd664c29b9108838d6a3d90d34",
         "dweb:/ipfs/QmYUYBQcRrWqGRgdwk9Wekriix2xEkZx9qzXAE6jg4FQpo"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0x415b193456056970a77c5ca6a7a611319ce197bdc845288a143fab1b56f032d0",
       "sha256": "0x4b50704e5b245c97da025c5adcd893a19c4e2dfd87aec064b7e45069b7b8333f",
       "urls": [
-        "bzzr://99bb321a5e5a90a7b192f409211960f8d971221fd0a0b2d4319133da36ef8882",
         "dweb:/ipfs/QmZ4ydjmqK7tYFWbLx3Ajk44K2scFnFaTS2oEGPNDrG6wf"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0x31c896ccaaca3c28b2f7a5d7af64a119449d64b7869df8279f6932b50b365493",
       "sha256": "0x61f379fe68599eab8fb6ee17f5b22656498ebff911e22a2112ad08454e8c3021",
       "urls": [
-        "bzzr://a5a3c021de2cb151dee1900070bad5df098f5c5c503088fd2f423b6391496bba",
         "dweb:/ipfs/QmabfhBtgysWFcjEAnQyaVVqJbLxjUjVLGvCQbKkmF5S2P"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0x5ed0545ab2103074ae6feb777ba73fec90516676acfb53d7669708a751016124",
       "sha256": "0x5b30f5eab232f6ee5e384048688bfd9dfe1d6dd6dcda137aff72bda3a84cf1d2",
       "urls": [
-        "bzzr://17e2104b517fca722b4a78190a777d7781e0fa5f1ceaaf034e4c8d62503ee54e",
         "dweb:/ipfs/QmSzBi29JryZmeGKEDqRkxMLknbcnGGGEDqwAggPN4xwky"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0x2de6e0cfb7526987aa4e5fd3504fc2e0ebe5e3630a3cdaaed5efd8b90aa58a3b",
       "sha256": "0x3ae6316fa03d576f4acd3c003b09d2e1b144c1f46d2c999add1047b8fa027c0f",
       "urls": [
-        "bzzr://573f6193469b559a4ad55e698473b8a296c70646f09472a78dbef05da6b7078d",
         "dweb:/ipfs/QmQSqen2kZKrPsgpMqv91pmbi5NycF3yq1h82F1T6W3E3o"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0x7b418a09602d0b4c5dcd23998d3843934f8fff43337a1f3bdf324fd402294aaa",
       "sha256": "0x1425a06e0195580f7a8a0db7015f8e8b4402decea45bfbb19d5841b24e7ebf0f",
       "urls": [
-        "bzzr://de94c41f727124a5b02bd1db087e6bcba19a682c5d89bf3cdaa650e9fdd08403",
         "dweb:/ipfs/QmeLWKuwusKjbTNChaV6EjEwkPgDwg9bT7WUdAEi7TEnSJ"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x25d22483d6a6ba6fd44e5537f796f8bf2964bed34a8dfbe24080fb3b901fc707",
       "sha256": "0xeef2854dffd1b108b68c3d6b3b9aeac642fa34ed6538401840f1b8c0a1fa4f6e",
       "urls": [
-        "bzzr://b873fa122233c91b1531527c390f6ca49df4d2a2c5f75706f4b612a0c813cb6a",
         "dweb:/ipfs/QmeMDLUZSeLwQQZ5JVMWenHWZSL6zdcXh9tdBspQp17pWb"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x30094baecaf6c36245ac8d56b2972915c1054827fe5b0dc6d1245e9d2e19e357",
       "sha256": "0x7272fe089382706a4c18addf63eb875bfb0767d9195d2538ac86b55f7b9a46aa",
       "urls": [
-        "bzzr://de00cf8d235867a00d831e0055b376420789977d276c02e6ff0d1d5b00f5d84d",
         "dweb:/ipfs/QmdmfBV5e4vcDZiAbpY8Mg5HQp6FVqt2szA2rqfa47EKf2"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0x61faf6e732d89464f022a3146a1939f204472c0a243e86b08173e1ec41cb4a7f",
       "sha256": "0x34f26cddd538c7d66fcc1ddbeb53a432731b06e493a9899b87291a8d111caf83",
       "urls": [
-        "bzzr://17c083e0ec2a29ec7a5c33cbd40a773dce5448891f2eb22a75898c9da8dd03da",
         "dweb:/ipfs/QmUtPpVGL3ophmbm9f3Qgy9UaxkgZ9LSppmhwH1uEDxu8Y"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x2b3e45f09075c576d599cadb2e749105b425bb2c8ab30b48170f0e23adcab1aa",
       "sha256": "0x7e93fcc7202d25ef37409541e799c5785efaafc1046cb2b4764e4a706d5dcbd7",
       "urls": [
-        "bzzr://677fdc9a1709aa44b50bcdfc9610f2694ac92e4822e659db458afc1e77eb533e",
         "dweb:/ipfs/QmTGhdXqkvHG9xFtnfkDS6MMdhWtoVmYPeB6U1o1vE9Ly7"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0x090c0843563e30fc7e0d6a66daa6ae0ff84dbd48e79a17d187905f25df73d1e0",
       "sha256": "0xf26d712a3a7d0ecd835eb077e23a3eae8d0b2054272baeb3eaa7feb64c69d1ea",
       "urls": [
-        "bzzr://a6bb732071169230d3c5cab20d5381d618bbce35a1a1413dc52940d03e2757bb",
         "dweb:/ipfs/QmcRwRvoCQNuAA7kp27diMtd1WFv93Kvm9Cy3Yf1r9SomF"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0xde17e284da94d3d600c1096f05d83af794eef746d2aba2e4e066e3d3efce7abf",
       "sha256": "0x6cc5b7c2c3c640daeadc8a41ab5cacc085b4fef667c2e119767529ff23075111",
       "urls": [
-        "bzzr://21a06f49cd51d05d4f40a0f2ade84309e5d411ccdcbaf8b93d14163e42716f7f",
         "dweb:/ipfs/QmWfzqxs26GMHLZiFiNxTJXtZSZZYoqMorJj9fwhKpaKJy"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x44dc961e7512f70b660555c7d900632c1863c1bf6234b0244a90645bdddaa53d",
       "sha256": "0x304f7b092e9493525867b49dd8a833bec53ca6ee5ccb408daca7e266e17a6cf7",
       "urls": [
-        "bzzr://021fcea53baf74dc83891d864b6d6a63a0d289dff9cd4542d901b9d62124764d",
         "dweb:/ipfs/QmaJpZwtLAzHjk2nZpXY9XNknFopYNZbMhiPHHTijSd4Yy"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0xbeaf9919ff94d1e339187d97290ed45bf4d6b87a8efc6e9435317f3be35b76de",
       "sha256": "0xf359e1a7d60cd6259caa91a641e29d99faf97a47d7e75318516196248fdbf862",
       "urls": [
-        "bzzr://c8bd3b51963b90d0c76daa19ef2f966a28b5bf3849cf26c4c3b2f5c48e9c5b52",
         "dweb:/ipfs/QmeVdLjq74LQT5Lw7yTBwar32bCj5ficAoEKTZVTw5PvVk"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0x3dc0900782c03e034959cf33b5c5784265ed6e9daaa101b653f2038c2b12ac4c",
       "sha256": "0x83cbe2d5eea94bb7c37ad2f4f9827a67c133852468f8d7c69ea72b9bde0d4b48",
       "urls": [
-        "bzzr://6b69ee5d38284e52a0cc5d8f14c30b4ecc234fba2d77a4124a1f80f3bc5ed8ae",
         "dweb:/ipfs/QmdLDrvouSEwCy4gtJ5rmCdjjzDAF7XKt3sCpXbg19oyd2"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x4e9f4990d124fa4194a7c06006185d262cd19c47aef9b8a153a688ece674f11b",
       "sha256": "0x6e81a09fdf1c630b51a3d7ede35a828f02be2e3ed53d97d361267bc915d774ff",
       "urls": [
-        "bzzr://fd5e4ed25921655527030d42c49ec1ff5e638ec1d151c81978f9291405920141",
         "dweb:/ipfs/QmPtex161AWSwStCw77rUkjcoCh9RZudG1rM65utzHjyai"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0xcf2f44568e9cbb0e2b9d2a23abc949bf9db5c6cf3e9d45408eb0fb0df28cf316",
       "sha256": "0xe654be6ccdfa6e4a80a25dd1183f9a6c1e8828089f400459117f38831fede0fc",
       "urls": [
-        "bzzr://9ef5e813839ffe0eda504e58a02476735b8467fde4e9768ecd87efe8ea84eb9c",
         "dweb:/ipfs/QmPV73GNxrjLQbhhK8mjW38BEn288WhLe3JyE9JEsYazkV"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0xffecfa33abaaa5c998672c7557947149b25b1e6d8c952fdc3f34fb50620ec100",
       "sha256": "0x6ebd370d42785bf3a3523b798d85b53711a0f7766c82a465420f67bf403bdd38",
       "urls": [
-        "bzzr://f42d52773526513cdbae2eab0a8c6ba2f87e3208c4950d7125b39dfbfa12c474",
         "dweb:/ipfs/QmaaMCL2gEYQTDiL5jkFT1iQNTgS6AUuL28JKmng2jscr5"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0x53d76fdde235668fe06b519bc6378aa6c8eea249fefb9bf84232801bb8c5dcdc",
       "sha256": "0xa52d6dddca6c3df5a6364cc11f93a6dd1c58e38e8c740f27e39f98e43cdaafce",
       "urls": [
-        "bzzr://8f0a94235a4a86bdf162270a3165570cba46e7d6646b84f6ed6bf857f9d1883c",
         "dweb:/ipfs/QmcuAtXyeJPJtmg4sxQgDw9BkMKFNK8YfRBFfHAX2ZrmX1"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0x0478b43de978b1af1d6d6d8c09e84cdb2cc8ed76218d38f17b841b6e539742f0",
       "sha256": "0x905e3d253406973f545666d79cd64c5c85985992f68fa35935f60249e311d74f",
       "urls": [
-        "bzzr://bacf94b83b539b0a704236daf9fd9083766905760e39d1372fdefad9a53ea26f",
         "dweb:/ipfs/QmbM3mus64QrXn7qdk7nyqedSwurLfKmS9L8a6rRop85NG"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x96b6118bea8d3d97739b621e6b0838e3dff6aa407d6a90fa65e06997414f61f0",
       "sha256": "0x61071ed96228ac7b88ccb9c6eeae9a152daf6c06f19bb15b45b7ed22226a27e8",
       "urls": [
-        "bzzr://5431154a2587e9fcb5922a2490d755e0efa650e9347d084b5107fd5891e2fd57",
         "dweb:/ipfs/Qmf9oR491y62mr1s1KX2T5gTMFVtQL1Kiroa8Aga29iQXc"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0xa4d676d718f45f3b81140bd4c3b2e8781b8fdd38203f61a344577ab95bcd89f6",
       "sha256": "0x2dbd26d82bae11c5469c5a4cc6c04d96e8fa0d6c3e1a98052133840794ed28f6",
       "urls": [
-        "bzzr://58b337aa6762473f084d0065040044a29f072e8d6ac47066cdeffc6d04d5473e",
         "dweb:/ipfs/QmTkdw7j3gsegBPSb2HeN5vykkHRwEQqSjQoAWyy3bR4bb"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x0d044f67281d5901da07f83548e017f9843870c7a75adc81b8c3b3204a34cd0c",
       "sha256": "0xc58b63408782a254767d1513bd20febfcda3e611a76932279d0ed507900cdc67",
       "urls": [
-        "bzzr://254e82a618047b9c6796caf7538907eb38dfcb8f1c43b0f6b219b9b4c87c8cec",
         "dweb:/ipfs/Qmb8HU6YHA26wxAWXSyMLFgDC5AZsNFpFrjphftsqGc9cb"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0x0a069b2d28a777626d192b69e0e9d3b4e571714783f6f5bf67990294b3c9ffda",
       "sha256": "0x770884d5d6ac8daf6a04585436d246fddc26be3e6914c30f6cacd8d7f93e376c",
       "urls": [
-        "bzzr://8ad92815a49691ee4befe959b45e5a9afdea64e7ffd930a12a1c08a7745eb074",
         "dweb:/ipfs/QmTVHMTsEtWUVZtC5LUrz86pcSuyaJnvndeef5PQeFM8VA"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0xf928dd3a232c2ea5f6e56b3292966c7c4dbeaa1f0e1f7ce1554bbdbf70d55993",
       "sha256": "0x7c7011c0fa6838cfe0368b30ed4a61d2b4f77f4ba9cdeff8e8f08c44286bd7dd",
       "urls": [
-        "bzzr://ea78db655cca333e39c0775a6b4c6042bac2aa8c7d4ec1ca8146165f2b38b408",
         "dweb:/ipfs/QmeRkE1X9oBVXuzScRd5PFemXZ32e16TPCbXiAkQhQ4e1c"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0xee322e8f3117fcd7c196e88407d938846c096a3c62a51debd8a646f3aa228fcb",
       "sha256": "0x9d9ec631865882a435fc577126fe068ccdf9c3962aa439acb2cdd0794907fccc",
       "urls": [
-        "bzzr://bbcf75b3549aaa4b68bdd805e5c5b8a0b0be6a964e068b7ef36c48431f44e8e1",
         "dweb:/ipfs/QmWyGqzpXbJjvMrqySeSMB3mzVP2gcz5FcXhpajvnbtYmn"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0x6bf3bf312e572e6c25c06412307b971af3f75730a63cfa9e3ea50bc96feef7f7",
       "sha256": "0x6d666d08307afe4a40aa57140794f835a338d2ac4436154ad1a0f043851ac2cd",
       "urls": [
-        "bzzr://71756135f36a4d7647c0c1449c7b483f006ee346f151205519058def72c4a916",
         "dweb:/ipfs/QmeLfwmfJD7rdSJZzCkLyrxx1Qnvtcp1wU8nPVphVwxe82"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0x4d774dfa046fca4d838357949a50e052278a90ad2f417f0c5debfe7498028752",
       "sha256": "0x357adb49bb74c9eabaa034db28f96b4105def2b052c7795db8e30ad9a34cc551",
       "urls": [
-        "bzzr://3a1c2595504f14bd0bb1a93b4bcec2d95560abd0d23b29c00739225ef8956d2a",
         "dweb:/ipfs/QmP4J71T2maAavhQazHQrhjoGHyWQH3YZQzZhEL19rcLLe"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x58f38d5282278f80ce27c57cf00d8e7521fd7061d5b164ee5119e88b906590dc",
       "sha256": "0x0a6b1175a618d0341da604a672f4735a96de862b4611b79fb02b6424336df3d9",
       "urls": [
-        "bzzr://38f84b39ff79bd9a11e4a541737dea28aec4dbe3e403186b79a69c5c4d5d4328",
         "dweb:/ipfs/Qmbxpo24W4pZzjWSBNsbW5HucPYb5eeprF5tvFe9brvyD6"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0xc90ad3242c8b9c0911c79e65d466b3ed3fadc74c142de2f40e7aa1ea7ef937a2",
       "sha256": "0xa9856e3ac7ae3c943f457054f95552a9cc128694e196e4774e183fd7fbd6f9ae",
       "urls": [
-        "bzzr://10e1cf972e0330409b59fc02157698209410534262ec5598db11480a42c6925c",
         "dweb:/ipfs/QmYwwdB1X6aivm8me71EwWXFZjGtjkAmUuT9qEDQBZmdSk"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0x6695104643815375924901787608f42c25607038d7c8834c849b19658ff68a03",
       "sha256": "0xf855a1e0816ac4426b8a9eebf37273b89acbb18b076a519935a05ca212c71f34",
       "urls": [
-        "bzzr://23950a583f2a109e175014e5400d104834adf8a1bfd822c97e83c82a3adaaf42",
         "dweb:/ipfs/QmYfvH1JSvt3uUiJdTCP7xAWF5zxUF2ESbgcTkaVDcGZa1"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0xd8d79f6a3c2bb4f74a26dad18b99b8368051574415758c872f41e2c8235c68a8",
       "sha256": "0x306e67055dab5a25572a322b6eee5c82018750f97ebd5700ee46913d06d0fc80",
       "urls": [
-        "bzzr://b703170cfd59ffa43d30147ab4727b3f8a193becf701b473d2b99d4f7eb667bc",
         "dweb:/ipfs/Qmei5XTKBwKJSctz3DjTJuUD3BMoAQBAn6Y26qgoFDvFgx"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0xfe04e7343a4daba43a2344ff196251f832a9dfdc2b54af84044aaa4b10363351",
       "sha256": "0xb0ed6d5b9ff105e8169887da4798a4a1421a7317b02f1cacd06bfe6f69e5d389",
       "urls": [
-        "bzzr://f83c27f2d98d0f33056e999594ac32c962c8be737f0762ccf2bce4fd52eb8cf8",
         "dweb:/ipfs/QmNd62qF3urZxCcj7hSdJZkua5gw9LTR1WC6FsSVUGzvXL"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0x7dab358bfe745766bf640e78799beb84646a856717b773eb36c08d274f24fd21",
       "sha256": "0x4b78ddd0da9d01983e9893dbe6d66152f4049dca09ca97cf26a6b8939bc793e3",
       "urls": [
-        "bzzr://b1d6cee21ac31939a391b84c465160725699c5baf3b7ab74f27f45ecc91387ad",
         "dweb:/ipfs/QmPULESv1DkHo9nimf7CRcfrPVKZSUppJBcvehgGorER5f"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0x79b5637e6ed22dc77ba31b231b0cb53cd52f578c83a666a43e3e2b966d6798ab",
       "sha256": "0xef3429cc24ff6d6e89484210d72bbc43ba2541b9d2f00f797b6575270ece69d4",
       "urls": [
-        "bzzr://5c74dd1e1563fa833a35f2a1a9732aec28cbeeb5e8b0afe7a74133c863a370bd",
         "dweb:/ipfs/Qmf7qLYQVZsEfhwWCyWefVibZMZ4jp6ZqYnVsVzeA5wpMR"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0x20fdb5337e832c6d0fa736d8506241e5a6cf0ccd3d6611069d920cff5a9bc2c4",
       "sha256": "0x704e67e356ad4df45425c03f8852b4ce67152121abe41486a90afe9d65b1c72b",
       "urls": [
-        "bzzr://b1a85faf1d9909bb38d44b2d34d0c9aac0a0d4cbbee45ad063c75221e4ee68b6",
         "dweb:/ipfs/QmSxMWTNYSeT1s9ydzWLbBW3x2CopkVnaxWY1PfWg5ytJL"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0x7bdfc3e09790d5b1f488b10a8c0da4f85a8a64482c2be5566969feafdd7deb9d",
       "sha256": "0xdda3f35c4bd4380ae66a3268df92c260d707cea256dfcafa265637b6d8bd63f5",
       "urls": [
-        "bzzr://8923240b6d3f6e2f38ced6d5f8bfeb1b8a64ee49cdd358ea5c582dde194a699a",
         "dweb:/ipfs/QmdLsm73rn9KSHukKrZPbuzWGUmrwKugdpDExKSqowvHgz"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0xdb31c4cd1a6445eb7b469b8ba49f8dfd79fc86b4f5aa55fc601947c868f1edb0",
       "sha256": "0x9c6970aeed958d8d169857f728cbeb36aaff77bf7b56d1a8b219de4b983f765b",
       "urls": [
-        "bzzr://fdb7f85ba080a97770830c9188529fb5ef387b54759d8a865b116aa39706e759",
         "dweb:/ipfs/QmTL3fJQw9tDsYM6UcRJknZiyGuAQyJ3ypQV9yo9pPGpRm"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0x435c60eb61083f14782d1cc071f9c745b8761413ff00fce2678772690d418fb4",
       "sha256": "0x83e62e6e63fc85c856a0f8eca2a613927f6e749b27f19b7f85aafc762e783034",
       "urls": [
-        "bzzr://7f8f74b93df99ba6bb527c5597614075838eeb84ef84c90d9a5a81ec2c60cb12",
         "dweb:/ipfs/QmcyGFNgw86sMFNfjdYeXtQADFMUc55JPMrJStnFPLoH8n"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0xfe117d69aa8d50aab3ffc2d88352e3c2e624e6de58430af60cf7e09c705fc212",
       "sha256": "0x025e26a7c16f1ad2c2afd43b82bcc0ab90e56149c153524a4e7e72365c16c31f",
       "urls": [
-        "bzzr://d0f225f299a766aab366c9087c740fb7c5c6122262674576a98fd1fe6a7ed198",
         "dweb:/ipfs/QmcSnmitYaHxgWdqstA68iU2P8rPR6a5dcQ7qxsVs5suX3"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0xc17ac23500f490e479bd4f82f7ac93111cb950af5b388d1002972d42613feda2",
       "sha256": "0xb6012fb777a7f842a6e7efe8c50cb2eba3b3997c72b761810823e796d4390d44",
       "urls": [
-        "bzzr://f7136a4e9d4771a12407ff4dd8a5932840a79d77cafed760caacaa63d7a60d81",
         "dweb:/ipfs/QmNr26EpsCrNuPHBHbZvDAV4PFDG1XWShpmxZhtr4QsUcN"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0x1e158d4219caaefca3e9d0fa5cebb19cee56b1452a99d50a72f8795f62dce536",
       "sha256": "0x31dce3fd8f587dec8d7b0bcb0d99ad2f62160fe071d0f64deb5b549fb924c244",
       "urls": [
-        "bzzr://584397ffedeece5b3766443eba34de03f38a5589176aacffe568e079b8de94c3",
         "dweb:/ipfs/QmVUDz1LMQSfknu7ZXC3YNZrNkbP81gKezfeXeqELvz4LU"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0xd9a08eaf125656f3f54112be048895aaf9816181cce6851217188674b87c19d7",
       "sha256": "0x6fac4f65543e0796886a7e9b01869a2b53e2dcbe898f818220d0bae64e98cd13",
       "urls": [
-        "bzzr://d068ce879ce77252522aba3999bf80baffb5af3bfdbe2fcd5507f4510a04df84",
         "dweb:/ipfs/QmRsfQvuNyweNzvu1mvABxxVvni1EEYmqdmYrKVLKWqQft"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x2c7b2b4bfe208f30f731a296d4ef30d0b1fbd477d7d2be0bacbcca2523d43417",
       "sha256": "0x89b634fb1c6010ea3c45fe9fc2365601c3d38289ecc7ae02807a0433bc198ba1",
       "urls": [
-        "bzzr://86a0346de1e5e1d66086507da482ccfbe9bed8ea3daab249851324c64cdb7f4e",
         "dweb:/ipfs/QmVKpiJJsjwfiD1Zjxc3LupgJ9fYSLNdvRfWVwnv787xdx"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0x809ba589a8cd03938036739fec44e8f539471fa58af0cb0a7c0917fd65c7ac84",
       "sha256": "0xde67a88e4c35bd5da5dc7a8f538ae3116e97bec0df8af6edd26bbe843d41082e",
       "urls": [
-        "bzzr://1178e539b10083b2a417e39f128a38a76d6f92a6f0c36dea430f433bb73548a6",
         "dweb:/ipfs/QmRge6ua71ZBeiLzEJR1jAty1gDD1PqTnaqxw84VQ8E8ok"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0x09bad5cab9326f921c8f6a4d57fde317fb0cf5a66568defc48aeb682d37b0e68",
       "sha256": "0x5ec673e7ed29b0b23900d95ec926b3c32190831213f0d0b043e9112ef07534cf",
       "urls": [
-        "bzzr://668f46bbfabb58cabac9bce5c5b9003206222130b1783d602ea8709581ddda87",
         "dweb:/ipfs/QmU2HA9E95zcvAcQU1DnJrC7F4NQ2SQ3w5sW4koFxDBLRt"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0x4600bf758fe009e1f50bd11f8bf0be96bd356b0f37be3ee31b55d80a5063b6a9",
       "sha256": "0x52ad76de0634e875ac3d50e09a0057532ff53c6d851ef61204af1b0d620797b6",
       "urls": [
-        "bzzr://490c3c517413fde92c954ac36932eedd3bf6f62f0fdf9400eea0a21632074cbe",
         "dweb:/ipfs/QmazV6RyW7mipfnmvSrtbpMQWYXnyLr6NpyiVQq3DRmKyP"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0x49f812573d20aa8df2ff53cd9ad8398e66d63c088c1ca4f6fe33332c8a057054",
       "sha256": "0xdac1bc7560247d3e69bce9891f7eb2218a6a8d0106d9cdb4de8e03ede4546153",
       "urls": [
-        "bzzr://b9ce3b908fb7800cbe31559d7126a8d08f3b6f18f9568e905023caf3f852da47",
         "dweb:/ipfs/QmQcBV8t6Bpj8BPetd8SNWKZjcdocgWTCebxpSUk5yYXvk"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0x7ec496e409af23346e2edfada124fa19fd4e16cf70789f401f1d81af39f9ccec",
       "sha256": "0x4a9223dc645e2600d5e250420ed50f77b6f5180b1519711195b9d5bae8e643de",
       "urls": [
-        "bzzr://24c043e403b02279c04ecf1237bf30de16d2893fe90982e2a4686b9d2956b5f5",
         "dweb:/ipfs/QmV6Uqh6bUCBhaGDK1VafDvwGXh7bcE6P9Vs1SN1PmZeXk"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x587599c37a414855dfb389a774a3eb80e252e3b90ee8b84852ea100fb3662787",
       "sha256": "0x599cfe3faf33c09e3792b245d1e5d5c5eba07acc452f29c98e461d3bf060fda9",
       "urls": [
-        "bzzr://9a4a2e4c3afbb116036d2955b11d9cf28968d085796badb8d309ae64075cfe5c",
         "dweb:/ipfs/QmdJ5D8cf2EuBU2sRYvkFnKmJ6HA7ELRL9u9TG2RRU3Q69"
       ]
     }

--- a/emscripten-wasm32/list.json
+++ b/emscripten-wasm32/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0x4a1c2a6a4896edefd3a4178a6c3ed8f1de625bd7c00dd7cc5781a9f36236e7db",
       "sha256": "0xee7ba01680ed3a1c1cda236189a51c1e6ff99f6dca602a580e5b16441772b50b",
       "urls": [
-        "bzzr://83e99aa35ae67e71bf77040e5b4686aeb3558919f172b6c28213a4dcd8d79e91",
         "dweb:/ipfs/Qme9brfZS3XhbiRbbNDKhBpgFknyD92omMmYa7XSf56bJP"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0x07994ad8c59c498bf44ca8e84914e27b79be964d98a9556226db377819d67387",
       "sha256": "0xb83d2025e0bbc7f7f0dc9e47f5aa22eacb548b42c55add8f5f6822c105163500",
       "urls": [
-        "bzzr://414fc715062f91971c8e0d9fbdf470dd24a8a35f4f96df0ba79980cdb0ae7eaa",
         "dweb:/ipfs/QmcBZ6Q2iHmrf9omvD7Jyy8kgrqyPmZFwvKWqvVDaxo1Ta"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0x4c358c2e90447ad9e7c1816b5be8edde1172f67dedf16755a6c7373ede46b245",
       "sha256": "0x9825565e1f199dbed6de01d27e10f83a9180300acab80f8469bf427e3cf92e96",
       "urls": [
-        "bzzr://6ecbe30c4c8530b82d55ed6bec12e63efbab1cb16868b020d65399a8793599a6",
         "dweb:/ipfs/QmcEK5gvWNeHUtjsF3B6j5AXb9uNoG3aHbPrCMJDx7C8TM"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0xb67df5c37e8255e0de7918b6d3261f0f29e277d121bf5f414b66157a5b1070cd",
       "sha256": "0x67f8a94b60278cfb80d505c47a1a5e67ec2caf20167ef85f2bdf2a80a692bd1b",
       "urls": [
-        "bzzr://7ba69a10a4585d0a36e5843603476061e8b02878331fa580d5c2509ef01ddaa6",
         "dweb:/ipfs/QmVumPvgQVFLZvDvQddcDGcdxjbVWTTzxoQvJAECBBZ6Ju"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0x62a65d0a951617f022524fc844ca11d90266f64e693343a2f41107183bf364c1",
       "sha256": "0x66da311056ec26c9c3fb501350ee22187c30e79c41bf2713eeff7d84479948c5",
       "urls": [
-        "bzzr://ccf4f1e05d942946bcca929e9263c541b2749bf1faf6dc6c211b4bf700344d71",
         "dweb:/ipfs/QmXf2cKYJ26tXAU6A6tmUk2dn4tuX3CWNaXJVnGLuoe15y"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0x06afcb6dc23efb1482545b63c5e3983dded0c383ecc46c3ae319f7b868201e47",
       "sha256": "0x9e386edb2ee759ad65792f7d62c10ae7edf65c5b874a5451f1e695e586b69eea",
       "urls": [
-        "bzzr://e93e97b9989cd59673bb1fd64a0f940e8729c3c40b819593b8590480cba24bea",
         "dweb:/ipfs/QmSJFaZhpXQ2EPF2koyiTNAiiuJRykv1Q8yubhkmBhvYyu"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0xcdf7c4d4c6b9331b755170fa927692019c94088f87f100d2c3c920bcc3740d0b",
       "sha256": "0x7184dae0b761485a5dce66b50075e17857c5b55fe3fa71fe22d4d5acc0839741",
       "urls": [
-        "bzzr://e21d2bd58112fb165fa2c253504bf49ceca661ac1009d270a31cb996560cfa34",
         "dweb:/ipfs/QmYJuZgMbeMiotHAFNWEXdxjTa5yi7GaV4UkgBYABomFpj"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x52ca702b8ed4b1e6d43d8a006b3d27f6dba611bac118c523711bfd209fb1cc9d",
       "sha256": "0x8db9466df3b91c52e3412cebd13176ea9fe16d3239d000828a081c34ce899337",
       "urls": [
-        "bzzr://24dc5536a4771b2336fa304f3cd38d5203b6ab49c78a3057ec578991f3fcf265",
         "dweb:/ipfs/QmZZ9hNntBxJw3G7LGW3e8nXtnGxLnaSMM44K4BbLrkELs"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0xcd8a6a8b2626de75ef6ff73fb724f3ad5693a8902f86e88290f048b56182e7cc",
       "sha256": "0xd28a58fbc3ce56ff650d4daf3a1d8092e25cadf2a5b2769fd333b321dfc6a22d",
       "urls": [
-        "bzzr://6a5d22e366c35f184d5203f3e062131018d8a4d09cf770a0720cfaf4d7b49705",
         "dweb:/ipfs/QmfHjv4nYKuv3yFpWZqBYyiYEYmkQGydQmFT5b6mJkFpWp"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0x43c96fc79cf288cecda12b23a17f30b1cf0427a19dc7c1c094bb461eabefe0df",
       "sha256": "0x9af176f42b63eaec838999a07e80484f92f41a0fc497adefa65baf88d8fbecaf",
       "urls": [
-        "bzzr://fc0e644a61e43592754b66f8d911c91312538debb89da29ffda3d3fd81ff70d9",
         "dweb:/ipfs/Qmf7WYJJ8y6oHr4RQ7HC4tXgFPGvsnp3Qf6TrMBdK52Y5Z"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0xbe94ff397be2a951cbeb6c9c1a60ddf531d0ce76f45d51755386b6fa42cc2e2c",
       "sha256": "0x6ff1683eb76dc58c31043fea474be6da8535ec625d1cd8331a3daead84fd5564",
       "urls": [
-        "bzzr://6e134aa89a00a18d930924fc2fad2aa434f80b6a71085ff2ab379e3672c812e7",
         "dweb:/ipfs/QmeBWFbK1aAxnB6muXWStZJWndrFvMJt4xfAzEJD7AqaY3"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x178e51ad0c6a350ec4ed6fd07675dfd4d2581ee07b14b4954dd0b0f6d8633ca5",
       "sha256": "0xd70ca2f656a88a9be7a3f7d602f03b30149b3bda0d1057cfa3a3c5e3d6e07453",
       "urls": [
-        "bzzr://6e43013ff973198d7fcc4a43910041f2f07d0099f4252737a2a2545443b11105",
         "dweb:/ipfs/QmarthW41sfbrdkMmCK6jicXFZDGgvALzdgzygtUqEauae"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0xb8c3f5654b323cea016c0cc1a4584069714cdf796489efe2496a13f8f83a0e63",
       "sha256": "0xdeb3c274f8b840d657e2f9b1dba602e89f58b1bf3fd7178c48c9033310a1f006",
       "urls": [
-        "bzzr://084452a20ae520bba965ba0b863f3d6de0516d1f92ddb512a138fb787d841c55",
         "dweb:/ipfs/QmNUf8dTW9xANAvJmV1ho279AyWSCCvDp6bXet1QTcS2z5"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0x598af6fec02a6783d6a438a6bb0f7d3012716d003f7bf6c9ac5a4d2bc911941b",
       "sha256": "0xd522b307a014a32ed5815b05045c4396abc047e70c8a53c1e3ef92e14daa61c6",
       "urls": [
-        "bzzr://cef259b97217a7526819155f6dd513768be5f8718324ec3a63c315071e2f7c70",
         "dweb:/ipfs/QmWGK9FbQiNWNeqysvCNCBw3q7cR1dzpnD1EKtNija2zyK"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x93f7046d6e0ea2492ec5229936821b3b020dbe9eb2e1193953389293d64a190b",
       "sha256": "0x68ace74ca809ff47b09449d4054c77907d9412f14f6003d5475b60f4fec13709",
       "urls": [
-        "bzzr://8943b9e6d4ec52bda1b8fbd65509168ba3388651a30cb495d5280cfbf35614d7",
         "dweb:/ipfs/Qmco9fGHM6mdaPVYqeDQ11GB3BrCbwRcEzM5XzHpAdAVWc"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x7def3c264883cbe6ffbfc54894e48f9a0d2984ddbd1145eb898758d2a41d1559",
       "sha256": "0x54f3dc64f2ff5a5350410f6157a537d96fb4aeec90476e90a951ddfbd1fe4bca",
       "urls": [
-        "bzzr://3428015c422bb223c3fe8c3a85615081981c47ead375564c16701b261948f0f1",
         "dweb:/ipfs/QmXyyuEWhexuez2rzAeFjunpiAhncD1AfcXitGNHxpRWha"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0x9ffa9ee890ec483580c0b4ed72270b16e92eb0b7a8a97fb00c257f8809aa4023",
       "sha256": "0x3e64525797e0b2d9abaeb022688cc02d63fc5820327e382fc6574a7de650dc97",
       "urls": [
-        "bzzr://395f2d903c162ddc9b6ebd76db450ca6cb9cf8bb276c3d705aa462ae560d23ab",
         "dweb:/ipfs/QmW2rPbEtiVAbWJxtizzDqTjwpRpXCxkpSR696g9GxAYKT"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0xf0a6c32af3eaa2f8c6d9e6c8b90f3bac5e775c7f1c90a61c1e72b593fbb1528d",
       "sha256": "0x0e6d842e941cd8b76280c59f28f6d020af1afdea8e4be9d9da677ac5dbe860c6",
       "urls": [
-        "bzzr://f44b067fda20d169321fd3616f68633fd7a4277b6340f42f74203f33dad4a472",
         "dweb:/ipfs/QmSwumWbYwYe4xLcqpi38VNtw7xCgbNaUkRhiZro9EnqLt"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0xeb8c3c474b5fa792f9b1b2ac6be945c32f835ccdc059deb562da4e99a031eab9",
       "sha256": "0x7fe677e8214d0486fa7164f797862fae0a0fefb7b72cf6ad8e728faa54f12b60",
       "urls": [
-        "bzzr://37026d0ee2865c52fff8f6311b67b94f96dbb52ce8af3f84c3a9aeb47b12bf47",
         "dweb:/ipfs/QmbgEAtdmSoxH4cfRJXj7mVpKv9rT5Cq2YmXmAnjgsyqBC"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0xf824e695e8e66079b4b6063622c7dd80ed056d29969c8c3babac4fb572f3dfec",
       "sha256": "0x5bb50839ba5116bf31669f3de8dad72eaec298ba32a643be7d0dc2d1392c54d6",
       "urls": [
-        "bzzr://d847bc8f5d43cd348346c5bb253269de36f00810c2e189ca64a4becdb9e9312f",
         "dweb:/ipfs/Qmf5RrLbWeMykvWJbCyyThCLQ9YVmU8uWagMdSp9nNzZMc"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0xa60eadfddbfda0daebb8a1b883b89d33b800cff7ce7e12458170ea17cd5ede58",
       "sha256": "0x8c2a69fbab9bdf503538028c697e09e51a7e699323ae7100c375cb35c415a819",
       "urls": [
-        "bzzr://87e29a7298d49b8b52ed01d6146b05aa41c11a85d1b805dd48181ac2ed5e9b22",
         "dweb:/ipfs/QmSZEQEGuVJ7hudg8FzfDMXKVtn5AVGKaxbhSSDXwpX73K"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0x6c6dfa967526b7060634474ef730761711e5be662abf5ee02dc05985abfadec9",
       "sha256": "0x9852ad94048600cc5a1458b4a7ab625996844c809b314422693bdc81d953fcc0",
       "urls": [
-        "bzzr://3edc1542fb719d3e08138b492a5db06333fb36055a434c3b071b2dcb69e54fbc",
         "dweb:/ipfs/QmcsCpg6kfp7Vea4y9qPtfDXcaQJbDidb65n3t9f2MFDpR"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0xd0f9a689670184ad874ca6a2cb40dfe57e9cf539d9330ca3f2501951478eace8",
       "sha256": "0x4197bb1cb0ea7e637ed8a0e7810f1bfe32c90d0151d6f423bb3dfeef9f6777c4",
       "urls": [
-        "bzzr://1abbc4967f3c6c5124f8876abe521d508c71b0d0d64dc066c1e7a1bfe6ba596d",
         "dweb:/ipfs/QmY7UN95hdfFSD1jwFANegze5eLX8PgP5BfWFH1usTB8Sw"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x50972c5b966188341d133aa58fbf895c54655d7bd733fb5ad58852e85f9f9444",
       "sha256": "0x73458d16a3e34fc7b489d2399b3680cccfc968d01abc9f1b61e438b6fb0c24a1",
       "urls": [
-        "bzzr://9eab5a9c94bde3d90eb76a1189febd5ae4d6c7bbc63cc1d76e8871e14e6e9b89",
         "dweb:/ipfs/QmPUJNa1LYaThwLQsw6fF5DMYyDfEg57gmD5wCsazkLS8c"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x74f927b4f520d8d31863996a100ebc7827f919c77f777f6d4d416c6e613a03c7",
       "sha256": "0x98c350cc41f873af84a78d1e24cbc8449045ee54923af0a39440e4d84600dc50",
       "urls": [
-        "bzzr://a052dbfe589a766af66d85d4d797829241e867e0ead93fbf3d5e492c71b6434f",
         "dweb:/ipfs/QmZbo5YkSbcenWrUDjiCvUZdQe4UrNBw9vtx9nbgcMdRAs"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0x4cc2bb4c8894ad4349a88f330ba74d7ea643030d3f68037d1c94c370b6a25dd7",
       "sha256": "0xf83e8f7014ad6b8bc801dc3684c644e372673ed678425c35aea5d4b4fe37e922",
       "urls": [
-        "bzzr://2aae73578e361285488b6319e8e7b27e23b2736eeee3953cd65f1207cd849395",
         "dweb:/ipfs/QmauztXLDUdwJitA4Uc9MQYCTttUcivR5foTZYgwt4aAeC"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x92b9c5de10bd908527e9cfba3f04bbe637163b4a5313c5a69179ccddd5fa6685",
       "sha256": "0x782a999d3e1227c86854e7e29954ee856c6ae684124b9facf09f4f1724dc4e85",
       "urls": [
-        "bzzr://fb1e9b951ce8abe575f8514bff6baa01417a988a399fab1dd27a252e7812d1bc",
         "dweb:/ipfs/QmUtwmzqqCftcubfyGwAefLBQ8ffp8EFhW7HCEQfhaviFs"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0xc9c60203789ef778b9104ae7a39e9090b3d1256b24983d49e40e7d1e3c3ed65d",
       "sha256": "0x264d0d25e31cb32f4369f82ba3ad0b6a84a8a1975b10bd738123ddf947618840",
       "urls": [
-        "bzzr://335a6b94d26623dcaa4590ccd6d7529db1e153b65af3bf7def45fffaf9ee256a",
         "dweb:/ipfs/QmRd1uRbHRvpybQk5TQ11zyqmG4wQqHnefgvYdJ14V5D8x"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0x2921f518cf5a0627d96e07e8c3d2b5482dbbf14d7dc6bbb055481c46d98903f3",
       "sha256": "0xaf811843add541705ff65f0c20fd864bd0387116544524fa1830cf67a14af6c4",
       "urls": [
-        "bzzr://31231abb33dc43d0478f03a4c8b15b161b172097c884307cf6cf64aeb83a6dc9",
         "dweb:/ipfs/QmYLhaeGbq3tFdCUC2pvtA8QdGnCbA8kn24z3C741k5TUE"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x1980cf8a81c6bd2b371bf7d9145c819a7fb2d72e9aa462aaff0c10b4eccd595c",
       "sha256": "0x69cb1300b5f72eb128604507991d9ada97180d31afde7c59aa3fa3ae9ad5200d",
       "urls": [
-        "bzzr://7f35988e2c32ed2f3f1885fb81ace357b1555964d23085940980cacd29023da6",
         "dweb:/ipfs/QmPfxPYsYysRR8HFkWr47FMQ8ardmfmtrmdYc2ogT9Gfp9"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x3efd0585a3c00a1a2c62e590e22a69aa981d1b5148af2ebdbe1610dff93cea78",
       "sha256": "0xaff4ca62ac0b03cb4b9c50f8250e2e7307b5c75fefc9847f269bd05c20367148",
       "urls": [
-        "bzzr://e30e085b875fc291e5ee46ed7c88c28ec8e8c540ad8c799b106c365a52df9e97",
         "dweb:/ipfs/QmaZrQSg8njYzFXH2PzwxHDLKxkBhKmYmLm43DJWnurPeJ"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0x9b7a39606c3c27a8619b3eb493efca512cbd26c5ab7fc95489564239aab32a50",
       "sha256": "0x24b4cbc28d68bde8455c14a46b55e4f292c3c295271e09991b2176a487cb4487",
       "urls": [
-        "bzzr://3bccb9b8cee48b99b39f2f1296f7353bcd39c1ae61b1e19e5add7cedd0256cb2",
         "dweb:/ipfs/QmQmkd5FGiKKg8eRmo3L7Cn62nuV1M6GRDUGiq5bAx4AWx"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x4a6244b03de1968f0a48800e75640921d62b7602d0301093e1c5c318d1effb36",
       "sha256": "0x91ed0cf4390f33174a4aaf49d1ce7cd9c72e28b95d2f9422314a29b2144b2042",
       "urls": [
-        "bzzr://a5ab50564d82e6d55b462f4f85284d3fac294c78f2699b680544bc7efde2fb16",
         "dweb:/ipfs/QmRPchg1b5ofkLnLTPuunfSMKnxbXcZyzSR4NkyJAYUTrR"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0xf46cb35b3aefb9b3d59a1fb4c151eb23a0f0a05387b379b3e7fbed1c01c861df",
       "sha256": "0xaf812445476c101ae5ef92941c79eaebf57b39d455bdfb54a6a86b4ab6ca498c",
       "urls": [
-        "bzzr://2e72b599d5a700cbd03d9f7ca082464b4823dbaabfc5e1031075b9631c005d35",
         "dweb:/ipfs/QmPYEmgLWDjk7kPGovojurz7fzdGv8Ti3H66nEzRzdiGwh"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x66669372d2d958bfeb5129a387dbc3882a96e260fc12e2910a7eb148b8ea5dd6",
       "sha256": "0x9ffc04d0aee2c817ae6a897b1ba5aaca2bcd860416aaddfaa4de553fc1ad6e8e",
       "urls": [
-        "bzzr://5f5dbf4ebe3be5dbe3e917a2de3908b3a9ed24207a6406a6e434e6f041e993c4",
         "dweb:/ipfs/QmYWL8Z3yXfCuhrprimdLhYFkjR74TjFHULxcABbUipetv"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0x27e324f75dd52eb180569e7a8865048253e5fcdaacc52e7c998ecaeb78dcdabd",
       "sha256": "0xfd7c4e652d5891c84d93b28c90b8ac58c9253d2a3677935883a337ee96087b8f",
       "urls": [
-        "bzzr://764a91ca290bfa564d890f3c1a5a88067b04e96398f223576cbdd17bbc1faee2",
         "dweb:/ipfs/QmdEr1zJrD2UYawZzeE6zPuYiYaSHdpLtKeHYixHgRp9ko"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0x05c00863784c63220704197d8446ac1e277fe53c42b5264093960b7bb70b9792",
       "sha256": "0x25cfdd733e9c780ab85373268fde7bfa2e4b22093af57422ca3b586c7af7cd60",
       "urls": [
-        "bzzr://18fc5b15154aef1640559c31bbd91ae267def62a2b86e434564184b6d3d283ce",
         "dweb:/ipfs/QmSUakgiWEffZ82RrN7hgLaemdqtLSCD7pfGAKxGhDUJxB"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x7c967d9dc0fdca0db88a7cee22cf5886f65e8fa8b4a145eccd910fc81a1c949d",
       "sha256": "0x7d40c6325c0aa4635babdb8913626b7c4bac6a4f41e1c383de5f398e1fc98e1b",
       "urls": [
-        "bzzr://c1f03890d82592751d779ea2da8a690e15b0ccc5667314bf634c1f16ff4ed322",
         "dweb:/ipfs/QmZcHLPfa2Dz8M3justKYyDmDnaNo4pseTgAeQbtJNYywe"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0x012ae146ebdd510b31c1e44a8d60071a66cdebc77f0e743a6ebc2fe68e67d297",
       "sha256": "0x566601442deff058d393359df59ed72b41e1f6a65b0aa371fab7f903c189b59d",
       "urls": [
-        "bzzr://47c24a09321abb781b5dbc05fffae84ece6844e41a295847dd68ad69633f60a4",
         "dweb:/ipfs/Qmej9jEnSsD2LqGnL4jgbUvHTxTwiFiHqeMpqyuPLaX1uw"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x4ba5500559a9ad03e4c1d3866ba9d915cdb5d7f2e326b4cb1fa0fe7bdf90dc27",
       "sha256": "0x89978dcef86244b8e7af95298abe26aaf4825df819d6c556e4323dc152c988ad",
       "urls": [
-        "bzzr://c609e5725e607a4d853f33c8d46064e0ab11b489f7a585134cfca570e29f447a",
         "dweb:/ipfs/QmdgDj3bPSKU1xKMY8FRHj8E6z9BQefeuaVuF27RpvZMXJ"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0xcda83fe69ce2a319d0caa20c98b53ff36ea1886054ab3dab23fa80ede3dcdea0",
       "sha256": "0x1784f89fcfffccddaa94273a58e452682f61dea05d142406775f099c6ef5d61f",
       "urls": [
-        "bzzr://5eacd00f2f132ea8fbb308baed9753579ade721a44e94067debb602e193b7ae2",
         "dweb:/ipfs/QmPA1Uf4iwkr2ouguzxxFepVxaRg36XFXxiwqYUuwafQzQ"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0x432dd5d662d88c2316b4df503f693ae9e6e8ed4216726db2fdb3e7f628523fe5",
       "sha256": "0x6e095eefc48dfc21fec18d0b63f229e929f881b5d6e8a999e1622c6b707a7f54",
       "urls": [
-        "bzzr://1b3ef14eabfe47ff614c088337dfdf163c695612c193aeab9ac5a2af69d30334",
         "dweb:/ipfs/QmSgJ8Ru6vraz9CyCDPMifVxpckkoooVSBj9vYcQqG4wG4"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0x98e1027fbf3acb279f740c3b38df69d79ad3f2e6171414508d50604dc2dfc13e",
       "sha256": "0x43b85bc9941814b018065da5c6c8d40e2af49264d0d1f06bdefbfbe628e65ff8",
       "urls": [
-        "bzzr://b6283a40a65b321a0e88f61594fc8bed00fb21a53c7ac1bf5ae421706a372d01",
         "dweb:/ipfs/QmeXatGB9MdWA2NBLSNQbcKvuZpa4Sxem51vCrqyQGfXnU"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0x6f9251f86fd798a3ae25688307ffc7a9984dcf0d809a1aef54f5c68b6cf9fb6a",
       "sha256": "0x0d34e4ed048bbf67daacdf36cd5ce0f553a32962967b52edab6afccaa071878b",
       "urls": [
-        "bzzr://e866e6bdb31fea0646b44a8e57acc9505932ffe813028ce1330ca49fe3edc4d0",
         "dweb:/ipfs/Qmdx3AHUB8bN6ZZs1XsTV3Gz9FV3gAB7x7JbYeUsn43Azu"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0x6abf17bdb1b934d072739e0e083ecfd579c523d200d45184b8d3987924ca0454",
       "sha256": "0xa09c9cc2672678d461dc71100600bb58802db87be4de9424769241712ccbec03",
       "urls": [
-        "bzzr://9b51780766b138ee36e2796cee7bdd4cb494da5d925c36cc6101202818d37e42",
         "dweb:/ipfs/QmQjodGav6KhMDjuoyJ1ag8osgKLBsFC1E9LmaGP7qCRZ2"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x936e6bfbf4ea9ac32997adb893b0aeecd050cfef8b475f297dca1add0a1ff934",
       "sha256": "0x7fd1d3f1fddc615e117f7fb7586acabd60c649c390cf110c8fdc5ce159fa5734",
       "urls": [
-        "bzzr://949bfec63a83091f5d08d6d8df36fa34e674d75206e8a6476cc0ae18f3c57bb4",
         "dweb:/ipfs/QmNrRJwVHaJSZ3aAQZWZKjV9o8BqWKFP3RPYL6hKU65PAE"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0xea559c55bf7046cb48378fe9b43eaab6e345700aa22d701fcf946a42ec6b1008",
       "sha256": "0xf22c63511a85230f7640ff5a77433db643d8d32be8b7c7f1dc24c1301a5158e9",
       "urls": [
-        "bzzr://471b0435c47963835dd0f70d67ec069fab5daadbe6c8bf760d2e50adfb839461",
         "dweb:/ipfs/QmTQPQb6br2VEzKTiXBEE6z69xRXEk24xi2R2gn8EsvGD9"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0xb2657b5ce7a9b405a65e4a88845a51216cd7371e8f84861eef9cb0cb20d78081",
       "sha256": "0x3628fdefd6971ea9cc16acbf91e5f6d6cfb2079181784b47e4d24f4c5d92e4e4",
       "urls": [
-        "bzzr://7bc2dc95d81092991a4122b45aad03f9cc62bc98fa455f03fc9286445ef9de8e",
         "dweb:/ipfs/QmYWAkYAJo59kc5dHWaLuQqEm7xusESdu5meDzjpxnyXKt"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0x7dc96455c864b49abc7dd5f38ba6a47904709ad132ea36babbfce98d42e962e6",
       "sha256": "0x25f564cbecc5bfe95d6d358e0e7543c31ece0ab1332c555ff323ca163711bd2b",
       "urls": [
-        "bzzr://f61230aa01565c8c24aa2ed50eec7dfd26195be35f5bbe4445c6a3efceaa4b7d",
         "dweb:/ipfs/QmaLUM18c7ecA911ig5u2HY6fAu4AiUbhJpnZwwCMc9cWi"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x39ae8b2f3ba05ed7d4a7c16f0a9f4f5118180a209379cfc9bdd2d4fb5d015dff",
       "sha256": "0xf89514dedd8cfb3c4d351580ff80b8444acde702f8be0e5fad710fe6e906c687",
       "urls": [
-        "bzzr://1d6deff5623d883b8d0b3a3a5539e4604925ce4c1677defb86e0e37838ea70c5",
         "dweb:/ipfs/Qmd9JfFpUXsUQrJad1u2QDuMxBMeVrcG8mrpfJVV9jiBXB"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0x435820544c2598d4ffbfb6f11003364c883a0766c8ac2a03215dd73022b34679",
       "sha256": "0xa4fd5bb021259cdde001b03dac0e66353a3b066b47eb2476acb58b2610a224ca",
       "urls": [
-        "bzzr://62ef2a9bf7dbb8fd596b7c6ca6848d9b1a6c8562d10239659f0a56ee27c110ce",
         "dweb:/ipfs/QmTxzbPN4HwcK5YX7n3PNkb1BzKFiRwStsmBfgC9VwrtFt"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0x6262768243c1ceaf91418e52dc6f52d2ce94d19c6e1065d54499b7bc4d6e14dc",
       "sha256": "0xf8f83757e73f33f44389d1fa72d013fb266454a8dd9bb6897c7776f8fc3b0231",
       "urls": [
-        "bzzr://ed91c1114615572c10a34f0ab28a3a159d2d433fabbcec9eae7253c25ecac8b4",
         "dweb:/ipfs/QmRUoBQeA5zpun1NK7BvBhQk6pTT4uZw7Jn2wZnWQETH9W"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0x3c9cfccc78bf352f4c7901d7af76757bd228f93af2634af4cd16b4916c13e44e",
       "sha256": "0x09f6098026622c5c334c7798c3ad2b8f7c0ebc62f87846c7d5e7e725c3d1cbc2",
       "urls": [
-        "bzzr://ab23bd0e01952ee485f0426c9c4e47fcf6a508bc4919e83be31c0f9ea6e396ca",
         "dweb:/ipfs/QmRj2pxXxvmJ96i57maVjLMfs4DUtCuptM8vSVvvDweJ74"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0xb463b6a61fc027247655a32cbfd50bf543eafa3a6b42ceacdda7293e3ada8866",
       "sha256": "0xb795f1b20f065a0aee492c24071fc1efa1633c3caab77cff20278a9ae822f04e",
       "urls": [
-        "bzzr://c82fea785ae31fb4847f5640e6305edc05d1a5b0b47552f60325c25cce280f75",
         "dweb:/ipfs/QmShUrNZf1dZFjziorJYE8fMGNUSMFsbaR3ipSvsCMvExM"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0x537cefc0579dd9631ec952cae951b3df0a50a3e557b5638107a67275f7aacc07",
       "sha256": "0x3e8b01cbd194e40971b41017ada7c8b2fa941b0458cb701bdfb6a82257ca971b",
       "urls": [
-        "bzzr://130bff47eed9546c6a4d019c6281896186cf2368b766b16bc49b3d489b6cdb92",
         "dweb:/ipfs/Qmdq9AfwdmKfEGP8u7H9E4VYrKLVinRZPZD1EWRnXSn1oe"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0xa2d4d3ebe5d52bfa7ddf1a1fcd9bfed81eaa8678e6a1dd5a1c84954dd064422c",
       "sha256": "0xf1724fd46b7a353561b3f8d473b0dc8c855b6d84b5af559d7e3326ac79b9d758",
       "urls": [
-        "bzzr://2c5fff6b816edb78adb2220f175591c9f4f6d38cfd27a83afb1849191cf9a524",
         "dweb:/ipfs/Qmad6iesaR5FQ45RRtMrt2Fa1EYDuq1oGoMJJB6beMHESn"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0x620163da7ee7b2622c9ee48b06110a52739f633189555148a3b5ecf767e60cfb",
       "sha256": "0xfa27ce9d23bddaa76a4aefbafa48e48affde9a1ee7c8a5e8784cf8d4c390f655",
       "urls": [
-        "bzzr://823b4efe3ca2964d660348214fd1a44579e13e1e8ce69a81f447372a11d60316",
         "dweb:/ipfs/QmUinsRZvs2zFNG6FMWy7ngTYUnZccXq7MRtgpj1dPfxu4"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0xf0abd02c495a0b4c5c9a7ff20de8b932e11fc3066d0b754422035ecd96fcdbbc",
       "sha256": "0x9778e4a7667d5fd7632caf3ef3791d390a7cc217f94f96e919a31e3be332386a",
       "urls": [
-        "bzzr://9f9244a3605543a67f5ff35f21e3d6d3331a6e1361f09b271c37f396b5b89bd5",
         "dweb:/ipfs/QmXyjgFNMyFD4fdf8wt9uvUU92MGdDVGmcPdMZhNEo1g8N"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0xe1412d909a0dae79b13c0066b9bf08831c522daec00b273bbc19a799af213d6a",
       "sha256": "0x3e1956c550ca48e289044c7c0bd892403081b4b5e17e77ce707c815ce6c4228f",
       "urls": [
-        "bzzr://b69ab6704a1e42fddb326e91f331e35fdf071b158e8754e2c887c0e607aee7b0",
         "dweb:/ipfs/QmTs8PnAGr1ijXtWvMjoWraefAtVv2Y5ZnwkArz6NqJ93w"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0x0c7a4386781683c327fde95363535f377941e14feffad5bb1134c7aa7eba726f",
       "sha256": "0xe7e1be3d0a67469f6a37cd676a22314c4faa8a22ff9d5ebde11302db754453eb",
       "urls": [
-        "bzzr://65dc33e3d9ef94defff1b24e66f093d9d15a92c59778c8eb26e76fd8b64bd3da",
         "dweb:/ipfs/QmQFhTptWdDzhemjGpa7Q65HKWGphs4nKKS13nzkcVE8pM"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x3502cf7933fbce9f1fe1d87a83d5b9df12eee36c03997c3b9821493ce03fcf3e",
       "sha256": "0x7fcc983c5149840a47b946fc51fc14f1c21cda07c01d650e4a1f814319cb1423",
       "urls": [
-        "bzzr://617dff84fd7dc06b476f93a95c015a561662d9ff1d3356ac6a3e5f5b09a636f0",
         "dweb:/ipfs/Qmdw9c3usmqgdV2w4JoNWJqscHzscKNVWsWtos1engJa1o"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0x0c80a0bf9e17700249a04a80d7729ccb012a55a82cb0f9e412fa32cc14b09c2b",
       "sha256": "0xdfa3f2bb4589bdc9c054292173c82ee70e65af8d1971598f6e13b9b79ba94185",
       "urls": [
-        "bzzr://a45264806fb74fd38c19704070c83053972270b63bf7b09ddff3c3e15cd1baa0",
         "dweb:/ipfs/QmTNWY4vkVLgtNdfGXyH6CY8URmzr33VzMJNN37z5dsAgu"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0xcf099e7057d6c3d5acac1f4e349798ad5a581b6cb7ffcebdf5b37b86eac4872d",
       "sha256": "0xcaf4b1f3e01fcf946aad2d22bbe046b9dc4fd50049a05c3458ff239e2c93a785",
       "urls": [
-        "bzzr://2f8ec45d2d7298ab1fa49f3568ada6c6e030c7dd7f490a1505ed9d4713d86dc8",
         "dweb:/ipfs/QmQMH2o7Nz3DaQ31hNYyHVAgejqTyZouvA35Zzzwe2UBPt"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0x300330ecd127756b824aa13e843cb1f43c473cb22eaf3750d5fb9c99279af8c3",
       "sha256": "0x2b55ed5fec4d9625b6c7b3ab1abd2b7fb7dd2a9c68543bf0323db2c7e2d55af2",
       "urls": [
-        "bzzr://16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1",
         "dweb:/ipfs/QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xfe223dd264421f9b96c3dd3c835a3d0d4d9cfa4c61f75ca0761860c9ae8906ca",
       "sha256": "0x2ee1c6434a32a40b137ac28be12ceeba64701bfad5e80239690803d9c139908e",
       "urls": [
-        "bzzr://d67cf500345ceca523e9bbe55dab9399e27321fd9005704a5b16bab82185260c",
         "dweb:/ipfs/Qmf5fpJmeHdwgmSjQPqdu25XtA9akTotakkNmrh4axgo8N"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0xc68517effed7163db0c7f4559931a4c5530fe6f2a8a20596361640d9d7eff655",
       "sha256": "0xb94e69dfb056b3e26080f805ab43b668afbc0ac70bf124bfb7391ecfc0172ad2",
       "urls": [
-        "bzzr://523852f3e01b02ce947771e0279ffb6154d12700f809ba3606d908ba6271431c",
         "dweb:/ipfs/QmWjG6PLzF5M6kxkHujhEMg5znQCgf2m1cM1UptKA719Hy"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x08dd57a5cf5fd59accbd5b601909ffa22d28da756b5367c29b523ff17bbc2f99",
       "sha256": "0xc596765f9b3dce486cf596ea35676f37124d54f3ada0fcbc02f094c392066a59",
       "urls": [
-        "bzzr://7047ade6879aab4c825594dab0914b8ec673bb907eecc6dfbd68f63086e5a36e",
         "dweb:/ipfs/QmYh5C2rgDAx452f7HyHA8soLhnoL1GeeNNEWEuw9jKY8w"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0x84a0e9282047512eeec499d55c83dbb6981430b08692d81d6c09730bb18e6cd8",
       "sha256": "0xf77f141e5fed9594b28342e2c630ac6d48f2a724e4383a457881acd7fa62b1cf",
       "urls": [
-        "bzzr://da8c5ea3f2ecd33d3f83ac2c276871f4ee41370fb55ae62c6c29835c9376bdec",
         "dweb:/ipfs/QmQ6W5VedQpZAwuGTtp1BhmNkvVheLnJq4xwN9Qmt9bAbH"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0xd0c15275c5b0d03871332719def9b0f17e8860c7db60e0e71f18b971458a7391",
       "sha256": "0x015e83fb0b72ccdafb0c217961b21a0321adb2d3f2ad992f5e79635c2086e6dd",
       "urls": [
-        "bzzr://629ae5ad84c45c248144b5eec7827a9cd5b2f2779ef84ab251c8cd876347a098",
         "dweb:/ipfs/QmdfVfa2mhyosaJVeV7rbfnvQ95GTHPeRPzmvxcds7RYej"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0x51777116af58223a41aa3016d0bf733bbb0f78ad9ba4bcc36487eba175f65015",
       "sha256": "0xb5cedfa8de5f9421fbdaccf9fd5038652c2632344b3b68e5278de81e9aeac210",
       "urls": [
-        "bzzr://c7d43da1bc5529d2cc311e00579c36dcff258c42b8ed240b6c4e97bd85492a64",
         "dweb:/ipfs/QmWbNMzJryhiZmyifLDQteGPwN4aTgXQB6barBvXYVw975"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0x7e0bca960d11fb095798ff65d029436f23358ac060b25a0938acfcb4652da2ec",
       "sha256": "0x4a14c7bcaf0d988a829db2174b8f7731898aa8633216490603ad74bff64eca3c",
       "urls": [
-        "bzzr://7f33fe204160253c7ec23cb0ac83224bde3aca9f91a7a686cb67d99248c5fbb6",
         "dweb:/ipfs/QmPYDf4qYtZLNEAicW7hcvpUJ69FoHiXmUypipDpTKo9hU"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0x6d6d75b033717aae0a728e527005d8d2cc7dbd0a835c8873c630a2a9689a2976",
       "sha256": "0x4af595f976235d33a22ffe223e9e3210b4ca510f6a93f153b3daed60f2b11fbc",
       "urls": [
-        "bzzr://d501ee8c460db75379b5716bcb5ae10e3e32625d6c9b08e319822a110f178906",
         "dweb:/ipfs/QmNWkyirqXy3gDHNXpPuVUbExMGWjMqPR82Xzs64RzgQzy"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0x070e41c7f761ff1a8383a2c0d54c22aab0f115ca8c3790ecea27d6dde11611ca",
       "sha256": "0x06a671efd8865a6ecc0ad648076177b35abcd06a7059888ea65111272e33a57f",
       "urls": [
-        "bzzr://e4f8176cdb3a0f3ba0b7061079dd9d3495f6a2288bd724780337cacd96515148",
         "dweb:/ipfs/QmQre11ZPgWSx79Jzca1tkTYFyMbXz8H4kcrhfpWSj4qs8"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0x8d6be9e58c33d265b5a8b1132a27fce126067419f3f4f15d3ef6b7147593b61d",
       "sha256": "0x663ba99f7c7ee907f0f03227502d48a78256c3c292ace3b79a5d3eb510665306",
       "urls": [
-        "bzzr://0bdbad1bdcc3a9775f16f20a35556be4baa0e6c9a9b9d820e8e2cdea80667c6a",
         "dweb:/ipfs/QmYv3Rsi9pL6PZAtc4XLHezPqti8yCRGEdDBqzEsQv57GV"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0x56cb2f6978bf1213982ef217ee76b39dc97b6e66c92a7be7a1b44079c0236e5c",
       "sha256": "0x534b7d4079d13bb4cd10b7559dc105c2adec625df4105f20ebce47e6da60bfda",
       "urls": [
-        "bzzr://7543aa16521848b06a1359afcb9dbd7be1dd09a36f4ca53edd3ed3a512a475e9",
         "dweb:/ipfs/QmZaSrn3TPvPVoShtjSonQLFd3BV6RdgRMqw8GTzhnKYpm"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0xbc470ab3442e78bb4d3f16c01c39b2f160f4f34eb4373efed11c234e1c7f6ca0",
       "sha256": "0x5b25f987aae32a0275fdc6c1be36cc47cf126024a04dafd8e4be39a1d1d1422c",
       "urls": [
-        "bzzr://83bf64f11a09845a6eb732da08283a58f877e9227190f489c9852f790c81d0c4",
         "dweb:/ipfs/QmfFq3MvisCSUJy8N8EVsBribgPbdpTZb7tQ2eHYw7dwag"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x3820aae0de50f10f62819d65f0b5a236ccffed11ab465a3295a5408fa47e24f5",
       "sha256": "0x5eaee3240a06891abf5ac70c75caf9a0c33ebe9a2736abdaa22a337f86c22933",
       "urls": [
-        "bzzr://5124a21890d6b0ae70bfd031f741d7edc74cff70a26ca74750d446b15a8efb06",
         "dweb:/ipfs/QmcsfYpEWbPXfVptzi1YvGokxi2FYCUzUr8rQYJCc5fEiB"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0x798b23086ce1339e3d47b3648a1f3ae40561e2c9f66ffcc98e71fc14a7f77584",
       "sha256": "0x64117d4b13bfc5bc6e5f80823519b140e753a0c09e99edd756772dc3029bc1f8",
       "urls": [
-        "bzzr://0fd1c8db6338b2143ab0e49a33edaa133108ba77f1238408018b5b2a0ecdeb62",
         "dweb:/ipfs/QmNQTFQmfnjxnDmbguVSnZ5DiHGFQHCsffccW5c2DMcSsT"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0xdd4ae95607655404b769fab5f949ac95c6a1a506330f512aef0d92974c390431",
       "sha256": "0xc2c4738c96ad329cbb9baea615ed50ffb5a53d93fed8e00785e47242581d3c60",
       "urls": [
-        "bzzr://38f396377d5a5a60d0b9d8c4dc1343485517ff31bcd281d531f98534dc79d811",
         "dweb:/ipfs/QmVdW2ygaT2vecoSUog3HUn8hZqXU4XXQZvuRSdpV6DJPL"
       ]
     },
@@ -956,7 +877,6 @@
       "keccak256": "0x9afa714859d1c8f8ed2fded497b83a7a420474282494d25d4c9f592667729f21",
       "sha256": "0x387343bcf8f2b77fe4cdcddcaa84361fabf8e1c3508f874fbbcbb9c313542f56",
       "urls": [
-        "bzzr://ade0fd040981c4e8c7adfe366296e452687c7bb6421de8546a0678be4add016a",
         "dweb:/ipfs/Qma9V9dJwmkim98H6DQX4f7RH395vsUuqHCDxbKetcbj18"
       ]
     },
@@ -968,7 +888,6 @@
       "keccak256": "0xb0f7f19a8590e5c0aaf779019c1deaafed170d8c26bec9bfd782d212e097619e",
       "sha256": "0x7c3b3d0066fd381283b1d8d9a86153b2ddb5c01da14a1ae015c05cfa484e81b6",
       "urls": [
-        "bzzr://fa438d41ed52c9e0cca556efee61486fc77e60df06081921abb0a0f19b602d35",
         "dweb:/ipfs/QmcM1TcDB4ta8ttNLWZ4d24M4Qs35rc91sQkdNmJMNbuvV"
       ]
     },
@@ -980,7 +899,6 @@
       "keccak256": "0x4f6cdc0f25e734bcb977bb6a3e22fa41d8a82cbd5f220a2e4238c2d233526d1a",
       "sha256": "0x71135e459d691767ce3453bab4564ef4a640dd50182da36517cbc1f96c1d4c7c",
       "urls": [
-        "bzzr://ac5baefba32f4779a03d1207d9f1ed69365280c702fd73002a729b7a3d52c425",
         "dweb:/ipfs/QmPiBrYZxxpNZPQ98GNyL7Xa1F9Dq7uHtdt9ESwhPNkHhc"
       ]
     },
@@ -992,7 +910,6 @@
       "keccak256": "0x331f4bc6de3d44d87b68629e83f711105325b482da7e9ca9bdbdd01371fee438",
       "sha256": "0x27b2820ef93805a65c76b7945a49432582d306fd17a28985709a51e6403677c2",
       "urls": [
-        "bzzr://af0d70945c85865298732ac2bfdacdf2774fb4daf793c94fafe135b839a60a5c",
         "dweb:/ipfs/QmWzBJ8gdccvRSSB5YsMKiF2qt3RFmAP2X25QEWqqQnR4y"
       ]
     },
@@ -1004,7 +921,6 @@
       "keccak256": "0x3f2be218cf4545b4d2e380417c6da1e008fdc4255ab38c9ee12f64c0e3f55ea9",
       "sha256": "0x617828e63be485c7cc2dbcbdd5a22b582b40fafaa41016ad595637b83c90656c",
       "urls": [
-        "bzzr://fe8da5b2531d31e4b67acdce09c81eccba1100550a7222722152ffdb16ea85ef",
         "dweb:/ipfs/QmTedx1wBKSUaLatuqXYngjfKQLD2cGqPKjdLYCnbMYwiz"
       ]
     },
@@ -1016,7 +932,6 @@
       "keccak256": "0x9a8fa4183ef95496045189b80dfb39f745db89a903b398e40131f500953e5d57",
       "sha256": "0xd82bdcba2c386d60b33aca148a9cfdf097551f68c5e45d8ec01aebbafacf5075",
       "urls": [
-        "bzzr://338117c2130fcb6bce3006330712b6e7ee99875b56ce4bb6182312f76e4a6bac",
         "dweb:/ipfs/QmcKzrqRBy7PeFQxzJDs1AZZzNHKaKbJces6zUDysXZofJ"
       ]
     },
@@ -1028,7 +943,6 @@
       "keccak256": "0x6be35b86f5656c06ae897ef311c28da375bdcbded68c4a81e124f2cb36adf830",
       "sha256": "0xe0b74e0a16e783a35169f74d1a615ecb48d07c30f97346b83cd587949268681e",
       "urls": [
-        "bzzr://434c17a0cc3bf371e5b9baa7f804b37ffd2dc141a98c59b2ba6021fc419a39c0",
         "dweb:/ipfs/QmPnhNtzrEBeWWQMXdAByQTDPoKXXV9NFXLk3YL4QbghMP"
       ]
     },
@@ -1040,7 +954,6 @@
       "keccak256": "0x3a420fa9963772eee5b9221ebb8cf9548eea8f88b09537390960ea9b440f333c",
       "sha256": "0x5c509f760dc110a695c8b39bbc21e08c17dee431aa14d606f59e623d7c3cc657",
       "urls": [
-        "bzzr://fdc05062e4c7ec85ed18ab17b6f04f3274a4b7caf0be483eb86007d708825fb0",
         "dweb:/ipfs/QmciAxUX2kfuoxitmMdkKSfWn2SfxQdieLRa3S5S2munot"
       ]
     },
@@ -1052,7 +965,6 @@
       "keccak256": "0x370efd28e2d28b6d0ba55e20d8994f3d286c3772552ed63586b5fe157c0d3c57",
       "sha256": "0x45bea352b41d04039e19439962ddef1d3e10cf2bc9526feba39f2cc79e3c5a17",
       "urls": [
-        "bzzr://5e66947c220c91a6cd39bc22965dcf861015b8613a6e09aa7fb7dc10f367b5d7",
         "dweb:/ipfs/QmXLgy6oexvCBWYS5pTpJWohsDNGqgdNFLRKX7JrE3NxYt"
       ]
     },
@@ -1064,7 +976,6 @@
       "keccak256": "0x907eeba6e6e0d6977ac5a8f50e4dd2762539ca827ceab1afb1f5a4f0f3ce3e0c",
       "sha256": "0x92d283c545395b91a656fa1ec94d567a464bca55aebcdbb99debf42b43026845",
       "urls": [
-        "bzzr://63ec828814e2b57db2a7a146061a96cc39797ba39a0063a7b664421a48f21c00",
         "dweb:/ipfs/Qma6o4e57YtWj8cQLQs12r2Enx9qmRA7VHtupCauXjYTAk"
       ]
     },
@@ -1076,7 +987,6 @@
       "keccak256": "0x743aaafac24d9740a0b71215f55a132f89336a662487944767ca4bfd66400769",
       "sha256": "0x9c681b165c8647867589c0a5ecdc8692637a935928a2b1bbea2ff4a1f4976985",
       "urls": [
-        "bzzr://6e70fe6bfe8c3fc63f8a3eba733731aab129e6e58828b78058e53bb50440709b",
         "dweb:/ipfs/QmZy5ho8W943FMGwppXZFS1WFrVwV3UXhUUwcD7oH5vrYe"
       ]
     },
@@ -1088,7 +998,6 @@
       "keccak256": "0x1b6ceeabad21bbb2011ba13373160f7c4d46c11371a354243ee1be07159345f3",
       "sha256": "0x11b054b55273ec55f6ab3f445eb0eb2c83a23fed43d10079d34ac3eabe6ed8b1",
       "urls": [
-        "bzzr://c604bdd6384bf73594cd0e5cfbe979048191549ebc88e70996346f3b744c0680",
         "dweb:/ipfs/QmW2SQbEhiz3n2qV5iL8WBgzapv6cXjkLStvTMpCZhvr2x"
       ]
     },
@@ -1100,7 +1009,6 @@
       "keccak256": "0x4639103a26b2f669bd3ecc22b1a1665819f2a2956f917ab91380bd9565dbcd01",
       "sha256": "0xf8c9554471ff2db3843167dffb7a503293b5dc728c8305b044ef9fd37d626ca7",
       "urls": [
-        "bzzr://d201e60bd46193b11382988a854132b9e7fb0e1574cc766cb7f9efe8e44a680c",
         "dweb:/ipfs/QmdduJxmPXungjJk2FBDw1bdDQ6ucHxYGLXRMBJqMFW7h9"
       ]
     }

--- a/linux-amd64/list.json
+++ b/linux-amd64/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0x66bd5478b31c7ad1ec9b148618945dc8b7d0dc9ca4a2469992b9728daf672f9f",
       "sha256": "0xf3638225df24f444a72123956033f5743079118f0e1195ce6969aa16a7ef2283",
       "urls": [
-        "bzzr://9d3ea309ce8ece74f89babfd3e55035f6164e5a0f9ab7d839c0493fe10e915de",
         "dweb:/ipfs/QmUGR45KnfMmJUSGvZyNiB9c9Cpf7FLTHdK8X3bZQb1GaS"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xf27dfded17794053f0e9144a35a9a9e2fcc1c7b34f46f593b87000d00aa39eb5",
       "sha256": "0x0a8d138ee245039e6f8312edc024ba3c4739cc3c013b47dc7fc9196a2e327fea",
       "urls": [
-        "bzzr://f88f5572e75465633a2a1fad99e4ab329f854b73aa8c9d2f1a7a14011e32df6d",
         "dweb:/ipfs/QmenL4RpDaBXFcY8HHH5rzieMGE9KFWcbHZzG1ypC4pGLr"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0x6cffb262a3498b98e59baa4f579ba92c9496c960ca37f675fbd17d179a31dbd1",
       "sha256": "0x221ae33e12bda5c8b796c9abae2b2eb73e46d9b12128bfee451b12856f8b47ee",
       "urls": [
-        "bzzr://246480c5502c5daea350af895c79213971672c5fdb85b7de93d27b20406c89a8",
         "dweb:/ipfs/QmTTW8RScz5F9W9fyYMafyQKYP2y1XN5ZeJE89N55LU122"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0x7d2ee23b3ecbc3a178e7fbdb50eb52e5d2637289b92c0c370dbf69be20e58031",
       "sha256": "0x791ee3a20adf6c5ab76cc889f13cca102f76eb0b7cf0da4a0b5b11dc46edf349",
       "urls": [
-        "bzzr://d6182ecde7e8d10659176cb59b60d3fffdae0f87ae8f3ff79d758fa22c03ebc0",
         "dweb:/ipfs/QmPBGiJHDCyqFaqbtfPbSozFBtiF8cpL1mMDvumpSNYDEt"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0xd952abd8839609ebc5a42350419cdac388d39fa0def02cd2b0c2c559dc2598e8",
       "sha256": "0x28ce35a0941d9ecd59a2b1a377c019110e79a6b38bdbf5a3bffea811f9c2a13b",
       "urls": [
-        "bzzr://948ebc4b72e2e5705512ec441b3a3055e522a8cf46bd82cfad42aefb1c1c25d4",
         "dweb:/ipfs/QmeDMVjzcKysgVrEj2W7ewtNtDwut4xHknP79jqbdZMpBL"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0xba3b29e25b9e9b5082832bb27b0d1bafe2ce3a78aaad85a7ebbeba5edc825447",
       "sha256": "0xc71ac6c28bf3b1a425e77e97f5df67a80da3e4c047261875206561c0a110c0cb",
       "urls": [
-        "bzzr://f5f436b729b8c3a4e31d607f3ad0256de8b970b207fd83ae7552a34570e5071e",
         "dweb:/ipfs/QmcEoM1BbxFoUs1PrxkK42JiWbW8YS3ZsFNUgsthFaypZc"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0xc0c1df80393ca97d89bdfb435cd66027ccdbe4f88ca70b0c94afa1d243c99268",
       "sha256": "0x78e0da6cad24ab145a8d17420c4f094c8314418ca23cff4b050bb2bfd36f3af2",
       "urls": [
-        "bzzr://24f7c4bccb3711985253911fd2df23be1bc92cf3629b238d4ba7aaa433cb5251",
         "dweb:/ipfs/QmVSF192Nbgqh9zA1JQYyCVbzyxqYhYPFXBunzyHtxJRZ5"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x91c51381736ad2bc23e2a29423f786c8da5f9a7e13d6cfade90e9bced0636026",
       "sha256": "0x13414bf86f80319e6f5863b4ca4af786956d188f5f9b99dda6439362c6d91115",
       "urls": [
-        "bzzr://e4b2755454fdc9ab73ba013f0d646fb2735f7d7f1c696b0d38be593ad68752ce",
         "dweb:/ipfs/QmYezLj4Qky7HXv5iZLzBc7itTV1xhnh3kPuFGMhohCkZj"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0x5f35f3ababcda47bcfbb7aefea8dc3ccda06bb12690e047a8330e895f2682e61",
       "sha256": "0x898a5e05d3ac08d726b019d2415c1c087a9ae87866cdfa551c08b36b6b45321d",
       "urls": [
-        "bzzr://63bee56c93171ea27e96e35f54411b79d12bc6c398f8451229919707e93a33a3",
         "dweb:/ipfs/QmcZajAm1bVSyGRmAxq3yNbF31M6yMuNX9tVkFzmarHn4p"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0x7310233685fca42969a942384662203fe3150098c20a3285ed702f769873661b",
       "sha256": "0x07f89753cdda28054bb6f159a21911716caeb43b3c7659a25f1f2d9dd17bc827",
       "urls": [
-        "bzzr://0fea8889d30bb35a31805e59382bf15fc6321c39358a16d0a7eb5a28b79b24db",
         "dweb:/ipfs/QmQBKWnNXJyVjBVsTLmbNosfScV3eoGDfz81L9inC4SJEZ"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0x6ac0e06558f9c1e28497da8e7b1aec808a85ad59862a13a42d537dc9e5608165",
       "sha256": "0xd966b8215a4f83377ce9d622c9198fe91e5b93300652bf081aaf2f6aa3ac6a16",
       "urls": [
-        "bzzr://bfe04eb5a64c0be572bb03df2a53d8bdef52db767cfecc963ddca4b584138105",
         "dweb:/ipfs/QmXfGHL16gtaDFTkk4GT5RXmxp8ciyMz4Yt5YARE8PoRUx"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x18830ee60c27e630558ed4dc26543800ecd1189aab3d42f3ef0bcba9ced97a26",
       "sha256": "0x905228505420cd31e6393e09ea685b87585b62c4339d3addc0a3049bebbc4332",
       "urls": [
-        "bzzr://28cbeae79e05b0b72b7a22247124071a3881b09886ee716acf2024038a5c52aa",
         "dweb:/ipfs/Qma2XrmazW6bsiEma64uUmpjfJMDXCsirP72nw8nuEPpKX"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0x7fb2ce6341df972568b9987542f17c72f0f8481b6d6544df9464541dcd48ce07",
       "sha256": "0xfade9ba6dd489ffc3f73e53a13d5f1031325779708e448224970979b8cc86ba7",
       "urls": [
-        "bzzr://1ad67b6130be54ad37b3ed7d4024d8277e5abe01fd2ba3b4a1db8d7d95c743d2",
         "dweb:/ipfs/QmWzkuv48UJnPwNdDFKN2A5yejZYizckwX4FdD2A6sXcGs"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0xbab9657147aef06499bf9b016671754be7233ca08bbfc056c260fa888789d044",
       "sha256": "0xc648d299bd21f4c74ce17954706cfc5a7a9fbbd1e8739546ed8754cacd8ca7c2",
       "urls": [
-        "bzzr://17f4e7bea5718a310c7a59b6bdce8e33e32e6569f186116e44b49c83e394ab71",
         "dweb:/ipfs/QmeYUkb7mzaKxgHsTszv7FnSC4wSrMk73BxJrwsuwisYgo"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x9dc72f961d7dbe7c3d3cc380955b994dd5fffdf4020d217cbe45d349d25aadb5",
       "sha256": "0x665675b9e0431c2572d59d6a7112afbdc752732ea0ce9aecf1a1855f28e02a09",
       "urls": [
-        "bzzr://8472dab7460f19869b64c3462bd17f689a77bb9ebb178cf7ace5c887e5c0985d",
         "dweb:/ipfs/QmQRjyb894sQXHy7izsj9D7g6UNn6WapQUnemRiqiNRucC"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x3daf486a85a9ed33b63c7e9f89e40f46c528340b3d096f3ccd84bce60a9d1d59",
       "sha256": "0xc9b268750506b88fe71371100050e9dd1e7edcf8f69da34d1cd09557ecb24580",
       "urls": [
-        "bzzr://9d44af75f7b3d0a8b1079814c9e78e07efe9ffc7b42c7ef379e3453ae7b49f3b",
         "dweb:/ipfs/QmcBqre2ncDfq1SRX3SzXtP54FJXbD4smmWVhhwvWGrs8E"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0x5ee9bf00d10e712f1d43b94df82a17c4a2382a622f41ef67757f83fcbb0a604c",
       "sha256": "0x5d577b3f7918dd735ab157e2f37a21d06c90469f13868359874f15184f2fa4d0",
       "urls": [
-        "bzzr://ec7ce34dca7075d994468cfc407b0cddd2fd5d6426d5ba3bc7b9f0471304e11d",
         "dweb:/ipfs/QmbVDnn2V5uvBZk6vBXSELYvQLZQfegQUNygn3nXMyfrTU"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0x7189e393d88774aa4b82ea081f871fa50812c85eaa46f5555169dbcb6d0aff66",
       "sha256": "0xc1bb15b520f5076aebd7aa9ef4ce5fa245b6f210a91cbd2064b9e383e6510e08",
       "urls": [
-        "bzzr://b041cea8f6345b61b95e46edb2fe259fddde1f54314c8ccc4ddb6f50fbbd2f84",
         "dweb:/ipfs/QmYWyPLHYcgptU2PTffmycrSYdpvnx2xssjKoKvEuugH5C"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0x622e30657718674c5c9a1175c432eb3e2873ad15307bc7083c2539de6184565d",
       "sha256": "0x6275d481f23180e00b38996848534db78b4f73caaca15435ad861df545bb71d0",
       "urls": [
-        "bzzr://702c4fd0cfaa35c3f55578208ad49256a94e16949bde4e0abd3a908fd5042dfe",
         "dweb:/ipfs/QmTigsgEim4YBrRd4XWo4zR2nyFewLBEu7H9mgq1PmVxH4"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0x636748ef7a5915f5ceacf3d4ae173b66deb129db22b1b6b6e2e502efe7a0e302",
       "sha256": "0x87146a7b284b1c9067a915930c0c6af7c99ff9dd1807e3680367fc03a59e83bf",
       "urls": [
-        "bzzr://c9a3d6a2b2324f8c47a00ac071c4c79181c28892342124342d66b350056a7bc8",
         "dweb:/ipfs/QmPTVaEGr5RWyNa6ULXbuYQtGW1qyEWbiy6AGqrk4qSQMH"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0x6013590701af06ff53c10861ade4d52eec3005e6d730155f28fd04e3115d2d9e",
       "sha256": "0xbe08eb95cb3a1da52e918cf51a0c0397fbe7f0693145eb31835bf2924209f1e0",
       "urls": [
-        "bzzr://aec5fb36baf59e8f06e7dc721a1e27c3c59ff29a83d601cd971962fe3b6babba",
         "dweb:/ipfs/QmbDNEV2Nvrro3S5LZ5CwhcErd1vY7md715Rrsn6JBNTYr"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0xccd306bccc95abb2eacb561fe3580de72c08a3be138c82b6962850f6fe4db564",
       "sha256": "0x0fde347db5e632fc3aef3ca8da74896d8df7a35287646e7fbdee829fe236054a",
       "urls": [
-        "bzzr://c93b2d5ff975e9213a9d2d2bfd3060bf36f4e4b6a9a569b09a2eb3f51345197f",
         "dweb:/ipfs/QmZU87uh8XYDvADWmkayr4kQ2sPmRD6E7kyrpanQzRgJfM"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0x3657b60cb1f6a25ed8698b3b4de1720e71e35c3e5ee48fdedc6aca23e2eaff7d",
       "sha256": "0x718c7cc5818a9179d360ca5422c9f13a312a2baf8884f3dd8bbe3287ecaef0c6",
       "urls": [
-        "bzzr://ba603014c72546dbdf82c93ee3919418d5e36f34c8e46cdcb0ae5ef8b1688820",
         "dweb:/ipfs/QmWvL7waFJgJv2Mb74mzeHvM6px1QDs1P6TFyFxxacKm5v"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x5653c7311b09a6b04060e5b68bf28bb8d45d3179894f6ff3526c02c70c050ee7",
       "sha256": "0xf3c70a4d716b7b4e811ef5204b3ae6a16497ae701a2b86260d1bdee7e4484b53",
       "urls": [
-        "bzzr://ac1025b53049d2ecd2cce1e12ff2f4c1dcbb0855c1c90e470b5d40bdb0a21438",
         "dweb:/ipfs/QmTVw4eKdJZgc6m6RZutt6jkz1N6VkeMGg2XjoMqmudvrs"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x7b32dc1532f3813dfa8500f956c80d66c03f82ac220aff0156b8fc62b4d796d9",
       "sha256": "0x810c52cff29511f95c44f9a1ae2b11c04598d413d6ffa37bdb19415926fb5b37",
       "urls": [
-        "bzzr://85af46ad75bebc7a45987d0460c0de075b3e0161abd1b78d91733d5ff10a8852",
         "dweb:/ipfs/QmQxKe3R7iia439pkZEVA11TJLummjLQkZRvXkEHmj13gn"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0xb389dda6ab00851f358e3cbc63225446ad25e040d41aa5f6d0e9652c091eb8f2",
       "sha256": "0x58fbe9bbb709277957fd12b922530f03cf558cf803b72333a2d76d54757885d1",
       "urls": [
-        "bzzr://f7d73e9b221345383d49629aee97feb49a454339b8c31a3ff135fd57685eaa3a",
         "dweb:/ipfs/QmaDkx6JGoXGe6u5Qc5k3JJfgUULnMUuppPNqCcEzxwLYu"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x26b8447660363201da6eeb1bc385c787665e021b10d030880652451310342fff",
       "sha256": "0x390d14ac47b4a01e4f804a57159ffa526c2329a0eb08b9e20dee00649efb3461",
       "urls": [
-        "bzzr://b439b715fae73a8c2471d8315575e4c79b541b0185e4f0da9a78ee08a903794d",
         "dweb:/ipfs/QmU8DmfWBdwWgTb5AZtkJeHBrxHkBV5dGprXvSVdh1kH2h"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0x2b6c452b238ccc907e9522591e4716bb5413ee8cfa7c4e086a82c16487959011",
       "sha256": "0x3c9b2e8eb98d4294fc45326dafcbccb46a70993c346c7d3b55aa0292b3ca0334",
       "urls": [
-        "bzzr://eb8e321524b2f48894c1668da98f2aecbfd79204544ddc07353dbff57792c18f",
         "dweb:/ipfs/QmeWo82KNFgwHCyVe6Cqj6G8XJcMbEM7UXMdSNviaaMRmh"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0xbf509bbb99e6ef89500b4f7ae7d7a7c4b85228ae71da485fe7d1c57d5533f78f",
       "sha256": "0x350d5abc5862dca43292426b6d4e592f81f40b02cda833f38406ba0047b6b9d0",
       "urls": [
-        "bzzr://318190b038a3eeaaa27cb5436fdcd27d27aa0bdd35c8462baf4e5cb2d6add544",
         "dweb:/ipfs/QmPAZqF436X578buawLseywFbvBQo54A76jaau9h9GEbZE"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x3087e10734e9af721d84795d384f4485927dadfa5e65aa0e648b2eb51dfec881",
       "sha256": "0x70b6f0a355385c5aea26c761b2e58b3216aa564f41e4e156813be3c47a66ae9c",
       "urls": [
-        "bzzr://caa56d91c1184ca7983dd9c6aa143de3f57f03290c5c8377de06cea4b61f68d1",
         "dweb:/ipfs/QmSFtnXbPxR5mJbZwrydD6ABPLJ3hNuBBux2hBtVen4yi6"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x98b18283a9a1da352430e948499d5d548acc760b84f8a56d1830c4ec8e4304c3",
       "sha256": "0x5b62105e89c229f5951d05f2b19af81163599c7f0decc04af81e253996366aaf",
       "urls": [
-        "bzzr://3370e2d53cbccc0e70ddf342bd7fdddfbd6c583fa4b2c335597a0ab73c06e81d",
         "dweb:/ipfs/QmNboEZDcAnbuHki5Apz9G1nYnaeMRrmpazGT3p72jb8Z1"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0xb440f4b7c3255a977c55e8cb920777a97ce92ad565cb016eab6ebedd43a54d46",
       "sha256": "0x48454e290effd1b9b2aa860013deff09a79b4d7472875a07f3e7d547df297ecc",
       "urls": [
-        "bzzr://d392a01d93bd53fca27da9126452b7240577e1541144521d76616232665ce4ed",
         "dweb:/ipfs/QmX7eboJmijaznyXcBERoc64rWVwXQseoBuemAz7TieUta"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x43f5c0bd6454961553e545545b01f63cd211bdf4c1bff904236c308b1caa0456",
       "sha256": "0xbc816f2104d0e316179bce69afcf24a48b5c6c7203cb72becad7d9e7b66990b4",
       "urls": [
-        "bzzr://6eb5b621d876347c431700fbed4853eb598d3506c5911df918283ec4452afef9",
         "dweb:/ipfs/QmYMz5h8r9mu29uYtdLSqB2E8mw9CxHs43f9KNmUwQVAGF"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0x6b11bfff1870b2b6410a4a9d97c9142325770c80e3620b05b7f78a7fa1fcdecc",
       "sha256": "0xa15f01700ec7e02f91bbdfd4b6ff4450b3c2decae173e4f41910a3cfbaf5d3d3",
       "urls": [
-        "bzzr://259dcd9c09bb9fbb50fbb3fb4b97a03cfcd47c3fb99fd7b75be10bf4c59835d0",
         "dweb:/ipfs/QmdyLZQ1LWwx4joeUYMN7rxPkDp4wDdMCgmUoDNQU2J6KC"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x7e3f9626d004adbe0b835b08ebec2c0373f46dbccc0b2b36119c545ec27ff701",
       "sha256": "0xc35ce7a4d3ffa5747c178b1e24c8541b2e5d8a82c1db3719eb4433a1f19e16f3",
       "urls": [
-        "bzzr://f9f1f3d03d7caca5683f5206ea2439d85183d086668bba688fd095ac9d67384d",
         "dweb:/ipfs/QmT3q4iWxzcF8X5ArX6vQpQue6f6rBP86cvti4udk6gMbC"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0xb93ada00cffdf9bedc152f8a095c7694cbf16f9f0d0be5d27ec44814fb4b67b8",
       "sha256": "0x5c4b30da18b0fa5f1ae3183127a4dcd64a279fcc15e16a477b0841d576770283",
       "urls": [
-        "bzzr://ebe627323633c0fd23bbfb17ced455db9786dff2d30d9be30232d0076660a8a5",
         "dweb:/ipfs/QmYZEbZxXVZbapmzXdea86J4e6RAADa3kyFTNrqCWoiiJk"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0xe2087f40f53b10f8c28d84c5062da1659d99ad299a4d1549ba676163d7d682ff",
       "sha256": "0x499c2aad132ffdf7a59ce87d88e4fece2ccd63f5ab7e283b1be4c722b06206cb",
       "urls": [
-        "bzzr://c04235c5dedee430f9013641993ac5ebc7d76c94b656ec4d94333217e3aab066",
         "dweb:/ipfs/QmVgKp1VC2vpGcdGtEgopvSiefLKzqHzKEnUf2gqcUzQj1"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x876d2cf22bbd0e036ad1d5ec15b7d611907319014d27832356001944dfcd19e9",
       "sha256": "0x109ca8c6b92f4548e78c72a64c47c614617d7b2b5e4b6f8b9e7d654fc5186365",
       "urls": [
-        "bzzr://4cd19e2db58f63d3bf597a478aa7152e44c9c25284d7d0f8ab140ddd5920d931",
         "dweb:/ipfs/QmbUMYf94qPgf4yypkmCgDdkUwViDpQJ6Wk5GAdmcoAwse"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0x69fba2b6f43131c1a1ad71bd79938a83c320bfe58066f1b8c3de5c53b17d2c21",
       "sha256": "0x601f874e2a52c759ddcc1074cb75c12848e2ce899a8746a43e2affbd28a655e1",
       "urls": [
-        "bzzr://0c4192b681918edb569a86c907f1e7efcb11b0cc1243c743fd58540cf4952bb7",
         "dweb:/ipfs/QmczLgpsCYbhNEVkcm3A8XsussFXBa3rBd4cP5N8n7thoZ"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x6caf7161a0fc98f00aa278f8adc243e2945282a5f9a64cb7ad215dcbf862116c",
       "sha256": "0x96ddd81ea7d94d6e7f1135f7b11ab1d0635ad5585ed94147f1fe39b1ab7266fb",
       "urls": [
-        "bzzr://bbfeeb7c451be78c94f5c8bd0d5238bdd59fb48363bd7d7f07f7ed8c3000de8d",
         "dweb:/ipfs/QmQsiknhp8sSbDa1Yz3Pxs2jJTAMBFnXTJke2YqsgJmFdL"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0xdf597805353d77648745b8fcd9280cf03bc9ccbadce9832df6a94dd63f2164cf",
       "sha256": "0x33276adff8f0e620adf71c4ab66d748d0690c34360ce4f55e0d18c77fa13476d",
       "urls": [
-        "bzzr://cd7ee6bcef98c2825cf62e5f1d9224c357c2977862d9aa504d30fd94fb1d0666",
         "dweb:/ipfs/Qme5AoEsw1knaoGJk2GhwBbHpxFcaxJoRnvUip2qqqZMgh"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0x802424b83dc8a24e867dfb26b5e63ab553f01ab0529690c420b54d3517c5f953",
       "sha256": "0x5d8cd4e0cc02e9946497db68c06d56326a78ff95a21c9265cfedb819a10a539d",
       "urls": [
-        "bzzr://8ef79a241e86c95822e096d2fa48b990673cbb53102265d9ad6732238a8d3604",
         "dweb:/ipfs/QmfUrBizg8wPJcY5VX166LEidWNyT2GWjqunEVJHY63o9E"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0xb287de7e2847e25b8b07ce260ac6a69ff679b35e1657f29840abe29b07b1e1b6",
       "sha256": "0x20263aa17c2e7ca8c10ecd3d4242df61db9d549bc1ddb72b9a387c0c1136c1cf",
       "urls": [
-        "bzzr://e916a33d8b35fd712dcef219aeb08bdf17ff0f9e939c0765a5d83fa07e36c6e0",
         "dweb:/ipfs/QmcR4mBvu2unSmwCD5AXGt1r8cPv3iSMM8cdHc8RKy919R"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0x79a7f7af2d8730ccb11d9b21f20cd033c1c0dac58490976e202f0dec24587c58",
       "sha256": "0x9f76167c78635cd048ca30e75d9dade57ea6f0d03b83384d640d5da38e8c580d",
       "urls": [
-        "bzzr://77d79270a51ce044c8525d1de127a6f2c303751d558bec1bef59839f4a10aaf6",
         "dweb:/ipfs/QmR5GGfqrm1cK6wg6h2D3RjqmV2Gn45emGXGVp6nxWSdyN"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0x8a2ed47fa7e1df9ee005ef76ae177619c5f4e7ef2fca378d910787834edf66a4",
       "sha256": "0xeb42bef5784a0dec0f1b54c260b376deb0495940bfd474c44b5be31c0b634603",
       "urls": [
-        "bzzr://21ae78060cf6faa09fcf7823bab119e10d6fc8f89f2ea3f54bfc3092a394e28a",
         "dweb:/ipfs/QmZuLUuX3FgzFLCiEtzHMeaaRqiyvhJRnezxGg6Tk2zNkQ"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x21fcb7912ee577def32c50261fe40b7b5f47e31889a66eb24f5c0173b76430aa",
       "sha256": "0x68c414ba78325570a34817a829b1f3c62a18985708a2509729b50f79829a374b",
       "urls": [
-        "bzzr://07ca755f5c200e94effb587ddb9870618e5b8eff3cb2d4b6320db118e1ec70e8",
         "dweb:/ipfs/QmeB2irmzLRG4ijqZepyVKzRptu8LXHisBUYsHD4xJxfqD"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0xb86c9264dcf7f5c95fdae2152e585e0ae27cca7473eb3846a8529bd7f201b031",
       "sha256": "0x2e091d5f13bea0bc445c7f674d5cf8c9e42a3d4e35e1e50f00f4dd44898505aa",
       "urls": [
-        "bzzr://77cd25017a79f47a4a7d89ede8e6dbd444568da0434d6b23a562ada1d709526c",
         "dweb:/ipfs/QmTeKeZRbb695CuVMFtxChsM2B7zLEb9Yc69bDLCerPtCU"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0x29aa693df3ed607f8dad19d47eac620c3db0e3f80eca94500b22c0f9975e6cb7",
       "sha256": "0xf6cb519b01dabc61cab4c184a3db11aa591d18151e362fcae850e42cffdfb09a",
       "urls": [
-        "bzzr://9c92be120b892904eb7fb993724e9afcefe1acb49c8b53a71e6e154bf0df8fd8",
         "dweb:/ipfs/QmW2QNCj3nqoBsNjJCQX5sg6pNKUoU6SjpVgvJ6j5P9Qsr"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0x2835bcea8a4bd76205a1734604747c3418039a78395034be4e25323689c34921",
       "sha256": "0x117454791903d34587b7b07626c03253c6d4472b6f09f72ee007cf1f220b49e9",
       "urls": [
-        "bzzr://4c426ab9c8545eee06aeb8288430e6653c1325b858b0e9cba99e26753b1b80bf",
         "dweb:/ipfs/QmUKUg8pGVUiSdcoZCKbk1dctFxvuGpMN9QjHb21RhUqYL"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x2e51df133f8a2a242ba061662ab3eaeb4443b4d903ebfa2e73dd264bab06294a",
       "sha256": "0xc0c49402eaf18353e6bfb8fdc72627eca5d2d63fb36a5ea787114dee949799aa",
       "urls": [
-        "bzzr://f27ee269598fa41541b53d7346b679d2851c2425c000eced8c4734e5c50b3f41",
         "dweb:/ipfs/QmTjxYdpykbUKJVMp8sCsdU6pLsYJuvthaGupRdu19TGVg"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0x0f1fb44ffea640ecd278fbe68859391fafa076183e9e5d3a2684c7eada34a7d5",
       "sha256": "0x759930b396cda0d17621dd6eca8aa16a3570145960254431e6c42e81626e5a10",
       "urls": [
-        "bzzr://887fae3c92d4ddd0fb35f17a10060c20fdc953b95a602c1cec62bc84bf756f70",
         "dweb:/ipfs/QmVBDrv9CPZBnucUNASqeV2gWdJzTcqDJZr1mutw4TKB2u"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0xbd9427ebf103bc57b76c2d58b56643251bf4070aa573cc53bf10b0e1046307eb",
       "sha256": "0x2a17dea3b1785eac45e6af0ce328af68eb943a6463b36e03d31d99d7651a28b1",
       "urls": [
-        "bzzr://14a344535f797bb68fcac5061834d2510c24a0ccf1be3029d8d9dd8d7a389a71",
         "dweb:/ipfs/QmcrNXLFH9Q7t6L94ZHSpUC4oTgL9sp5qYM6Ws8zMP3TKi"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0xc0276f1a865e4403c24172c53a540b5c6177d1aa52e0631b2d4689c5347f51b5",
       "sha256": "0xe0fa6a8347a52bc6ec351e22537e645be06eb5041894460b1a9114f3732e9d07",
       "urls": [
-        "bzzr://825d909b0212b5c62a22315a29afd7ffc49e33efaafde190ad2cf5015b1387a5",
         "dweb:/ipfs/QmbwNDaZBPRpcTKrw4ersHpidTuprKwc2A4Dub5hw2QsWr"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0x843edb5865c0668a6c7047af388ab8d3a6286006fe8ea8b3c3b2da1a873fd633",
       "sha256": "0x96fb22134c10939334c62c8c0a668b712696f8f81426e6fcf042f0e709e7aa1e",
       "urls": [
-        "bzzr://37a486de05ca46f2214e89fc2fbf80bbd985e9a9f7af191350de517566444840",
         "dweb:/ipfs/QmWuiwFpMVA6Fwnfmt75BHbJ2294P7ZTcSBH9iUxz1inux"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0x995f7d67d87a936dca9922389e6bdbfd2febb3aabe52beed5a43f73fb45a5146",
       "sha256": "0xbd69ea85427bf2f4da74cb426ad951dd78db9dfdd01d791208eccc2d4958a6bb",
       "urls": [
-        "bzzr://dc89697408277a96a802a0f84f113a65cd0923206403d6c6cda9a99f9071c5f7",
         "dweb:/ipfs/QmUr3dNEKNCvsALhMb9NAhiX6otFBGfNpSXniLUn87hSoC"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0xcbc4fc0c2aa7976afd378608aa5702e2d53d5df325c0c29c894386e5cfe7d327",
       "sha256": "0x64016310a57caf1af76a3610f1f94c8848c04c9673e7fa268492e608918a4bdc",
       "urls": [
-        "bzzr://a541fb3df5f6b7ebe0716a958e83dd540ef820ea7b40d9835962d219d4670cd8",
         "dweb:/ipfs/Qmas3dcZXXHwBtPp9aKCxZfVoJL17ndUHSUdBc2cLzJkZh"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0x0fbc7448fd94f69159e28505bd9afe1a6fd3659a4651884409f04f55cfbad754",
       "sha256": "0xdaa7f6d6cc0a316beb2607533183b64904798677b0cb99bda0549ea70e8de61a",
       "urls": [
-        "bzzr://b3f593c602c78873a90c3b558f1d5ee7587e1833b294630f4c9d03ba8850fcc7",
         "dweb:/ipfs/QmdsHDR2fbRsfEo2oorumuRsdAGXwhgFyssHSqcWV2eqaR"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0x1cd8e6d1f694fd6287882c57043a0ac6212788eae7c9ea10125b5ae85a3a0e27",
       "sha256": "0xb6b9429d71d4395901795936a0aaee0b23082fcaee10d563d87b42e69c0e68c2",
       "urls": [
-        "bzzr://bf4d50233cc84b7d827494fdcecdfa0b273811e02b6b920daee0440eed77f0a7",
         "dweb:/ipfs/QmXb4CcPVvKfnst6xP7W8oeEY6XLCd9LAMzpKnk6PEu3gJ"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0x8544a5953ba29ded6dd78cba0343c15bb99f0994f8252527c1d8ab82d49f75fb",
       "sha256": "0xfb33afd761d0d704671dad582d3b4a790d4d85a6370fe71b3f8935649681e292",
       "urls": [
-        "bzzr://95d6a343a95590a185e7a34419ee0a55b1870979206f6d30bb1e780b33114d09",
         "dweb:/ipfs/Qmb1AFeoZzpy32zDG1A4dqRXwk6idm5z6pnxkv3rU1toLV"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0xd13637ffb69029cae89a865066e78772d3264c0d05674c973a637c768f588f61",
       "sha256": "0xf7115ccaf11899dcf3aaa888949f8614421f2d10af65a74870bcfd67010da7f8",
       "urls": [
-        "bzzr://2f553b9aa9558949b90795e49298cb74ccd99b71bf44f1b038bd4f9722f64328",
         "dweb:/ipfs/QmaH93CFvM25yNszPFokJqsGhoEs38fT6ib6M2WQwhwxqg"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x81b1b9610c05be13dd2294f1419c095131763187914358501d85789c3c051ad6",
       "sha256": "0xbd782007a7d50500d22703145ace6d44c916c853cd0d0fcb2caeab9fa5fa33e7",
       "urls": [
-        "bzzr://9b2f9cf220a2e42f3f33e7fa473aeddfb31f30d0a2acd933c75a73a507fb974d",
         "dweb:/ipfs/QmaVmPWbjGrVaS9H3XEKqR8J9cYfqAPobAMjzRGNVwK2Cb"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0xd82f930c3db5da803c7b634bfca624279967da3a53bee1e2cef5b74057438a2d",
       "sha256": "0xabd5c4f3f262bc3ed7951b968c63f98e83f66d9a5c3568ab306eac49250aec3e",
       "urls": [
-        "bzzr://4815ed102dbe75cde56e0c2d89a340c601c6b86e78485937bb2ee2b3a1951f2f",
         "dweb:/ipfs/QmTVGXJndEL6a8XHyxqsdZBh36BV3GQzZtV327P5TD8pfp"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0x0163c110432e288bef6ef2c7e7c043e887459f5aee018cfa8f5a95f1a5d32746",
       "sha256": "0x003d75383e45212f9812d0b6add90329fd3b239e6c378d2882f61f9345896d99",
       "urls": [
-        "bzzr://4f16ed229bfb441868ca5cacf6005671a0fc6715c098c9732b6cf306bae1ee5c",
         "dweb:/ipfs/QmW3LxYgQHDcUQp1SYMmHNRoLDrKyY5hh4czR5ZoJ1ByQv"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0xd2f57fd0233d9ba2bccfb29498da59ee02c0433e07b9a99bcbd789b0cadfe99b",
       "sha256": "0xe677b1216b136c61e38934a3de3a8e67de3f733d7ab28f0f046bd4a078b0cbb0",
       "urls": [
-        "bzzr://6354038df1fc237e1f501ad38f8270b70e05481de75ece157b316abd58656886",
         "dweb:/ipfs/QmUfzeuKDqyhGtFK3SB7mNFth4jXnnaSA93tsiFWVQVro8"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xc3a70946c825ecd5d7ce2db1ff2e9a608f1319e8912cc10bd1be9d171617066e",
       "sha256": "0xf851f11fad37496baabaf8d6cb5c057ca0d9754fddb7a351ab580d7fd728cb94",
       "urls": [
-        "bzzr://50b453a11c6b9a1f944cec38d4fd803abb75a4eb4a592592a769c38d773b5415",
         "dweb:/ipfs/QmXV9woKT7inPFZEMhp2QiSnR7uMavef9CnBJoMUMdWVcb"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0x915372f0d78e22a4fd337d3b0f13a7fe5aac57ec120639e7ebd066571a8e4420",
       "sha256": "0xc7effacf28b9d64495f81b75228fbf4266ac0ec87e8f1adc489ddd8a4dd06d89",
       "urls": [
-        "bzzr://6303ebb014b5fefc0a72f8a0c034994f8ad65c0c7394e8ccca37ea780e6f2866",
         "dweb:/ipfs/QmSq2hGDMwASXwvEgZVkaUcpfBMwzQEWDnPEFdPTyHabmm"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x222e13f9ebf5119083e555823669a7e537475450986bd1d095124e240d98e21c",
       "sha256": "0x717c239f3a1dc3a4834c16046a0b4b9f46964665c8ffa82051a6d09fe741cd4f",
       "urls": [
-        "bzzr://4d8a2aeed9af85852274b64edb3b8512e5680e9ab219d712383e5bd1957efbdf",
         "dweb:/ipfs/QmTz8D5wkVmW4jfMHMsi638XBXQc3fWZqk2QJPz2Hk5Jos"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0xe18e051fd3770fc0f2678ea2975b33212feba0f5bdbece0aef0ac96265a218a7",
       "sha256": "0x556c3ec44faf8ff6b67933fa8a8a403abe82c978d6e581dbfec4bd07360bfbf3",
       "urls": [
-        "bzzr://ccaf2bc010c8d3ae9dc3d2c83092a1ee67dd2fbb34fbed42a08c5b315e84cdf1",
         "dweb:/ipfs/QmamYEMfG154iMNydETqvGnpQDWGXEmu7cg6YHmKWDbNqQ"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0x789ce72e01f83cf052b543d6f0508c2ed2adae7ed40ea37913d9bd90166040ce",
       "sha256": "0xa805dffa86ccd8ed5c9cd18ffcfcca6ff46f635216aa7fc0246546f7be413d62",
       "urls": [
-        "bzzr://73cb255e06cd0f1eb3abf03dcb915f4843728f2783e3535c76f547b87eeb829e",
         "dweb:/ipfs/QmSrfbnJcgUXUjT1oEAMQ77LC1MeEDxVfMGYuCJVRnogTr"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0x73c9a363ad79aa396a706175521b9ccb41dce2a2eee9f04b58dbac87b1fc8614",
       "sha256": "0xd5b027c86c0f8fecc024d5d4f95d8ea48d8a942d79970310e342370532b502f0",
       "urls": [
-        "bzzr://a46ac2b6fa96c949a6f70c05b07f378d565ae51f0de1b6bfb5ee4dbd13820019",
         "dweb:/ipfs/QmPpPcCq91ufSe3ZCNjWs26nuGEuuUNLcgX5Sa3y3wPiPk"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0x3811602585e07c5404735f5bd329b11619a855f40ff2e1428bf95cb10c1a57ff",
       "sha256": "0x5189155ce322d57fb75e8518d9b39139627edea4fb25b5f0ebed0391c52e74cc",
       "urls": [
-        "bzzr://151d8aa0efc4c02e7d5656b9d2b926dedd3207ca010f787bf2ecc0564eb3c3e4",
         "dweb:/ipfs/QmWdaqCBgtJyXJS5R5CbUYzxqbBuPxkKnKNxVmUtFGf2Zd"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0x88dde999590940b17b34e657c40067918e0078b3d903548d4ea44fa259ff2b71",
       "sha256": "0x1632786c6c1f856a4a899232ec975a12f305118f43cce90e724ed0b2eebfeee1",
       "urls": [
-        "bzzr://3061e1e12ffcb7dbe9f7b198bffa3a3fbd0d484e27ca96888b9b944a384e8b2a",
         "dweb:/ipfs/QmSzG1PQR93uiUs3ov12vetPkfvJzxQZyfpeVh5WMGW4Uk"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0xca03e8f6474b5becc8c28ad61830a23761e28b0dd53a6c89d48be89ab82e3a34",
       "sha256": "0x99f2070b776e9714f1f76c43c229cf99b8978a92938ee8d2364c6de11c1a03d4",
       "urls": [
-        "bzzr://f564ec3270c16b1bc458d9162cf10f26dc5d0a5884912423167f973a6dd63f96",
         "dweb:/ipfs/QmePhTsZLZJfEsMSWpB36NRx7vZQuwUoysGgKaEdZLtnHb"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0x932901581a2ef0795851363522811fa160db5561e34cbb306e7105b6bbc3834d",
       "sha256": "0x95e6ed4949a63ad89afb443ecba1fb8302dd2860ee5e9baace3e674a0f48aa77",
       "urls": [
-        "bzzr://61828ca55d703ddcd2ceff0e20a48ae6bca28a58b09725836893dc5f6b8e8018",
         "dweb:/ipfs/Qmf68UBPAspGAh6TJ1F9zKLFy3WjvH6W43HvzWWGAUQXTv"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0x8da560f93223e19fbd973f12a29f765869559274aaeed3f795738ac433130ab9",
       "sha256": "0x7a5c1d3dc9a8eba62bb2ec37192c9178ae5fe8a54a56e5573fd3c9c17cd9eb48",
       "urls": [
-        "bzzr://49229e5b39418fb70d9aac067baba0a745ad1ce4c01ce1a97fe6a73bc416140c",
         "dweb:/ipfs/Qmdpou1M3LCvJNUihLD2cmopbpbeKdhro1YvkT7KfpaTvt"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0xd68fa7092d5af50c1dca4d6318f8a2470b11a766794814e505e3cc6a587deebb",
       "sha256": "0x0479d44fdf9c501c25337fdc540419f1593b884a87b47f023da4f1c700fda782",
       "urls": [
-        "bzzr://ea20fb34f982032a6bc6dcaa895429b859d7cbba5f80ba2b3343df65c77f2d2e",
         "dweb:/ipfs/QmVhca2opoR2DEY7v9ntXHETfytq1jRMnatid4UuLNCMyp"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x00bebaa90cfcc8c807b6b48cd8e9423bdbe5b7054ca0e47cbe5d8dd1aa1dced3",
       "sha256": "0xf2857a898be15c69e8de5598dcd3f3e169e94964a0ce9a0bbb1b111f145a81df",
       "urls": [
-        "bzzr://b22588ecb5c35fe0754c755b50bd1a1a7533171138e04970fc9c4dd2fcc269cd",
         "dweb:/ipfs/QmagT6RpAi56zzW3GiFED6q9ztbgrp5WXomBzisbbRTYPg"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0x0e8190e07b0928bb7c9523cc5f992430fffec6bccc0dd4bec7937039ceac20b8",
       "sha256": "0x8be0aeb74fc1b8213292a09a84cb524a403602526df87ecad5f5cd2a7ea7d089",
       "urls": [
-        "bzzr://e51e0fc25e86d76b070a9e1f97fcbd16902f18cf77688782388a6731f1635d1c",
         "dweb:/ipfs/QmNaGrJcjMiTU66QndCZMSHeTv2WbCvWyP1R5KankxeZHt"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0xf105026f42acb32bdad8d3dac86bfb37db9d9efdb0c730ee509a9cf3fdb1ec1b",
       "sha256": "0x28726a452290c70e1984f15c53ad3088e7d98783ee3070b11b3664da77415732",
       "urls": [
-        "bzzr://57ffacd9e36ddad5f6716914cb652c6ceffe72c5539b39a7ee88941d6fe939ee",
         "dweb:/ipfs/QmeC2pQS54j76BP85Akhsv1XEejqv2zxyK4mJvio7Pu9h4"
       ]
     },
@@ -956,7 +877,6 @@
       "keccak256": "0x5a127e73ef8c90f2df60ff2fe9dd79709da9e90d2d075cf05784c9a3efee2528",
       "sha256": "0xfb03a29a517452b9f12bcf459ef37d0a543765bb3bbc911e70a87d6a37c30d5f",
       "urls": [
-        "bzzr://696eac6b03201fe1e090f793ff3abcf862d738195e3db0da14c1cae1dc9315f6",
         "dweb:/ipfs/QmZ5YMZQfiLhjiXoPQBxJyY1KPVPzhUXDbD1B7bYQCVKjQ"
       ]
     },
@@ -968,7 +888,6 @@
       "keccak256": "0xce0797c0c76867d0bf6a1557961af6b9252faeee4f4802ce91d0b51c9b44e7c4",
       "sha256": "0xc42aada7a52057ddbed93ec011235e256c564c440b68dbaac5ae482babbb3d6d",
       "urls": [
-        "bzzr://158c03c3634e2d2818ff8eaecd989d951db63b3cbcb7027ee107b25ea4e783e5",
         "dweb:/ipfs/QmV7iyWgYrW9B3NzKe3SHZU9hN9MkHFVrGCHxA13MhmMqX"
       ]
     }

--- a/macosx-amd64/list.json
+++ b/macosx-amd64/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0x662f94643bbc549d00fe7cfdbcdff504c78c697b10dcfca645d6082d464c1402",
       "sha256": "0x02d581b5b373d8160b9e75d690dd2ee898c3e0f6a39bbda54cd0698224c09df4",
       "urls": [
-        "bzzr://f8f4ef96514fda43ca31517a4f493aef6224d72ead70ac0b4cc36a5d341901a6",
         "dweb:/ipfs/QmR59SfyA5TETyhBvxgZBvhedSZyA9Ka2NPBGVbV9CknYf"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xe15cdf6bfd7a87c22aca862df0ed268c56d0a3aed404c56c92aaa1c02b4738c2",
       "sha256": "0xbba6e2c33935259c478060501a7fb0ee1db4b0c56567356c9d01b6ec0491a558",
       "urls": [
-        "bzzr://e130cfd6a4369d932e02220b164417ff025a6967ac2a4f4241140eb08793c8f9",
         "dweb:/ipfs/QmWtKJmhaLmaLsqQW5Bptq6FADF7WCaZkmMQdKdzi8bdUw"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0xd0142f44be7a230ff448237472451521abbabcb5d75d388346d1b7cd1e9e6962",
       "sha256": "0x2de730163c80670b2f4c1ef78dc77ab13f757aad1ead044761821293275c382b",
       "urls": [
-        "bzzr://441e085a6f97965273b9dc0cae1870fdf769473db11aab99a9fc1dbbe073e7b3",
         "dweb:/ipfs/QmQhL9fPTox8eJsiSxzFyUjZ5G26sy2BVUSYXLya4KpcWT"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0x1b25df7ffcbd8bd77346482483164905ec57837bca8a6035aa4d32beb11434ca",
       "sha256": "0x9882bb966b82c0f4847735dba20b517118cf5408ed2a872485750f6ff26cf98b",
       "urls": [
-        "bzzr://5d6baebbb6372afa3c0d6185de44709dc9fa0a69b239bcc06612eccd44f80216",
         "dweb:/ipfs/QmcjAyKwEdj93CTgL4DNYwgSzigb6ZhBtEzWpXBjs4xJvr"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0x41d167822f3ab9cf03e4e3dcb800aff49a93cbd2b5ea37941777df80a5bef69e",
       "sha256": "0x3ac02a93f4c7c20b9f17b6038af25b41acb8cfe178040be0f2246adc8bb8fe0a",
       "urls": [
-        "bzzr://03a77f58631ae16e81aa85c6dacbc6bc2ca7c34c1073171e2562ef0738979570",
         "dweb:/ipfs/QmaZZSYJV7pYHTDJTX44UsVrSS8UkCX2xBx3FhYyjzP8bn"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0x66721111ee0d4c3d718832ac2150fed55b3d61baa4fcf0f3bfcfd6d034f7515f",
       "sha256": "0x38ceeea801b5952d74bdb79ae5bc6bbb4c187ee5941e2701de388fdf95322f58",
       "urls": [
-        "bzzr://fe16871dbb1f5ae55e7fd4a2feb2e57f10fbe9ae240c408d74e4821544a71cfe",
         "dweb:/ipfs/QmWcNcnW2NiHiY4Lm1DaEWGgiBnHcDh8NjAJzmxtEewHC1"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0x5171e0d6ee047330e44c5b041a579aabe348482145405449cdcdf70c089db66c",
       "sha256": "0x003b09c2f255d2a40c2b2a1798192f92e6a3f1b35bda1a35ba66675919be1555",
       "urls": [
-        "bzzr://77fac88430da037b2559f5023168624a071f4ecadf5ea6c65d9689a2e1f829cb",
         "dweb:/ipfs/QmTVDBJBqUyoJVXYYAYGsL3udgx8QrTcTMAADottWRCYpi"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x6ad5195014b546f57e6dee05a5170dadbedde6f657893da05d9da1416e45e2f0",
       "sha256": "0xaef1ebf2d2783a31742a612461f13e0ffc656c4a5ce25a0eeb747186ce03b276",
       "urls": [
-        "bzzr://2aac1f5d260866e1707f750fcad9eb253afd35073a6a97aa1a62121fb78d6a0f",
         "dweb:/ipfs/QmbrbFFvcCstpF8sVoSP8sPt3WYqHfvGmZ8zKHF1syx8uS"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0xeeb96fbbe5b942c2c6ecf8a0ca4c0a88d290731a56782df8e52284aa3d48e754",
       "sha256": "0xfc386d2547b6f764a0c1139487ed1d4a19e334c510a727614ff8ebeb1bd01a93",
       "urls": [
-        "bzzr://518ea2503a211c4dbf511dee27dac4a367820273268103c14d0366400fe639da",
         "dweb:/ipfs/QmWoWxZpANYVnTwSf9ef1BG597NVDkxVyJzdxMcp1qTKgs"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0x690ab93a9d9d5174e699cb58f4898391ea112850d95f5ecac25e259f36505dad",
       "sha256": "0xebb64b8b8dd465bd53a52fa7063569115df176c7561ac4feb47004513e1df74b",
       "urls": [
-        "bzzr://1a6089dc3d33e3bbec9f0a9ccd04872282b90da2563466200bea21eb72b8c7c3",
         "dweb:/ipfs/QmRiR9xu9wV3sGmfQbiWjDHnbpa1HfqwSeudL831LqFBYt"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0x31fa8fa8b04ddb729490ca59fe1e212e8b1d25f9fb19de190864a1093d7c1609",
       "sha256": "0xa5b4227ed259c474426d8a2ef380606766aa8ba7f65487ab177139b3a51f0dee",
       "urls": [
-        "bzzr://06fdc632eda9b6916774ba35432bc0f02bbd2f48ca8c8675db24ec5a902b82b6",
         "dweb:/ipfs/QmQTVdW8cyRGPXEWbpRvinZBDGBYhUAsSZSf7Khp5VQKNQ"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x7b642dedbe89b221e7ab15c1b67d18aa04e4de91f987c5d2b8ff90c0bc761e60",
       "sha256": "0x40f179e4d27201ab726669dd26d594cfe10bf4dd6117495ee49d26f0dda9ef42",
       "urls": [
-        "bzzr://79a004dab9401b9e45c882ef19929ad3141af89b3d3f9fd8c21f8cf3310703e9",
         "dweb:/ipfs/Qmbsi7dJy45HyzkprNd3QuxARRedNH3akSLwcxibGghGaU"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0x230569faf79408fec44b931151f7113006e4b34038b55eecb2a2d1dba6407c60",
       "sha256": "0x287eab0187dd4bdec50226f3173526bd8d247adeebdf64bc0b7448711abbea61",
       "urls": [
-        "bzzr://9cd6f534ed307b73097d1efa92f1fa12c4d44ae45026549e3d6c968d8c351e97",
         "dweb:/ipfs/QmZEGqT4RLTC6ngDzP22MAunduX537gdBD5FuHMRqWPzGi"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0xd347f34d80512781730a88a35f54ea60cc8f22f41fa89a90fa23d6067e48e9c5",
       "sha256": "0x65cc92c918d6334f533a7596f62916825fc722b2a7a235729ed87cfbec622bcd",
       "urls": [
-        "bzzr://e6b9f049ff3fa866f1289081cd7696d0d60f5a6532d785c1453b8499244e24ee",
         "dweb:/ipfs/QmUGFo9on7dTJZEU5JUZpUpgat2B9dhyawSMxYnYVTmuvP"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x0715c4a2295fae7c057d810535d83cd34b280a2296cd7fc83efdfa2f38d5fece",
       "sha256": "0x701eebf0e37d172cb829dc1e65c74a46b3b96737f3866758f9894696a639b6b7",
       "urls": [
-        "bzzr://2b54f83e600406898dc18ba2e43307c79c49f29f1d2fdfdae0afc9b8f20a3d0b",
         "dweb:/ipfs/QmcTSjhWs8WCjqAoU8h5Wo5qCstmwxnNsDtGMzNu3F6MiV"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x1fbb0477543b5d27102f095807bf68ec8f2ff23b65212869fea942bcfe6f1e4d",
       "sha256": "0xa4ef22d9d36e75151bdd64720e69eddf57500883dd623c57805edb5ccb644a89",
       "urls": [
-        "bzzr://826435367348f6ecab540323f9dbe55540a0d0aeb7336cf7dfee5c18bd0eccbe",
         "dweb:/ipfs/QmdfbxCdhvrfL24y78KNzqUKGJzRHi5H8ckW9p6GLTZr72"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0x64a70448467ddd8207ef0917b405ec5378a31b8b8e71b896f72c7b2721ea8366",
       "sha256": "0xe449a4980db4ff18e7ffe704b40083cded96cccf33986bf6a6bb6fe925eb86c0",
       "urls": [
-        "bzzr://d12223b8d998d355bb53aa8806ca68d64303521ec0bd33a263686b62ac47dcf2",
         "dweb:/ipfs/QmQrFUVDkwGfDeLvnX6tyTeEQf4ivcNYEHBGUmhZan1jTg"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0x05d5bbd0dad953327dad1fcce80e5c44dfb04995d8ad87a3e7078eef6b4a83ec",
       "sha256": "0xa24512aee16652c4469979715bbdcaa6c4afabb94b717bb40980e4b2d25c4709",
       "urls": [
-        "bzzr://f69b11c78859b4d63777a18ce8320989a814a75751e9a1e7e8c958574d9b7089",
         "dweb:/ipfs/QmeHjMa2nfHsQkPHd2ameFYTEM7dRHtFvXRm1TzUakfRSA"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0x52b105a3d36e2fd2b99e1fa69e4366035810c93c92baeb27ad9d37a29391a23d",
       "sha256": "0x458c3e2de2ffe609b79d9cdc4eb3080d6ed7662ef1bdd7c8a03fb18f1ca9a137",
       "urls": [
-        "bzzr://caf9f5842fe15e713653a69236cf51f8cb2bba9b29f03915b6588fcce8b9267d",
         "dweb:/ipfs/QmbNCaPHNdpaHBLYcAEHVFjms6TKfpo5maU9kS7fj2zF32"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0x6ed8a169695fddb45e22975b416b6ac8bf5758f6765a5fc45a7708e266bd3eeb",
       "sha256": "0xdddc86683d12d0f016b5d5799ed84f6f2a79f667ebb932b9a8e6bfe9a48c3190",
       "urls": [
-        "bzzr://61696afc061612e49abd151286c3afef433f8d0a9e2eaf9527bc7fce7f3a5a2b",
         "dweb:/ipfs/QmQBofdea6hmCFSurTKyiqVW3dLC5raFiucVG7k8tFq26y"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0xa291d2f1fb5d75e61c3f07e96093bce7fc0ac1607c609bf352b434bb9158170d",
       "sha256": "0xace5107a68fa75634e26848d6d208b808a76cc4f9262e53e8a3622bcefd4dcaf",
       "urls": [
-        "bzzr://9971fb2527a4627a4f74efec763417bfb80da2da2152a030d86112861378947e",
         "dweb:/ipfs/QmevE3c2Bezj8ommRqtY35SjrwRHUEMbJM8LntWHzqB99n"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0x035cf886038fb4c4afe8014391c8432cf91997971f37d2cd509e8dd56a3f7f71",
       "sha256": "0x47425e338b9461d3e6498a0b0d5c2b9cc7cf998e4aa69126ea9f64c0a176e605",
       "urls": [
-        "bzzr://f07a63c06de8fbc236ae8e90d8e936656a1b1cb6d4009685e16382aa180ed6c0",
         "dweb:/ipfs/QmUUkRBTZ5KF5yZi8yzPVn7wrMr1rL2NPE7xfyyBCsbGxS"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0xf5cb6ae6e7ad8d7d33e0dfb310691eff9fa18f27fbe8db2c3a848812ce38e1bf",
       "sha256": "0xe035cb9a81b5e3e11a7b99ead6f51a3ef7729794eebee470a964e2c08e30b857",
       "urls": [
-        "bzzr://6bb86ad1929e0eb0c499b0863324cae9f2c74686bba8961b23acb39c324b574e",
         "dweb:/ipfs/QmcgbaThT7VV5fJn3QrgMxXL5convCAccaopRX1yWii4CM"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x49ed59d22c36ff495a6167d4e34074dc0ad0c50806016fbb6e2dc111baf0ab09",
       "sha256": "0xa9341add7a4f01c52dbb36bb4028104676c684b0b6003a2cd9dd84a2a9802b59",
       "urls": [
-        "bzzr://e549af82db389897157316c7748c276d2b7706df4af04bd761e3f58b0b8efe85",
         "dweb:/ipfs/QmURjSdCxu4e6qpmFPArWjR5zZGaZt4gMxooWgUmZjE5ih"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x71f9c2c1eb71eaa97dc8cdeabb254f2bc460933bc59c2b3059aefab4942825a8",
       "sha256": "0x502eddb177f9268d79b1e05e6acfb2f229471823bf6711eff411d2a23e8cc0b1",
       "urls": [
-        "bzzr://8edd27d6b2a43ed0c8e4d3f4ab569d3bbaa58f18b7d69fe9c88913e2e074fd1c",
         "dweb:/ipfs/QmPHfgmtFZXrwb2jWnKSh3hXESNcHx6rRSoWPoDdvgyzKq"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0x287dc3f7742980f494c95d7b70724133b7f49d51132eb47eaef1423c87a6edba",
       "sha256": "0x7034c4048bc713d5c14cdd6681953c736e2adbdb9174f8bfbfb6a097109ffaaa",
       "urls": [
-        "bzzr://d2778b5ba7cbcab0e9fbf9c8b0fdf689b3b680c145c6f949e47ec4f023bb2189",
         "dweb:/ipfs/QmbPhCgU88uhyWjYF7CBvFiCK6etGssxUTNkV3QkBHgtMk"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x857693802947544d326f294238bcffbade6a49acd2e1e7204d7b5c0577de21ca",
       "sha256": "0x9dd7686975200be71ce731f153823e7ea0d68106f3354ea16fecd5975f5c98b7",
       "urls": [
-        "bzzr://c1011a43e36ca050aa9a00b52e7ed0c42176439f781e4d59f45ee496f37d3e98",
         "dweb:/ipfs/QmcaC5MrrbYP9jEHo4Pn4FLMMhSwL6z8RhheGaVPFvGJjB"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0x0f75819686eab4238b1f662667cd55bde1f923d022e83a547f5b9d4753ca7147",
       "sha256": "0xbc956645b792dcbb8f820b8010a8d4ec1e188f7b40c6af951a436da4c13ae677",
       "urls": [
-        "bzzr://1928511f27ffe8f44c5cff04e0f4f2787b67c816da9ea869d34628f6f499c7af",
         "dweb:/ipfs/QmaM4Fs6pzH8LvNFhFCbfgTfUo8nmZTKugfxmN7Ze6tT8U"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0x0a89e22f8423a2ee551b4a7811c69321a06a70d8a00784deb712c6cf0757fca2",
       "sha256": "0x9fa663fc427e8e9613815ad6b83783b4e4cb10439f16ca0dcb12fc002c45ab5a",
       "urls": [
-        "bzzr://5f7b9658b980f95e54f2da92b39e02af3e1c81a8aca603955c3492b72651e51c",
         "dweb:/ipfs/QmdHxa1Z4fM3mFxueHba257rxyxD8Vjqg6a3n8GzvMQqFz"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x7135a9fd0c2e6cb403adbbd0534f22b8904bef330f5debaa4c240d7d5bdfd5ac",
       "sha256": "0xf2bad43386065684b4e15b86a175410f5d1e4d234b052cba44eb50f4c74b021f",
       "urls": [
-        "bzzr://060a48f64c36ec851b09dfa80af17a219db1945b1bd078e61e2e59287e5f5477",
         "dweb:/ipfs/QmejDUR2dLS5h6nrqt7x1pJ7seBoo82SJpRYBRW2qN2VDa"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x7a87045680f25893ebd0d14c36113303ee36864c715dae6b6bf60eff7c6c6073",
       "sha256": "0x9e7ee54f0bc2978fa8738b9603d636715a069d84771778d6195577bb91ecb9c8",
       "urls": [
-        "bzzr://6f84855b70c094210e3e0edb4549d746135a441ea5fcc5f3ac0e6bdb3d64225d",
         "dweb:/ipfs/QmPwnPkuf89E6H2U6mBjRUeMr6feD5YoAihnzd8a5HeQrF"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0xa3e5beb407a5396463e4bb17a100cd8e19d00aa8bc76496af4dd7e96787c53b2",
       "sha256": "0x03a6cfa2d74e57ea38eee83ce9a3ea37a6e50928d7f109e74b37cae31319af2b",
       "urls": [
-        "bzzr://b0a16ff7c23c5da577edcacad06972d6cb7fafaa5c9215699ad99f0b4be9f8c7",
         "dweb:/ipfs/QmYvHkxeXXk8sPUsVtzmetE2osWfEYB85PNhtQ2d7uxFKe"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x6ac8af918e4121b072d51212a4648cbc3667f0aa7e50285cad1291577a08efb5",
       "sha256": "0x32a8affa996d05c55257317cc700b9e5b4377d94919b59055564eb0b5f941773",
       "urls": [
-        "bzzr://c7033e1e4fdf923304d28a5e188cb4f4a11bced6e3178c674cc843ed4c3583ed",
         "dweb:/ipfs/QmUJFZ4To2PfV5rbqpjNCfBopZQ7VXzkLd4DiRYf5EFWN4"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0x182fc3bd33895c32dbb0613113aecd72f59f4330e7e7bfe5c47646abbdd26cc7",
       "sha256": "0x7fc0600cc150020402c9539ec0ad584eb9271b2d0e0bff9e3b4d4ca672be3452",
       "urls": [
-        "bzzr://9bad36f6326e8adc929b3c95abd6c6580092e0a3508056773203ae34ca17830c",
         "dweb:/ipfs/QmWp2yX7HF2sH61XsRkwqWmngXEdPnKtcz6Ah1pQopeMUj"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x29720ecdacb43bad240afea74e98c21ee106ddcf9fba81a2046bcff698e66346",
       "sha256": "0x428f9c0873d88740242f6fc16a3ae6f91b35f73ddf7676b5d5b39687d9d9b7dc",
       "urls": [
-        "bzzr://f704edde1884e85980ebb07b8fb9feb32adcd605c19cb78a1195aa4021354d2e",
         "dweb:/ipfs/QmSsdA3d2CzD2cMrhid4yDsTy1USkBWDYySLSsKJGvtPAc"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0x02ffc634068a3930b72e9861207346ce033fc6710f11d288489f905b4c325815",
       "sha256": "0xa7d6b8e3cb22d90789a79b484b721fe02943f89e9b7e996863edd2d40ba7b524",
       "urls": [
-        "bzzr://dcf38cc06936a72f761c6b8eb77728d21d14e1130380a985893840c4f99fa140",
         "dweb:/ipfs/QmamAAci8zMaxZ3zCdQMm3Hke5ChCqLbRR5zJiCCH27QQB"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0x0fc5f3026ac39048101bffae40a053f6da119e57c0154445cfabcea6dd716cb5",
       "sha256": "0x9f383896c8506cd96ac5ef9c97d7ab1c385fb5f4772a5f3d2cf8715cae793554",
       "urls": [
-        "bzzr://5256f697214601e713a377821707ab7aa81e00a86ba63cd0291683629d5c3db6",
         "dweb:/ipfs/QmdqvCaENZmRPg6WCjh2hVhWTpnaU7yf2qvY5a3T4BMXXh"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x0d4aa467fe96d5c934201f5265a5c940e556551e10bb630481f88ff59070b8d5",
       "sha256": "0x92e3688207c0c2b86bd9d10088340e4a585e29e3a88d1cf79c2043f4f9f121c4",
       "urls": [
-        "bzzr://8b6991bceb463e4d1617c9e5bbb2f5fe40c435a5fcc76b8286f3581e56ae3cbd",
         "dweb:/ipfs/QmYQEBMqCFzJAQgijj3AQUXx1b1UEEUmM6zHw3m8xQwrsA"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0x001e08d9d1902a4f040e109b2b7e049371e687896409ad2de84dfe9b455bd547",
       "sha256": "0x5082bb5c492ca35b68b0c3e24d5934b56d3add83f1400ba95654e8f163c741ff",
       "urls": [
-        "bzzr://bae78448cfca3858a555580c0824271eabfd1bf808a15adc68fc00a861b98e53",
         "dweb:/ipfs/QmeXwGRydas256VMavRw4kPcT3fX1MY6LjZP28qmsnWPwx"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x6f0de51d7773d7670b5db78e143fd55809cd4490759311e018ad82b9f10d58a3",
       "sha256": "0x0e8ee89ddb1096b81c34e11bdb5985822e749d3a9dc4e7218ba2474afa6400cb",
       "urls": [
-        "bzzr://83204b31d6fa5fafc94244922a04ff84a63d5089e61359aee3fcb76935d92f54",
         "dweb:/ipfs/QmT4C8cecbPkS4vzkSYfA2KX1b4iqApEdQd4fswZr9K88u"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0x815157d38845c5127c3dd3ab399ef90c6139019f6bf2a807a08e612e74439d35",
       "sha256": "0x3dfb97bc941492afaea7f404c3fb9c6fe215b3386aa6e0370791b571e4679548",
       "urls": [
-        "bzzr://cdcd3c916db81ad1f05405220069ee136a17d0f51db613e627fc8a36897b5b03",
         "dweb:/ipfs/QmQhhZKvjDQVwP6eaahfro5srD4jZ1JxQwgUUUowi6NkaL"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0x472dab91d5bc4f7a4066a66869da74075dc587d48bd1cec55814b01f1126b9b9",
       "sha256": "0x68a344d9de40b0d7482089ee7748e43088c52e3b108480d801b34c64020beb48",
       "urls": [
-        "bzzr://9f15e79ade2f897c8a754887839c4aed352f37d3bbade568c269580c722563f6",
         "dweb:/ipfs/QmXxM4YfZcq5np84wcCn762sm4XDxyjoMaKXtUaeunp6th"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0xcc9cddd6f0d0de2a39afaff31a063dc66eebe91b3c7bdd62e0152de4547bba07",
       "sha256": "0x8afa926b6bb8ad492fb25078b1dce09fd05faa5765e4e2b2672b3c99cf71eeb1",
       "urls": [
-        "bzzr://1bf2e4af9bebd83bf3dad7ff7bc6cfd1fa4571ea0627da66890cae3ae6f39c1d",
         "dweb:/ipfs/QmQZsPrUCGcTnFiBgdvbAFhw5qoUp61Eer1Rxe71Eg7Db1"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0xf918ebb44bdc82a0129b4d0b2edeca7de44b5af66ded6765a784d23b2f344014",
       "sha256": "0x9e05051c3d42a49c8470cbed1f2bfa89fe76e930a9e5558c52ce5653cf794e25",
       "urls": [
-        "bzzr://ebb5a9f6594feb4096866be5f43fe1e780454d405efd07f891c411d1be7beb8a",
         "dweb:/ipfs/QmY5eKeMgFVxGgyzbVsmeEUurZyfQVUZ9hVoACf46iyN8R"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0xa8d1fa05cbf6d30c9d6cf4c0080d040c1518db7944ba943ec4a816f1b6f0b1bd",
       "sha256": "0x9f6624e408497142bbd29efe0744ee25e445aeb7c932be401c0bc30478a6bb75",
       "urls": [
-        "bzzr://407abc296f3a4fbf71fdc1f413c5f32cdd66a2b525081a21524a6ab5608e870b",
         "dweb:/ipfs/QmRwNXSmQj5m522CJNC8d9DEMPQ2ut6kNmDZQr4oUdS4jw"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x1142bf5e71342697a0786a0032838299c3e106afd5c54960c9b44b5f60ac0760",
       "sha256": "0x35be28f68488b71f1de66148f915b91d64e062900e4fc175bf2eb8fb948810bd",
       "urls": [
-        "bzzr://312c6aae351990e74291d8cdf9d732768c5bcc57fefae1a0aa3720d911a239d5",
         "dweb:/ipfs/QmVXgA6QjWq8CTtvhysrru2QgjVdqx2Bd16iuADZ2eP9fC"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0x7875c887df2e92df1163665db622d962e0336ccf9784549244f3595ed37e8570",
       "sha256": "0x37beed8c8b947eba644cfd8c20446e1ba5d74055e6856b646dd6ad4bb470d9ae",
       "urls": [
-        "bzzr://600161db2bf70cdd1b150e4e6dc5dd08b642092d75a96994290aa8c59134bba9",
         "dweb:/ipfs/QmSuT85oAvJFVfWj6PBRHgSAC4iQQ5uPTJFDpxC84aGtq9"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0xa60603c327514c2acedd1bc917e769b74739e711ee341cc08bdad6d065c3fa14",
       "sha256": "0xf1649bfdb0e6e53be2758544836258cb4d02e0b381a9e43216aa2b2fad0c9b8e",
       "urls": [
-        "bzzr://8932ec9fc8a9fe70346f4fdc2f92820cb620c596149ab63047b4e25c982a1953",
         "dweb:/ipfs/QmTLGMSSAhzwhc7CEQphcZxdAEfUE5eVTFHeip6h8RCMEV"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0x441fc0107c407d4bc18ab301c208cc8f3793f6d811627798283994d5cd74c985",
       "sha256": "0x2bb19d8cd69a32854acce1245b4492cfc5b5e751d322d2c6556d4a521bfcc3c8",
       "urls": [
-        "bzzr://d27138690388eafc0478a642bcfe12071f7478dac8ed4f270d53f064cb94f777",
         "dweb:/ipfs/QmbuPyqt1XkE7UXP7WgKV7PTLCQJYQd3Ytg8yzsTVc3qFM"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x48221990f9d74d82a093722f20706a2a43d79772552a6bef718752427259a792",
       "sha256": "0xa09350d5a182b3da799c203d1dadc4ce0e6fe3b96dc9ee1c9d73e9a9d9592e2a",
       "urls": [
-        "bzzr://c7ed1cfaf43061ae8e6760a949f4c1e43a2d961c9f4c867bed61eb3cd7390660",
         "dweb:/ipfs/QmXv1gpDqj9iVZzRoYbVhwFo5j2ooptQAYz7vp9hnAB3bp"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0xae0015245fb38b3b333339930ab635958ec00b4bb062ca1a5f346d6f51d88602",
       "sha256": "0x082fd42cc96c28262459306f2854fe7049cc0d14473e126b2db6d30bf02f54d0",
       "urls": [
-        "bzzr://e3aa6e6ccaade31d61c1c24df8cf03a5fd32a95a3c7fbf652ef2fdc8368d044b",
         "dweb:/ipfs/QmeHkJw28pfTsVEpQXGJnaehKneXQUP2S6gwCDbmbmzAsn"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0x7c96df0411896e573a12852f40beb45c9c6d4006b0eb4e304665b83692064f1b",
       "sha256": "0xa8129254b5247bbe003d6e54f35c0bba853694126744577289b6bdf1d35a1e4a",
       "urls": [
-        "bzzr://743e1144947432ad10792fcd4213ee95cb6ce49ef0029bba0c1daa8313ae400f",
         "dweb:/ipfs/QmRxqoK6QQPWcxqeYwN5GyE9SF71gcnW5UwRg9QPUjbmBg"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0xe7810e0e9d8bdb79087d4a8ae84ea88d33422a37906fad7114531675790fd0f8",
       "sha256": "0x45c7f956197ce08b69f793ea610cf1ee65e12b6a518d6160cc28c8eeff41517c",
       "urls": [
-        "bzzr://08164ef3f682e8963d150b40478c8321a1ea93f5db6e00f7b325896edea813ba",
         "dweb:/ipfs/QmX2s1id8TC9Hdaemi6yWXMBaQbcT3pWdAU1gkda2PgNAM"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0x0f348362eb3dbc20c7a6989a8d09adccb40e3f6ee731803d59992624fdf33992",
       "sha256": "0xbb78b6de3df7db6115a1033346c3e9df8a6b9c4fd038cc12d6bdf16abd29c952",
       "urls": [
-        "bzzr://3563864610d0b3402aed2f264298bf8efd5278337af9ddbf34800c58cf19fc11",
         "dweb:/ipfs/QmWrPCuuXkGx6WxronttXLYDdoRyyvbxaJHuwJpd6wLZaJ"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0x9bdbe9621aaa58357dc8695d5d13370fa9a89b3dd71a3f1702ae4ae50457b378",
       "sha256": "0x801efaa3d0288637021667c0d116ee2b339e62cf26027f8c168259e0805e8b60",
       "urls": [
-        "bzzr://8830f7671dd8b5e9def1397dd1b262a083598f38c931e8dc9e3aff855752acdc",
         "dweb:/ipfs/QmcZSrp4jW4cYn8MskSs8VjHNGsTakgxiaHyFX4iqC9muG"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0x6a34879f5ebf3e6405d18c1812aa540fe9903ad889cebc3dc0246d5a49cdf3cf",
       "sha256": "0x98fbe10755638ad5ccc0683810b961a803450e94b642af112593248a685aa4dc",
       "urls": [
-        "bzzr://4ffbd77aa5bdb73bec29e4d4e236a9dd907caff79296a3d94646760d8e5af78b",
         "dweb:/ipfs/QmbjW4apLQwPd8ALgCNEBax1C4tgF5Eg7dHdLgqgjTkgnA"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0xc833a7ce648e47524699bfcff94bf0a5143f2f0ccca7b75703dc825fdd038c1d",
       "sha256": "0x3773e66c3ef14e2e47bdd7d06f30f952c199856df240d164c91c1f00806fbbc7",
       "urls": [
-        "bzzr://181a5c54edcc14ce2c5d5155c4efd56a204a49834409772ed85ad932857a9750",
         "dweb:/ipfs/QmbQEy69AoRM3h5vCzxe4aDCAxKDPFYwGQSGVQNMpHHDKy"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0xd289b8db3cd371f4a5df8e57b5382b361fcb8d5112536797ec2dd90dda1a079d",
       "sha256": "0xa0a64aa092a616ae7145da908fc427fc3c296d3afdbfa8ea3468a22722d5d01c",
       "urls": [
-        "bzzr://9fd78b77716ce520e78aca45af8709101d0a9eb07ed8ddc07a166f6964a9df60",
         "dweb:/ipfs/QmVKPzEU56b2ercuGibmt1PNX6T38oiv1UTMZNmBUsexkc"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0xd3ad11d172cf5b8ca7c7c0fb6b751611a85323becd788180af5b30fc8b4b4987",
       "sha256": "0x05ad8afa83df3b51d36fe9a84ea4467b3ed17585c903946985d6e2cd5e95685a",
       "urls": [
-        "bzzr://45e7aadac409633022704d4d4a63317c8d106edaeb67972bf160bcaac9746dcb",
         "dweb:/ipfs/QmWK8t2TGf4UEKFGkk8aa9TYtFcWU9NYqjwsYyso4VJNLC"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0x0f29a363cfc30a28d2f82e241b3c6feafd04c6aa57cfd3969b6c70d6d64997ba",
       "sha256": "0x40555d6e826104cacd0c0b637c5fb573d5b6e2a6ac70110dc0333466c0115e1d",
       "urls": [
-        "bzzr://720bd9c72285bf715fae1ca378bd1bb24432d662ce6e8ea3605735d0585d8e61",
         "dweb:/ipfs/QmcpsbvXVFacMFTgAoKz5VXKdT1WFNFFEmsxGq9K4Ef6Sa"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x5a29ea217cdacf04d8611706771ee041571207db75e554c88e38c975308fbfbe",
       "sha256": "0x55b8072cc6ac154bf27f22177afe58be05f28c11ef51fc4e660313d3045a4268",
       "urls": [
-        "bzzr://3f6fdb64f1fd58f16285737aa4c46f5cf955aff0accc36a93a0012c84e1ac153",
         "dweb:/ipfs/Qmbsseaeu3GmMe4y3oqqonaVUkSYLqKB18gdrNiA6BdT2g"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0x1fcec1bb8e66af87b944f82ccf8ff7690931f7872093f4b14647dce62174a3eb",
       "sha256": "0x5518641f6c4a286054f5c9f29146970ef72f2f34ee76ed23f5eb1f6d1dcfecdb",
       "urls": [
-        "bzzr://1c226f35bf118d903ccc943516761564497d8b0cfc79eba1206c924254af0240",
         "dweb:/ipfs/QmcpwuWTL3ZgcSX1WUs4L3WVZtctRSzm8eHhGXosn7cz3L"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0x2bbcfb7135c6ae1a23be3ff24d00f423a5772b8c96afdeb29366243d9b9b586a",
       "sha256": "0xf185104ed5e2a90b3ce8dfc7283c5d0ffbb738d7c8da19e8635dd9fda34c337a",
       "urls": [
-        "bzzr://576d33181f5dc0c42bf0c1cdcd5fae565d0278b035c907fd5410b212ad9ffa05",
         "dweb:/ipfs/QmNUC4SV1jEWHv2VDck4WYToHgZrZZ4BDLvXJnj9DM6G9p"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0xd6a9d389b2d303f226f9e5ecffcd33f610687b556cc254cf30589f72a6fb8b77",
       "sha256": "0xcce002688cf10fb0243a042503f3e9896aa991ab59b08b57971d42d68e99f83d",
       "urls": [
-        "bzzr://acba761d4123cfc40249bc922a66e9d190802bccf269431a5aaa80bf9f99803b",
         "dweb:/ipfs/QmSZzdgjm8M7gz44MKMQpFUhDG9HBdTNHf7BLmLrkagos6"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xff52724ea7d3e0913219c765b40f311f72fe1e5c95389020a165a1959e57e24f",
       "sha256": "0x1c100ce86a3167fd4c194290aafec0d3d94fe86c7a1aa0837c1346cc93d8b6ce",
       "urls": [
-        "bzzr://e40c2432e6e49c8ccf67ea1684d1fbdfb43fbbb7ad44264ecb17ce73ef3a7c7d",
         "dweb:/ipfs/Qmayevqr3TEHNqL2eAumCnFjgcMRp5Y1ckkwnfo9ewsCdF"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0xcbc087311397f47993e7332637a999ac98a5661754ce33e4b265edcaaffdcd85",
       "sha256": "0xa6a8f9f9388c5fcd9222474e00270242c832e936b0f5257c20374d27ee5bd1ab",
       "urls": [
-        "bzzr://f908a6c0e311461118264568c0cff1a428fa2b401ca9b815b9c74b4e5995b347",
         "dweb:/ipfs/QmcpVjAEjNMrQYWqZ96pHJp2v7CrM63S2VQJDiLTgWx4eg"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x945af5c3c9d75a6ca7d48a4ee9df3201b0a34c273ba6b50aed6afb2a41dab845",
       "sha256": "0xc7c3ff484d2dd69350fc182d44ecf6057ff2885b96a1c3990ca362e9c8325335",
       "urls": [
-        "bzzr://d65c16cb03339d288f0bf103fd22e610532989be6f64529db52f794da0c15427",
         "dweb:/ipfs/Qma8sQw9vxvSvEUTNsz7DxPvuo9Lx8nLpdAFgzQxVaHbSV"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0x1f546c34241257015e73eb90b7b7ed099399c5ed84964f266e651f3a9de0f493",
       "sha256": "0x38504e357632c15afed612c20ef878992ca8411ce3fb6afee37dec6ebd22ce02",
       "urls": [
-        "bzzr://a6ac5a8d50ade8d5df91dd9c6bf623a9246b721b17b991514ccdbeaee50ddd68",
         "dweb:/ipfs/QmShTho5JF2vrmnGwBWStrwTz89GNgiCfJKVoKKz1Dk1D7"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0x3abbb7ac75c90ba7dc9d4aafe0f5c183c8d572d9c07303e892963774f8e6c53f",
       "sha256": "0x0898c23b0ac8cdabcee3b646b676da1205f4be7c0bec8a58de81b060c59b4c1c",
       "urls": [
-        "bzzr://8acc5ef01c96279bb7665995352fbc3a2e1519f44de68b05abc2343cf2e377df",
         "dweb:/ipfs/QmYU4oyuNdJmNrPbNj6p3zWzhWzbdWHhSidHvSC3AqS3Jp"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0xef385c85cb7e3ab6faa28c7223c7f55b0d6a28e113420eb4d07aae5db1edb834",
       "sha256": "0x1188f5c24d33ec1ec2ce811a7a45bdc3c167f1ba71cbc2664016564d2fdd46ba",
       "urls": [
-        "bzzr://9e6b437fef68587b3c8ce3d930de77075ee6008611273ccfa2140f5c868e2ffb",
         "dweb:/ipfs/QmSUdtQRWmGe7kHX3FaJNiYp8TaPmDJFQQqwdYDBgUKq9T"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0xb8027ceccd3892550e0389af02716a658123eb4530bc02fc437d167c38501101",
       "sha256": "0x4f6f2e6942a09051bbbc850d4fa9b0d907749612cb5db58cac0c87745435070f",
       "urls": [
-        "bzzr://317c789ec9854aa6037a49f5f9b1598a95e6046a17b55d37b776bd0d3af93c96",
         "dweb:/ipfs/QmQ27VGKwchmwWN2TmfYALfgU17D8MJxPxHSCt2jSuAWDE"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0x728b089ccc3f1225ba7e7170fb88a75ae6b89c9d168f79493702f8b6bb725b7a",
       "sha256": "0x3421ee67a26ef4a720e79531ffd9b96deec89defbcd70bb4a33e968b12ddb938",
       "urls": [
-        "bzzr://e0e118ce0fdad202969c5ad18cffc482837c522ecdc86578a4fb208117e36cbd",
         "dweb:/ipfs/QmRGVXZ3rGb5zfnHCJEJTAgrDemFkKrxrcVKRFF9HAcF17"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0x89e95cde55521904929e8dae6f0acf450db091d28a45dc824780a35c4c9b910d",
       "sha256": "0x86ee99f64fc7e36bfa046169b6a4d4c10eb35017ed11e0c970f01223b2f5db36",
       "urls": [
-        "bzzr://057db05ffb78d1d29087c7ae6f7cb9c34890b97d105fe791643cbf0ecf1626a6",
         "dweb:/ipfs/QmQZsG2rzoXmkhHMGgXJxzbdi9TCvt4yuV1akuAcEE4QMT"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0xbcc6fd8ff1d27e4b1a1d277e2d36b3e135981472038401a0e0eee275d0b28846",
       "sha256": "0xcc5c663d1fe17d4eb4aca09253787ac86b8785235fca71d9200569e662677990",
       "urls": [
-        "bzzr://2ec2ee1c310b0f62231a74f0b18de7d669ae204288c895343153ca95a7913800",
         "dweb:/ipfs/QmWCTWH2NP3pSjcEPoYQ2ss6YPW98R2WmqX2mfQbLepvr4"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0xa7dfe9ed26a2d2e9f1e7b1581838bd35d49ccbec36228ce232dabd3a2ddedd3f",
       "sha256": "0x1422e10454251d56fef62940fb2e209a6f467ae35f73bdce580bc0bad35851dd",
       "urls": [
-        "bzzr://9464141458eab56775a5be4186cc6a73440f609b26c3fa14c7b0a424ce128926",
         "dweb:/ipfs/Qmd32FsxALkBcWgRCD6zvFmZ3PvZN2jLtYVWBVpnVj5PFd"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0x0dec1d0015c882a98259d9ed1c7a157c77cb4fb05dfe0e2b74484957501dce7c",
       "sha256": "0xd619d4f5d8fd988bc63262407e749e905ccc8d8ab1ccf0280da1d12b918894ce",
       "urls": [
-        "bzzr://b7ed2e4abec3c6e075fdd6369e3705accea9a7677be58a6ff05e94765e00d57a",
         "dweb:/ipfs/Qmax1ZEAvgqfyNmXBSTrmerSYWgsbCfiUMGqnQYQGUNEUA"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x6fab4e609b69b16f2ab6d3c9fc9262e52cb76ab93619325eaec590a5efe3178b",
       "sha256": "0xa79fff23aeb35be856e446827c44a9cfa4c382f29babd2f6a405ef73d1e2a4cc",
       "urls": [
-        "bzzr://4473d82fb0d080fafc4b1e4305dfaa042d081a1b9993024ba337cacdfdc29d3a",
         "dweb:/ipfs/QmZPQAFTJSBAg3GjSW7JS8h2yk9nBcAjCjYYEygz5GxNMt"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0x7f7e17b585fcd8b3c5025210e478a330281a4bdbb6054569d81dc21d32394b61",
       "sha256": "0x10cdcc8d8ea4dde9fd8b953b95885dc737f24b8a31fea65f4715ffd007b80281",
       "urls": [
-        "bzzr://c21c33c4d4907b1712003b3428b6af25fc1089493bc2aec06d04a41210f698ec",
         "dweb:/ipfs/QmRkNwKe9t8KNVMViMGEVJotaZCiY8i1qJ4v5EV4UBRnaG"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0x3285e72f53b0ce49958234d29e3c58aa2ac12e38c21ef59cb9940edd245ce76d",
       "sha256": "0x95738a27909a13502385e9fe8f8f3d8a873d2faf5d06ff617bc2fe3edb8c4bf9",
       "urls": [
-        "bzzr://1b149c02263e66a260c11be38c7b19ed946f1e6a59c77f15c4d8148d1d69887e",
         "dweb:/ipfs/QmSi3sQoQhUmQCxD6xaMtq3nYnWE8ydqYjqhe7kvRAfCUC"
       ]
     },
@@ -956,7 +877,6 @@
       "keccak256": "0x9f05bd40e25ff5ab7c6e657558ba71d472b30bff3359de15122271c4065b9c24",
       "sha256": "0x14d4ef013ea82ad95e91fd949b7fa7b78271a483ff1a79c43d6cc58b826f5bea",
       "urls": [
-        "bzzr://dfa7ef356ac5736c1f5cb2defc500390898881afa1b67913a832be445f026945",
         "dweb:/ipfs/QmXaKT1hqJCNuJX5uryXJzbHHUsH48GoGBhoYPoLCVrZUg"
       ]
     },
@@ -968,7 +888,6 @@
       "keccak256": "0x93d71d0692befba81239f7a0b7443ca117ff7fe9ae190ed32550db678d086aae",
       "sha256": "0xb3d19ab47657af37be4c551f83494248e99d7ba103b6072e8c08dbb62708e2b0",
       "urls": [
-        "bzzr://f46b7d64c5327360d840752b6acf354040ea61d43eac1d14e0f373f96e2b5d8c",
         "dweb:/ipfs/QmcK4egnnjdrkLsM8R5QeSBoYs59M1CxvRi331zaxoSEq4"
       ]
     },
@@ -980,7 +899,6 @@
       "keccak256": "0xcd862fb2d2e2f83738c2d08632cea128bee9278a4840053262b0e2495f9216ce",
       "sha256": "0x00656dc73224e4c0702940df10310bdc024b60f4a7598e774d305bc3b94f7d79",
       "urls": [
-        "bzzr://8a277ebe4f557a46c93f6e1a4ecffac34f7e0a60afe8a20508e42ae646571c20",
         "dweb:/ipfs/QmSJmnXuyPy4TtxnUSwD6f2vF5MSzcvN4cohtZfeJc8H6p"
       ]
     },
@@ -992,7 +910,6 @@
       "keccak256": "0xf3dd3636e7bca007430e091bcacc2dd9b9af72edb838a0e0d77de9610169f7c3",
       "sha256": "0x7d471cb9bae9a7f29c7ebf402f7e16fa8226b17ba9ab68a88ce107114479dc4d",
       "urls": [
-        "bzzr://53af1a8c08f9025b93c23759efa15c9eadaa3b20a8a590424c12d4a89a0b7503",
         "dweb:/ipfs/QmZCFxnqy312mEc99qxXLRs6UE57pgFM5XPMVmw6G1WXfS"
       ]
     },
@@ -1004,7 +921,6 @@
       "keccak256": "0xf1d882dae250037523afce650a3e6d2069810d7f7e18a5f861094587fd946b6c",
       "sha256": "0xe40eef83c24d4c42b47f461b01748a6ca89f1e09e778995b71debfa0de99e12a",
       "urls": [
-        "bzzr://1ff61f15fbeef7eb86e4a5df8046880cb31a07e354bc3d6339aa072e0eeb8e1d",
         "dweb:/ipfs/QmPLRuidw4wXZhaWbd24VYWthZrUftJwaXQKWHPPj9Gktz"
       ]
     },
@@ -1016,7 +932,6 @@
       "keccak256": "0x30e1130aa13ced52eb874d224dba7683ed4caf32291c4081f6b83230b341190d",
       "sha256": "0x8f15287c799ad2b33f241d1252226abda5d4bc3ef6be40b946923178fc57d397",
       "urls": [
-        "bzzr://892792c1a2975f25ec0f96083559933412c25e0c1100eb85c33b61d1b9a385e8",
         "dweb:/ipfs/QmTepA9fra5vjbooDmxjcmM8pYXj5Xz1KFt5d73N8S84NA"
       ]
     },
@@ -1028,7 +943,6 @@
       "keccak256": "0x6247a3e93a840acdfda0b111b27bd48e22ed2515bf67d0310864979fd4440155",
       "sha256": "0x38c8523ab67e0b3e21c48189d6bfb99ad6879b9ce02e0d802ec8be598bb2622d",
       "urls": [
-        "bzzr://f0fb303e649106358f518d1cb3c49b8c3f488a86f7e345a0d9f2029c2e3d7154",
         "dweb:/ipfs/QmdXcpr6U4kr7KmuYfduz7DRbvbyWViLoyoAEh5USqUKVu"
       ]
     },
@@ -1040,7 +954,6 @@
       "keccak256": "0x6968bdf9827c7aa35eccae41063e812250828bee530d23b59f0034f6c62eeb02",
       "sha256": "0xfc329945e0068e4e955d0a7b583776dc8d25e72ab657a044618a7ce7dd0519aa",
       "urls": [
-        "bzzr://c44d37faf405274cae14f988e4b0b5ebe66abbc2ea0828ff433d168e8e339bf5",
         "dweb:/ipfs/QmVgJUFru26w9nsKzEZ8WSrcc4JbtcTkbhuNq7Vb1juDqc"
       ]
     },
@@ -1052,7 +965,6 @@
       "keccak256": "0xdd0ddc6d53bbecac4ed0f0b78c4d9990841d250e0e4eda116e84c9d0e1c2f4a2",
       "sha256": "0x19d065749fb08cbff4f7b45284ac55853063865f6ae8621e4defa5d938b9a502",
       "urls": [
-        "bzzr://c701d26aee88e21ba5803b02561a031ca6f61abb6fe08fbb2b78c784789fe712",
         "dweb:/ipfs/QmX6LQNJ23wCfv3TCkbLS4nmazPAYgWTKred7CDTGLi8tX"
       ]
     },
@@ -1064,7 +976,6 @@
       "keccak256": "0x791bb778cf604f6dfd073e6b11673384aba23beab55accd3f29bb310b5c4d128",
       "sha256": "0xc8d3b7803c0eb2c3bdd34b2c3b9706e9d8c81b8829250e49245dacb984a62e05",
       "urls": [
-        "bzzr://a07c2d2704a44b2300cd130fcd2c834bed6edb203ee63f0529f78130c437b872",
         "dweb:/ipfs/Qme1Cmme2nGyy3V4KBcY2amBdZdykqiryYp5KjXcos4xZy"
       ]
     },
@@ -1076,7 +987,6 @@
       "keccak256": "0x8380e8a6f66e4b2547250b9cbee170a62e1e899df12f7c0c3effbc5df3c06137",
       "sha256": "0xe09a42980e44644be33a8455c87d095a4f0028e41a7dde1137f5d9a7605a2d62",
       "urls": [
-        "bzzr://00319ed318e2cd094791d858f56cd7031f60023b00cdd2f9bd2f0d96e5ad918d",
         "dweb:/ipfs/QmXuBDhncvou72S86KxNxeTcVH1pGhU6DCZYzbcVrbfY1p"
       ]
     },
@@ -1088,7 +998,6 @@
       "keccak256": "0xf8c5313dfe054e7f3c208905ee6bb4097a1c7a1dd360050f90fab4b182ac1c24",
       "sha256": "0xcc2d44c706905ccc382f484625dff61d741e0c24232d226f139a6835fc644f3f",
       "urls": [
-        "bzzr://fab9be6f2b588ade1d1805e2bc52896f9a51d283fa513daf8a70b3e6050524cc",
         "dweb:/ipfs/QmfNsBiCB9QDHh9fX8QRAJfFKubX2ahutAXnoWx4BfXosT"
       ]
     },
@@ -1100,7 +1009,6 @@
       "keccak256": "0xb530bf56ed297e663f77cb03e3c34f50edb38bc670f31eede8fcfb6217c52226",
       "sha256": "0xcc3f94a70ac681b0304084acc1980aabe2a1bb3240d44ce76a8df0e1e77a2110",
       "urls": [
-        "bzzr://188692fa8a9d78cf8463a6cce0384aac717d50dd28a0444af961b5c8aae21f95",
         "dweb:/ipfs/QmZCfDnCEPZYXUxkpEghPNj65T6gAQ7F6aL6jNjfVh9FYw"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
     "semver": "^7.3.5"
   },
   "devDependencies": {
-    "ethereumjs-util": "^7.1.3",
     "blockstore-core": "^2.0.2",
+    "ethereumjs-util": "^7.1.3",
     "ipfs-unixfs-importer": "^11.0.1",
-    "standard": "^16.0.4",
-    "swarmhash": "^0.1.1"
+    "standard": "^16.0.4"
   },
   "scripts": {
     "lint": "standard update.mjs",

--- a/update.mjs
+++ b/update.mjs
@@ -16,7 +16,6 @@ import {
 } from 'fs'
 
 import semver from 'semver'
-import swarmhash from 'swarmhash'
 import { readFile as readFileAsync } from 'node:fs/promises'
 import { keccak, sha256 } from 'ethereumjs-util'
 import { importer } from 'ipfs-unixfs-importer'
@@ -155,7 +154,6 @@ async function makeEntry (dir, parsedFileName, oldList) {
     console.log("Computing hashes of '" + pathRelativeToRoot + "'")
     build.sha256 = '0x' + sha256(fileContent).toString('hex')
     build.urls = [
-      'bzzr://' + swarmhash(fileContent).toString('hex'),
       'dweb:/ipfs/' + await ipfsHash(fileContent)
     ]
   }

--- a/wasm/list.json
+++ b/wasm/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0x4a1c2a6a4896edefd3a4178a6c3ed8f1de625bd7c00dd7cc5781a9f36236e7db",
       "sha256": "0xee7ba01680ed3a1c1cda236189a51c1e6ff99f6dca602a580e5b16441772b50b",
       "urls": [
-        "bzzr://83e99aa35ae67e71bf77040e5b4686aeb3558919f172b6c28213a4dcd8d79e91",
         "dweb:/ipfs/Qme9brfZS3XhbiRbbNDKhBpgFknyD92omMmYa7XSf56bJP"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0x07994ad8c59c498bf44ca8e84914e27b79be964d98a9556226db377819d67387",
       "sha256": "0xb83d2025e0bbc7f7f0dc9e47f5aa22eacb548b42c55add8f5f6822c105163500",
       "urls": [
-        "bzzr://414fc715062f91971c8e0d9fbdf470dd24a8a35f4f96df0ba79980cdb0ae7eaa",
         "dweb:/ipfs/QmcBZ6Q2iHmrf9omvD7Jyy8kgrqyPmZFwvKWqvVDaxo1Ta"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0x4c358c2e90447ad9e7c1816b5be8edde1172f67dedf16755a6c7373ede46b245",
       "sha256": "0x9825565e1f199dbed6de01d27e10f83a9180300acab80f8469bf427e3cf92e96",
       "urls": [
-        "bzzr://6ecbe30c4c8530b82d55ed6bec12e63efbab1cb16868b020d65399a8793599a6",
         "dweb:/ipfs/QmcEK5gvWNeHUtjsF3B6j5AXb9uNoG3aHbPrCMJDx7C8TM"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0xb67df5c37e8255e0de7918b6d3261f0f29e277d121bf5f414b66157a5b1070cd",
       "sha256": "0x67f8a94b60278cfb80d505c47a1a5e67ec2caf20167ef85f2bdf2a80a692bd1b",
       "urls": [
-        "bzzr://7ba69a10a4585d0a36e5843603476061e8b02878331fa580d5c2509ef01ddaa6",
         "dweb:/ipfs/QmVumPvgQVFLZvDvQddcDGcdxjbVWTTzxoQvJAECBBZ6Ju"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0x62a65d0a951617f022524fc844ca11d90266f64e693343a2f41107183bf364c1",
       "sha256": "0x66da311056ec26c9c3fb501350ee22187c30e79c41bf2713eeff7d84479948c5",
       "urls": [
-        "bzzr://ccf4f1e05d942946bcca929e9263c541b2749bf1faf6dc6c211b4bf700344d71",
         "dweb:/ipfs/QmXf2cKYJ26tXAU6A6tmUk2dn4tuX3CWNaXJVnGLuoe15y"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0x06afcb6dc23efb1482545b63c5e3983dded0c383ecc46c3ae319f7b868201e47",
       "sha256": "0x9e386edb2ee759ad65792f7d62c10ae7edf65c5b874a5451f1e695e586b69eea",
       "urls": [
-        "bzzr://e93e97b9989cd59673bb1fd64a0f940e8729c3c40b819593b8590480cba24bea",
         "dweb:/ipfs/QmSJFaZhpXQ2EPF2koyiTNAiiuJRykv1Q8yubhkmBhvYyu"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0xcdf7c4d4c6b9331b755170fa927692019c94088f87f100d2c3c920bcc3740d0b",
       "sha256": "0x7184dae0b761485a5dce66b50075e17857c5b55fe3fa71fe22d4d5acc0839741",
       "urls": [
-        "bzzr://e21d2bd58112fb165fa2c253504bf49ceca661ac1009d270a31cb996560cfa34",
         "dweb:/ipfs/QmYJuZgMbeMiotHAFNWEXdxjTa5yi7GaV4UkgBYABomFpj"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x52ca702b8ed4b1e6d43d8a006b3d27f6dba611bac118c523711bfd209fb1cc9d",
       "sha256": "0x8db9466df3b91c52e3412cebd13176ea9fe16d3239d000828a081c34ce899337",
       "urls": [
-        "bzzr://24dc5536a4771b2336fa304f3cd38d5203b6ab49c78a3057ec578991f3fcf265",
         "dweb:/ipfs/QmZZ9hNntBxJw3G7LGW3e8nXtnGxLnaSMM44K4BbLrkELs"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0xcd8a6a8b2626de75ef6ff73fb724f3ad5693a8902f86e88290f048b56182e7cc",
       "sha256": "0xd28a58fbc3ce56ff650d4daf3a1d8092e25cadf2a5b2769fd333b321dfc6a22d",
       "urls": [
-        "bzzr://6a5d22e366c35f184d5203f3e062131018d8a4d09cf770a0720cfaf4d7b49705",
         "dweb:/ipfs/QmfHjv4nYKuv3yFpWZqBYyiYEYmkQGydQmFT5b6mJkFpWp"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0x43c96fc79cf288cecda12b23a17f30b1cf0427a19dc7c1c094bb461eabefe0df",
       "sha256": "0x9af176f42b63eaec838999a07e80484f92f41a0fc497adefa65baf88d8fbecaf",
       "urls": [
-        "bzzr://fc0e644a61e43592754b66f8d911c91312538debb89da29ffda3d3fd81ff70d9",
         "dweb:/ipfs/Qmf7WYJJ8y6oHr4RQ7HC4tXgFPGvsnp3Qf6TrMBdK52Y5Z"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0xbe94ff397be2a951cbeb6c9c1a60ddf531d0ce76f45d51755386b6fa42cc2e2c",
       "sha256": "0x6ff1683eb76dc58c31043fea474be6da8535ec625d1cd8331a3daead84fd5564",
       "urls": [
-        "bzzr://6e134aa89a00a18d930924fc2fad2aa434f80b6a71085ff2ab379e3672c812e7",
         "dweb:/ipfs/QmeBWFbK1aAxnB6muXWStZJWndrFvMJt4xfAzEJD7AqaY3"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0x178e51ad0c6a350ec4ed6fd07675dfd4d2581ee07b14b4954dd0b0f6d8633ca5",
       "sha256": "0xd70ca2f656a88a9be7a3f7d602f03b30149b3bda0d1057cfa3a3c5e3d6e07453",
       "urls": [
-        "bzzr://6e43013ff973198d7fcc4a43910041f2f07d0099f4252737a2a2545443b11105",
         "dweb:/ipfs/QmarthW41sfbrdkMmCK6jicXFZDGgvALzdgzygtUqEauae"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0xb8c3f5654b323cea016c0cc1a4584069714cdf796489efe2496a13f8f83a0e63",
       "sha256": "0xdeb3c274f8b840d657e2f9b1dba602e89f58b1bf3fd7178c48c9033310a1f006",
       "urls": [
-        "bzzr://084452a20ae520bba965ba0b863f3d6de0516d1f92ddb512a138fb787d841c55",
         "dweb:/ipfs/QmNUf8dTW9xANAvJmV1ho279AyWSCCvDp6bXet1QTcS2z5"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0x598af6fec02a6783d6a438a6bb0f7d3012716d003f7bf6c9ac5a4d2bc911941b",
       "sha256": "0xd522b307a014a32ed5815b05045c4396abc047e70c8a53c1e3ef92e14daa61c6",
       "urls": [
-        "bzzr://cef259b97217a7526819155f6dd513768be5f8718324ec3a63c315071e2f7c70",
         "dweb:/ipfs/QmWGK9FbQiNWNeqysvCNCBw3q7cR1dzpnD1EKtNija2zyK"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x93f7046d6e0ea2492ec5229936821b3b020dbe9eb2e1193953389293d64a190b",
       "sha256": "0x68ace74ca809ff47b09449d4054c77907d9412f14f6003d5475b60f4fec13709",
       "urls": [
-        "bzzr://8943b9e6d4ec52bda1b8fbd65509168ba3388651a30cb495d5280cfbf35614d7",
         "dweb:/ipfs/Qmco9fGHM6mdaPVYqeDQ11GB3BrCbwRcEzM5XzHpAdAVWc"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x7def3c264883cbe6ffbfc54894e48f9a0d2984ddbd1145eb898758d2a41d1559",
       "sha256": "0x54f3dc64f2ff5a5350410f6157a537d96fb4aeec90476e90a951ddfbd1fe4bca",
       "urls": [
-        "bzzr://3428015c422bb223c3fe8c3a85615081981c47ead375564c16701b261948f0f1",
         "dweb:/ipfs/QmXyyuEWhexuez2rzAeFjunpiAhncD1AfcXitGNHxpRWha"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0x9ffa9ee890ec483580c0b4ed72270b16e92eb0b7a8a97fb00c257f8809aa4023",
       "sha256": "0x3e64525797e0b2d9abaeb022688cc02d63fc5820327e382fc6574a7de650dc97",
       "urls": [
-        "bzzr://395f2d903c162ddc9b6ebd76db450ca6cb9cf8bb276c3d705aa462ae560d23ab",
         "dweb:/ipfs/QmW2rPbEtiVAbWJxtizzDqTjwpRpXCxkpSR696g9GxAYKT"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0xf0a6c32af3eaa2f8c6d9e6c8b90f3bac5e775c7f1c90a61c1e72b593fbb1528d",
       "sha256": "0x0e6d842e941cd8b76280c59f28f6d020af1afdea8e4be9d9da677ac5dbe860c6",
       "urls": [
-        "bzzr://f44b067fda20d169321fd3616f68633fd7a4277b6340f42f74203f33dad4a472",
         "dweb:/ipfs/QmSwumWbYwYe4xLcqpi38VNtw7xCgbNaUkRhiZro9EnqLt"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0xeb8c3c474b5fa792f9b1b2ac6be945c32f835ccdc059deb562da4e99a031eab9",
       "sha256": "0x7fe677e8214d0486fa7164f797862fae0a0fefb7b72cf6ad8e728faa54f12b60",
       "urls": [
-        "bzzr://37026d0ee2865c52fff8f6311b67b94f96dbb52ce8af3f84c3a9aeb47b12bf47",
         "dweb:/ipfs/QmbgEAtdmSoxH4cfRJXj7mVpKv9rT5Cq2YmXmAnjgsyqBC"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0xf824e695e8e66079b4b6063622c7dd80ed056d29969c8c3babac4fb572f3dfec",
       "sha256": "0x5bb50839ba5116bf31669f3de8dad72eaec298ba32a643be7d0dc2d1392c54d6",
       "urls": [
-        "bzzr://d847bc8f5d43cd348346c5bb253269de36f00810c2e189ca64a4becdb9e9312f",
         "dweb:/ipfs/Qmf5RrLbWeMykvWJbCyyThCLQ9YVmU8uWagMdSp9nNzZMc"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0xa60eadfddbfda0daebb8a1b883b89d33b800cff7ce7e12458170ea17cd5ede58",
       "sha256": "0x8c2a69fbab9bdf503538028c697e09e51a7e699323ae7100c375cb35c415a819",
       "urls": [
-        "bzzr://87e29a7298d49b8b52ed01d6146b05aa41c11a85d1b805dd48181ac2ed5e9b22",
         "dweb:/ipfs/QmSZEQEGuVJ7hudg8FzfDMXKVtn5AVGKaxbhSSDXwpX73K"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0x6c6dfa967526b7060634474ef730761711e5be662abf5ee02dc05985abfadec9",
       "sha256": "0x9852ad94048600cc5a1458b4a7ab625996844c809b314422693bdc81d953fcc0",
       "urls": [
-        "bzzr://3edc1542fb719d3e08138b492a5db06333fb36055a434c3b071b2dcb69e54fbc",
         "dweb:/ipfs/QmcsCpg6kfp7Vea4y9qPtfDXcaQJbDidb65n3t9f2MFDpR"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0xd0f9a689670184ad874ca6a2cb40dfe57e9cf539d9330ca3f2501951478eace8",
       "sha256": "0x4197bb1cb0ea7e637ed8a0e7810f1bfe32c90d0151d6f423bb3dfeef9f6777c4",
       "urls": [
-        "bzzr://1abbc4967f3c6c5124f8876abe521d508c71b0d0d64dc066c1e7a1bfe6ba596d",
         "dweb:/ipfs/QmY7UN95hdfFSD1jwFANegze5eLX8PgP5BfWFH1usTB8Sw"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x50972c5b966188341d133aa58fbf895c54655d7bd733fb5ad58852e85f9f9444",
       "sha256": "0x73458d16a3e34fc7b489d2399b3680cccfc968d01abc9f1b61e438b6fb0c24a1",
       "urls": [
-        "bzzr://9eab5a9c94bde3d90eb76a1189febd5ae4d6c7bbc63cc1d76e8871e14e6e9b89",
         "dweb:/ipfs/QmPUJNa1LYaThwLQsw6fF5DMYyDfEg57gmD5wCsazkLS8c"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x74f927b4f520d8d31863996a100ebc7827f919c77f777f6d4d416c6e613a03c7",
       "sha256": "0x98c350cc41f873af84a78d1e24cbc8449045ee54923af0a39440e4d84600dc50",
       "urls": [
-        "bzzr://a052dbfe589a766af66d85d4d797829241e867e0ead93fbf3d5e492c71b6434f",
         "dweb:/ipfs/QmZbo5YkSbcenWrUDjiCvUZdQe4UrNBw9vtx9nbgcMdRAs"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0x4cc2bb4c8894ad4349a88f330ba74d7ea643030d3f68037d1c94c370b6a25dd7",
       "sha256": "0xf83e8f7014ad6b8bc801dc3684c644e372673ed678425c35aea5d4b4fe37e922",
       "urls": [
-        "bzzr://2aae73578e361285488b6319e8e7b27e23b2736eeee3953cd65f1207cd849395",
         "dweb:/ipfs/QmauztXLDUdwJitA4Uc9MQYCTttUcivR5foTZYgwt4aAeC"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x92b9c5de10bd908527e9cfba3f04bbe637163b4a5313c5a69179ccddd5fa6685",
       "sha256": "0x782a999d3e1227c86854e7e29954ee856c6ae684124b9facf09f4f1724dc4e85",
       "urls": [
-        "bzzr://fb1e9b951ce8abe575f8514bff6baa01417a988a399fab1dd27a252e7812d1bc",
         "dweb:/ipfs/QmUtwmzqqCftcubfyGwAefLBQ8ffp8EFhW7HCEQfhaviFs"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0xc9c60203789ef778b9104ae7a39e9090b3d1256b24983d49e40e7d1e3c3ed65d",
       "sha256": "0x264d0d25e31cb32f4369f82ba3ad0b6a84a8a1975b10bd738123ddf947618840",
       "urls": [
-        "bzzr://335a6b94d26623dcaa4590ccd6d7529db1e153b65af3bf7def45fffaf9ee256a",
         "dweb:/ipfs/QmRd1uRbHRvpybQk5TQ11zyqmG4wQqHnefgvYdJ14V5D8x"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0x2921f518cf5a0627d96e07e8c3d2b5482dbbf14d7dc6bbb055481c46d98903f3",
       "sha256": "0xaf811843add541705ff65f0c20fd864bd0387116544524fa1830cf67a14af6c4",
       "urls": [
-        "bzzr://31231abb33dc43d0478f03a4c8b15b161b172097c884307cf6cf64aeb83a6dc9",
         "dweb:/ipfs/QmYLhaeGbq3tFdCUC2pvtA8QdGnCbA8kn24z3C741k5TUE"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x1980cf8a81c6bd2b371bf7d9145c819a7fb2d72e9aa462aaff0c10b4eccd595c",
       "sha256": "0x69cb1300b5f72eb128604507991d9ada97180d31afde7c59aa3fa3ae9ad5200d",
       "urls": [
-        "bzzr://7f35988e2c32ed2f3f1885fb81ace357b1555964d23085940980cacd29023da6",
         "dweb:/ipfs/QmPfxPYsYysRR8HFkWr47FMQ8ardmfmtrmdYc2ogT9Gfp9"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x3efd0585a3c00a1a2c62e590e22a69aa981d1b5148af2ebdbe1610dff93cea78",
       "sha256": "0xaff4ca62ac0b03cb4b9c50f8250e2e7307b5c75fefc9847f269bd05c20367148",
       "urls": [
-        "bzzr://e30e085b875fc291e5ee46ed7c88c28ec8e8c540ad8c799b106c365a52df9e97",
         "dweb:/ipfs/QmaZrQSg8njYzFXH2PzwxHDLKxkBhKmYmLm43DJWnurPeJ"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0x9b7a39606c3c27a8619b3eb493efca512cbd26c5ab7fc95489564239aab32a50",
       "sha256": "0x24b4cbc28d68bde8455c14a46b55e4f292c3c295271e09991b2176a487cb4487",
       "urls": [
-        "bzzr://3bccb9b8cee48b99b39f2f1296f7353bcd39c1ae61b1e19e5add7cedd0256cb2",
         "dweb:/ipfs/QmQmkd5FGiKKg8eRmo3L7Cn62nuV1M6GRDUGiq5bAx4AWx"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x4a6244b03de1968f0a48800e75640921d62b7602d0301093e1c5c318d1effb36",
       "sha256": "0x91ed0cf4390f33174a4aaf49d1ce7cd9c72e28b95d2f9422314a29b2144b2042",
       "urls": [
-        "bzzr://a5ab50564d82e6d55b462f4f85284d3fac294c78f2699b680544bc7efde2fb16",
         "dweb:/ipfs/QmRPchg1b5ofkLnLTPuunfSMKnxbXcZyzSR4NkyJAYUTrR"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0xf46cb35b3aefb9b3d59a1fb4c151eb23a0f0a05387b379b3e7fbed1c01c861df",
       "sha256": "0xaf812445476c101ae5ef92941c79eaebf57b39d455bdfb54a6a86b4ab6ca498c",
       "urls": [
-        "bzzr://2e72b599d5a700cbd03d9f7ca082464b4823dbaabfc5e1031075b9631c005d35",
         "dweb:/ipfs/QmPYEmgLWDjk7kPGovojurz7fzdGv8Ti3H66nEzRzdiGwh"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x66669372d2d958bfeb5129a387dbc3882a96e260fc12e2910a7eb148b8ea5dd6",
       "sha256": "0x9ffc04d0aee2c817ae6a897b1ba5aaca2bcd860416aaddfaa4de553fc1ad6e8e",
       "urls": [
-        "bzzr://5f5dbf4ebe3be5dbe3e917a2de3908b3a9ed24207a6406a6e434e6f041e993c4",
         "dweb:/ipfs/QmYWL8Z3yXfCuhrprimdLhYFkjR74TjFHULxcABbUipetv"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0x27e324f75dd52eb180569e7a8865048253e5fcdaacc52e7c998ecaeb78dcdabd",
       "sha256": "0xfd7c4e652d5891c84d93b28c90b8ac58c9253d2a3677935883a337ee96087b8f",
       "urls": [
-        "bzzr://764a91ca290bfa564d890f3c1a5a88067b04e96398f223576cbdd17bbc1faee2",
         "dweb:/ipfs/QmdEr1zJrD2UYawZzeE6zPuYiYaSHdpLtKeHYixHgRp9ko"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0x05c00863784c63220704197d8446ac1e277fe53c42b5264093960b7bb70b9792",
       "sha256": "0x25cfdd733e9c780ab85373268fde7bfa2e4b22093af57422ca3b586c7af7cd60",
       "urls": [
-        "bzzr://18fc5b15154aef1640559c31bbd91ae267def62a2b86e434564184b6d3d283ce",
         "dweb:/ipfs/QmSUakgiWEffZ82RrN7hgLaemdqtLSCD7pfGAKxGhDUJxB"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x7c967d9dc0fdca0db88a7cee22cf5886f65e8fa8b4a145eccd910fc81a1c949d",
       "sha256": "0x7d40c6325c0aa4635babdb8913626b7c4bac6a4f41e1c383de5f398e1fc98e1b",
       "urls": [
-        "bzzr://c1f03890d82592751d779ea2da8a690e15b0ccc5667314bf634c1f16ff4ed322",
         "dweb:/ipfs/QmZcHLPfa2Dz8M3justKYyDmDnaNo4pseTgAeQbtJNYywe"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0x012ae146ebdd510b31c1e44a8d60071a66cdebc77f0e743a6ebc2fe68e67d297",
       "sha256": "0x566601442deff058d393359df59ed72b41e1f6a65b0aa371fab7f903c189b59d",
       "urls": [
-        "bzzr://47c24a09321abb781b5dbc05fffae84ece6844e41a295847dd68ad69633f60a4",
         "dweb:/ipfs/Qmej9jEnSsD2LqGnL4jgbUvHTxTwiFiHqeMpqyuPLaX1uw"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x4ba5500559a9ad03e4c1d3866ba9d915cdb5d7f2e326b4cb1fa0fe7bdf90dc27",
       "sha256": "0x89978dcef86244b8e7af95298abe26aaf4825df819d6c556e4323dc152c988ad",
       "urls": [
-        "bzzr://c609e5725e607a4d853f33c8d46064e0ab11b489f7a585134cfca570e29f447a",
         "dweb:/ipfs/QmdgDj3bPSKU1xKMY8FRHj8E6z9BQefeuaVuF27RpvZMXJ"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0xcda83fe69ce2a319d0caa20c98b53ff36ea1886054ab3dab23fa80ede3dcdea0",
       "sha256": "0x1784f89fcfffccddaa94273a58e452682f61dea05d142406775f099c6ef5d61f",
       "urls": [
-        "bzzr://5eacd00f2f132ea8fbb308baed9753579ade721a44e94067debb602e193b7ae2",
         "dweb:/ipfs/QmPA1Uf4iwkr2ouguzxxFepVxaRg36XFXxiwqYUuwafQzQ"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0x432dd5d662d88c2316b4df503f693ae9e6e8ed4216726db2fdb3e7f628523fe5",
       "sha256": "0x6e095eefc48dfc21fec18d0b63f229e929f881b5d6e8a999e1622c6b707a7f54",
       "urls": [
-        "bzzr://1b3ef14eabfe47ff614c088337dfdf163c695612c193aeab9ac5a2af69d30334",
         "dweb:/ipfs/QmSgJ8Ru6vraz9CyCDPMifVxpckkoooVSBj9vYcQqG4wG4"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0x98e1027fbf3acb279f740c3b38df69d79ad3f2e6171414508d50604dc2dfc13e",
       "sha256": "0x43b85bc9941814b018065da5c6c8d40e2af49264d0d1f06bdefbfbe628e65ff8",
       "urls": [
-        "bzzr://b6283a40a65b321a0e88f61594fc8bed00fb21a53c7ac1bf5ae421706a372d01",
         "dweb:/ipfs/QmeXatGB9MdWA2NBLSNQbcKvuZpa4Sxem51vCrqyQGfXnU"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0x6f9251f86fd798a3ae25688307ffc7a9984dcf0d809a1aef54f5c68b6cf9fb6a",
       "sha256": "0x0d34e4ed048bbf67daacdf36cd5ce0f553a32962967b52edab6afccaa071878b",
       "urls": [
-        "bzzr://e866e6bdb31fea0646b44a8e57acc9505932ffe813028ce1330ca49fe3edc4d0",
         "dweb:/ipfs/Qmdx3AHUB8bN6ZZs1XsTV3Gz9FV3gAB7x7JbYeUsn43Azu"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0x6abf17bdb1b934d072739e0e083ecfd579c523d200d45184b8d3987924ca0454",
       "sha256": "0xa09c9cc2672678d461dc71100600bb58802db87be4de9424769241712ccbec03",
       "urls": [
-        "bzzr://9b51780766b138ee36e2796cee7bdd4cb494da5d925c36cc6101202818d37e42",
         "dweb:/ipfs/QmQjodGav6KhMDjuoyJ1ag8osgKLBsFC1E9LmaGP7qCRZ2"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x936e6bfbf4ea9ac32997adb893b0aeecd050cfef8b475f297dca1add0a1ff934",
       "sha256": "0x7fd1d3f1fddc615e117f7fb7586acabd60c649c390cf110c8fdc5ce159fa5734",
       "urls": [
-        "bzzr://949bfec63a83091f5d08d6d8df36fa34e674d75206e8a6476cc0ae18f3c57bb4",
         "dweb:/ipfs/QmNrRJwVHaJSZ3aAQZWZKjV9o8BqWKFP3RPYL6hKU65PAE"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0xea559c55bf7046cb48378fe9b43eaab6e345700aa22d701fcf946a42ec6b1008",
       "sha256": "0xf22c63511a85230f7640ff5a77433db643d8d32be8b7c7f1dc24c1301a5158e9",
       "urls": [
-        "bzzr://471b0435c47963835dd0f70d67ec069fab5daadbe6c8bf760d2e50adfb839461",
         "dweb:/ipfs/QmTQPQb6br2VEzKTiXBEE6z69xRXEk24xi2R2gn8EsvGD9"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0xb2657b5ce7a9b405a65e4a88845a51216cd7371e8f84861eef9cb0cb20d78081",
       "sha256": "0x3628fdefd6971ea9cc16acbf91e5f6d6cfb2079181784b47e4d24f4c5d92e4e4",
       "urls": [
-        "bzzr://7bc2dc95d81092991a4122b45aad03f9cc62bc98fa455f03fc9286445ef9de8e",
         "dweb:/ipfs/QmYWAkYAJo59kc5dHWaLuQqEm7xusESdu5meDzjpxnyXKt"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0x7dc96455c864b49abc7dd5f38ba6a47904709ad132ea36babbfce98d42e962e6",
       "sha256": "0x25f564cbecc5bfe95d6d358e0e7543c31ece0ab1332c555ff323ca163711bd2b",
       "urls": [
-        "bzzr://f61230aa01565c8c24aa2ed50eec7dfd26195be35f5bbe4445c6a3efceaa4b7d",
         "dweb:/ipfs/QmaLUM18c7ecA911ig5u2HY6fAu4AiUbhJpnZwwCMc9cWi"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x39ae8b2f3ba05ed7d4a7c16f0a9f4f5118180a209379cfc9bdd2d4fb5d015dff",
       "sha256": "0xf89514dedd8cfb3c4d351580ff80b8444acde702f8be0e5fad710fe6e906c687",
       "urls": [
-        "bzzr://1d6deff5623d883b8d0b3a3a5539e4604925ce4c1677defb86e0e37838ea70c5",
         "dweb:/ipfs/Qmd9JfFpUXsUQrJad1u2QDuMxBMeVrcG8mrpfJVV9jiBXB"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0x435820544c2598d4ffbfb6f11003364c883a0766c8ac2a03215dd73022b34679",
       "sha256": "0xa4fd5bb021259cdde001b03dac0e66353a3b066b47eb2476acb58b2610a224ca",
       "urls": [
-        "bzzr://62ef2a9bf7dbb8fd596b7c6ca6848d9b1a6c8562d10239659f0a56ee27c110ce",
         "dweb:/ipfs/QmTxzbPN4HwcK5YX7n3PNkb1BzKFiRwStsmBfgC9VwrtFt"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0x6262768243c1ceaf91418e52dc6f52d2ce94d19c6e1065d54499b7bc4d6e14dc",
       "sha256": "0xf8f83757e73f33f44389d1fa72d013fb266454a8dd9bb6897c7776f8fc3b0231",
       "urls": [
-        "bzzr://ed91c1114615572c10a34f0ab28a3a159d2d433fabbcec9eae7253c25ecac8b4",
         "dweb:/ipfs/QmRUoBQeA5zpun1NK7BvBhQk6pTT4uZw7Jn2wZnWQETH9W"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0x3c9cfccc78bf352f4c7901d7af76757bd228f93af2634af4cd16b4916c13e44e",
       "sha256": "0x09f6098026622c5c334c7798c3ad2b8f7c0ebc62f87846c7d5e7e725c3d1cbc2",
       "urls": [
-        "bzzr://ab23bd0e01952ee485f0426c9c4e47fcf6a508bc4919e83be31c0f9ea6e396ca",
         "dweb:/ipfs/QmRj2pxXxvmJ96i57maVjLMfs4DUtCuptM8vSVvvDweJ74"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0xb463b6a61fc027247655a32cbfd50bf543eafa3a6b42ceacdda7293e3ada8866",
       "sha256": "0xb795f1b20f065a0aee492c24071fc1efa1633c3caab77cff20278a9ae822f04e",
       "urls": [
-        "bzzr://c82fea785ae31fb4847f5640e6305edc05d1a5b0b47552f60325c25cce280f75",
         "dweb:/ipfs/QmShUrNZf1dZFjziorJYE8fMGNUSMFsbaR3ipSvsCMvExM"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0x537cefc0579dd9631ec952cae951b3df0a50a3e557b5638107a67275f7aacc07",
       "sha256": "0x3e8b01cbd194e40971b41017ada7c8b2fa941b0458cb701bdfb6a82257ca971b",
       "urls": [
-        "bzzr://130bff47eed9546c6a4d019c6281896186cf2368b766b16bc49b3d489b6cdb92",
         "dweb:/ipfs/Qmdq9AfwdmKfEGP8u7H9E4VYrKLVinRZPZD1EWRnXSn1oe"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0xa2d4d3ebe5d52bfa7ddf1a1fcd9bfed81eaa8678e6a1dd5a1c84954dd064422c",
       "sha256": "0xf1724fd46b7a353561b3f8d473b0dc8c855b6d84b5af559d7e3326ac79b9d758",
       "urls": [
-        "bzzr://2c5fff6b816edb78adb2220f175591c9f4f6d38cfd27a83afb1849191cf9a524",
         "dweb:/ipfs/Qmad6iesaR5FQ45RRtMrt2Fa1EYDuq1oGoMJJB6beMHESn"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0x620163da7ee7b2622c9ee48b06110a52739f633189555148a3b5ecf767e60cfb",
       "sha256": "0xfa27ce9d23bddaa76a4aefbafa48e48affde9a1ee7c8a5e8784cf8d4c390f655",
       "urls": [
-        "bzzr://823b4efe3ca2964d660348214fd1a44579e13e1e8ce69a81f447372a11d60316",
         "dweb:/ipfs/QmUinsRZvs2zFNG6FMWy7ngTYUnZccXq7MRtgpj1dPfxu4"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0xf0abd02c495a0b4c5c9a7ff20de8b932e11fc3066d0b754422035ecd96fcdbbc",
       "sha256": "0x9778e4a7667d5fd7632caf3ef3791d390a7cc217f94f96e919a31e3be332386a",
       "urls": [
-        "bzzr://9f9244a3605543a67f5ff35f21e3d6d3331a6e1361f09b271c37f396b5b89bd5",
         "dweb:/ipfs/QmXyjgFNMyFD4fdf8wt9uvUU92MGdDVGmcPdMZhNEo1g8N"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0xe1412d909a0dae79b13c0066b9bf08831c522daec00b273bbc19a799af213d6a",
       "sha256": "0x3e1956c550ca48e289044c7c0bd892403081b4b5e17e77ce707c815ce6c4228f",
       "urls": [
-        "bzzr://b69ab6704a1e42fddb326e91f331e35fdf071b158e8754e2c887c0e607aee7b0",
         "dweb:/ipfs/QmTs8PnAGr1ijXtWvMjoWraefAtVv2Y5ZnwkArz6NqJ93w"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0x0c7a4386781683c327fde95363535f377941e14feffad5bb1134c7aa7eba726f",
       "sha256": "0xe7e1be3d0a67469f6a37cd676a22314c4faa8a22ff9d5ebde11302db754453eb",
       "urls": [
-        "bzzr://65dc33e3d9ef94defff1b24e66f093d9d15a92c59778c8eb26e76fd8b64bd3da",
         "dweb:/ipfs/QmQFhTptWdDzhemjGpa7Q65HKWGphs4nKKS13nzkcVE8pM"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x3502cf7933fbce9f1fe1d87a83d5b9df12eee36c03997c3b9821493ce03fcf3e",
       "sha256": "0x7fcc983c5149840a47b946fc51fc14f1c21cda07c01d650e4a1f814319cb1423",
       "urls": [
-        "bzzr://617dff84fd7dc06b476f93a95c015a561662d9ff1d3356ac6a3e5f5b09a636f0",
         "dweb:/ipfs/Qmdw9c3usmqgdV2w4JoNWJqscHzscKNVWsWtos1engJa1o"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0x0c80a0bf9e17700249a04a80d7729ccb012a55a82cb0f9e412fa32cc14b09c2b",
       "sha256": "0xdfa3f2bb4589bdc9c054292173c82ee70e65af8d1971598f6e13b9b79ba94185",
       "urls": [
-        "bzzr://a45264806fb74fd38c19704070c83053972270b63bf7b09ddff3c3e15cd1baa0",
         "dweb:/ipfs/QmTNWY4vkVLgtNdfGXyH6CY8URmzr33VzMJNN37z5dsAgu"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0xcf099e7057d6c3d5acac1f4e349798ad5a581b6cb7ffcebdf5b37b86eac4872d",
       "sha256": "0xcaf4b1f3e01fcf946aad2d22bbe046b9dc4fd50049a05c3458ff239e2c93a785",
       "urls": [
-        "bzzr://2f8ec45d2d7298ab1fa49f3568ada6c6e030c7dd7f490a1505ed9d4713d86dc8",
         "dweb:/ipfs/QmQMH2o7Nz3DaQ31hNYyHVAgejqTyZouvA35Zzzwe2UBPt"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0x300330ecd127756b824aa13e843cb1f43c473cb22eaf3750d5fb9c99279af8c3",
       "sha256": "0x2b55ed5fec4d9625b6c7b3ab1abd2b7fb7dd2a9c68543bf0323db2c7e2d55af2",
       "urls": [
-        "bzzr://16c5f09109c793db99fe35f037c6092b061bd39260ee7a677c8a97f18c955ab1",
         "dweb:/ipfs/QmTLs5MuLEWXQkths41HiACoXDiH8zxyqBHGFDRSzVE5CS"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xfe223dd264421f9b96c3dd3c835a3d0d4d9cfa4c61f75ca0761860c9ae8906ca",
       "sha256": "0x2ee1c6434a32a40b137ac28be12ceeba64701bfad5e80239690803d9c139908e",
       "urls": [
-        "bzzr://d67cf500345ceca523e9bbe55dab9399e27321fd9005704a5b16bab82185260c",
         "dweb:/ipfs/Qmf5fpJmeHdwgmSjQPqdu25XtA9akTotakkNmrh4axgo8N"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0xc68517effed7163db0c7f4559931a4c5530fe6f2a8a20596361640d9d7eff655",
       "sha256": "0xb94e69dfb056b3e26080f805ab43b668afbc0ac70bf124bfb7391ecfc0172ad2",
       "urls": [
-        "bzzr://523852f3e01b02ce947771e0279ffb6154d12700f809ba3606d908ba6271431c",
         "dweb:/ipfs/QmWjG6PLzF5M6kxkHujhEMg5znQCgf2m1cM1UptKA719Hy"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x08dd57a5cf5fd59accbd5b601909ffa22d28da756b5367c29b523ff17bbc2f99",
       "sha256": "0xc596765f9b3dce486cf596ea35676f37124d54f3ada0fcbc02f094c392066a59",
       "urls": [
-        "bzzr://7047ade6879aab4c825594dab0914b8ec673bb907eecc6dfbd68f63086e5a36e",
         "dweb:/ipfs/QmYh5C2rgDAx452f7HyHA8soLhnoL1GeeNNEWEuw9jKY8w"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0x84a0e9282047512eeec499d55c83dbb6981430b08692d81d6c09730bb18e6cd8",
       "sha256": "0xf77f141e5fed9594b28342e2c630ac6d48f2a724e4383a457881acd7fa62b1cf",
       "urls": [
-        "bzzr://da8c5ea3f2ecd33d3f83ac2c276871f4ee41370fb55ae62c6c29835c9376bdec",
         "dweb:/ipfs/QmQ6W5VedQpZAwuGTtp1BhmNkvVheLnJq4xwN9Qmt9bAbH"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0xd0c15275c5b0d03871332719def9b0f17e8860c7db60e0e71f18b971458a7391",
       "sha256": "0x015e83fb0b72ccdafb0c217961b21a0321adb2d3f2ad992f5e79635c2086e6dd",
       "urls": [
-        "bzzr://629ae5ad84c45c248144b5eec7827a9cd5b2f2779ef84ab251c8cd876347a098",
         "dweb:/ipfs/QmdfVfa2mhyosaJVeV7rbfnvQ95GTHPeRPzmvxcds7RYej"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0x51777116af58223a41aa3016d0bf733bbb0f78ad9ba4bcc36487eba175f65015",
       "sha256": "0xb5cedfa8de5f9421fbdaccf9fd5038652c2632344b3b68e5278de81e9aeac210",
       "urls": [
-        "bzzr://c7d43da1bc5529d2cc311e00579c36dcff258c42b8ed240b6c4e97bd85492a64",
         "dweb:/ipfs/QmWbNMzJryhiZmyifLDQteGPwN4aTgXQB6barBvXYVw975"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0x7e0bca960d11fb095798ff65d029436f23358ac060b25a0938acfcb4652da2ec",
       "sha256": "0x4a14c7bcaf0d988a829db2174b8f7731898aa8633216490603ad74bff64eca3c",
       "urls": [
-        "bzzr://7f33fe204160253c7ec23cb0ac83224bde3aca9f91a7a686cb67d99248c5fbb6",
         "dweb:/ipfs/QmPYDf4qYtZLNEAicW7hcvpUJ69FoHiXmUypipDpTKo9hU"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0x6d6d75b033717aae0a728e527005d8d2cc7dbd0a835c8873c630a2a9689a2976",
       "sha256": "0x4af595f976235d33a22ffe223e9e3210b4ca510f6a93f153b3daed60f2b11fbc",
       "urls": [
-        "bzzr://d501ee8c460db75379b5716bcb5ae10e3e32625d6c9b08e319822a110f178906",
         "dweb:/ipfs/QmNWkyirqXy3gDHNXpPuVUbExMGWjMqPR82Xzs64RzgQzy"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0x070e41c7f761ff1a8383a2c0d54c22aab0f115ca8c3790ecea27d6dde11611ca",
       "sha256": "0x06a671efd8865a6ecc0ad648076177b35abcd06a7059888ea65111272e33a57f",
       "urls": [
-        "bzzr://e4f8176cdb3a0f3ba0b7061079dd9d3495f6a2288bd724780337cacd96515148",
         "dweb:/ipfs/QmQre11ZPgWSx79Jzca1tkTYFyMbXz8H4kcrhfpWSj4qs8"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0x8d6be9e58c33d265b5a8b1132a27fce126067419f3f4f15d3ef6b7147593b61d",
       "sha256": "0x663ba99f7c7ee907f0f03227502d48a78256c3c292ace3b79a5d3eb510665306",
       "urls": [
-        "bzzr://0bdbad1bdcc3a9775f16f20a35556be4baa0e6c9a9b9d820e8e2cdea80667c6a",
         "dweb:/ipfs/QmYv3Rsi9pL6PZAtc4XLHezPqti8yCRGEdDBqzEsQv57GV"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0x56cb2f6978bf1213982ef217ee76b39dc97b6e66c92a7be7a1b44079c0236e5c",
       "sha256": "0x534b7d4079d13bb4cd10b7559dc105c2adec625df4105f20ebce47e6da60bfda",
       "urls": [
-        "bzzr://7543aa16521848b06a1359afcb9dbd7be1dd09a36f4ca53edd3ed3a512a475e9",
         "dweb:/ipfs/QmZaSrn3TPvPVoShtjSonQLFd3BV6RdgRMqw8GTzhnKYpm"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0xbc470ab3442e78bb4d3f16c01c39b2f160f4f34eb4373efed11c234e1c7f6ca0",
       "sha256": "0x5b25f987aae32a0275fdc6c1be36cc47cf126024a04dafd8e4be39a1d1d1422c",
       "urls": [
-        "bzzr://83bf64f11a09845a6eb732da08283a58f877e9227190f489c9852f790c81d0c4",
         "dweb:/ipfs/QmfFq3MvisCSUJy8N8EVsBribgPbdpTZb7tQ2eHYw7dwag"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x3820aae0de50f10f62819d65f0b5a236ccffed11ab465a3295a5408fa47e24f5",
       "sha256": "0x5eaee3240a06891abf5ac70c75caf9a0c33ebe9a2736abdaa22a337f86c22933",
       "urls": [
-        "bzzr://5124a21890d6b0ae70bfd031f741d7edc74cff70a26ca74750d446b15a8efb06",
         "dweb:/ipfs/QmcsfYpEWbPXfVptzi1YvGokxi2FYCUzUr8rQYJCc5fEiB"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0x798b23086ce1339e3d47b3648a1f3ae40561e2c9f66ffcc98e71fc14a7f77584",
       "sha256": "0x64117d4b13bfc5bc6e5f80823519b140e753a0c09e99edd756772dc3029bc1f8",
       "urls": [
-        "bzzr://0fd1c8db6338b2143ab0e49a33edaa133108ba77f1238408018b5b2a0ecdeb62",
         "dweb:/ipfs/QmNQTFQmfnjxnDmbguVSnZ5DiHGFQHCsffccW5c2DMcSsT"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0xdd4ae95607655404b769fab5f949ac95c6a1a506330f512aef0d92974c390431",
       "sha256": "0xc2c4738c96ad329cbb9baea615ed50ffb5a53d93fed8e00785e47242581d3c60",
       "urls": [
-        "bzzr://38f396377d5a5a60d0b9d8c4dc1343485517ff31bcd281d531f98534dc79d811",
         "dweb:/ipfs/QmVdW2ygaT2vecoSUog3HUn8hZqXU4XXQZvuRSdpV6DJPL"
       ]
     },
@@ -956,7 +877,6 @@
       "keccak256": "0x9afa714859d1c8f8ed2fded497b83a7a420474282494d25d4c9f592667729f21",
       "sha256": "0x387343bcf8f2b77fe4cdcddcaa84361fabf8e1c3508f874fbbcbb9c313542f56",
       "urls": [
-        "bzzr://ade0fd040981c4e8c7adfe366296e452687c7bb6421de8546a0678be4add016a",
         "dweb:/ipfs/Qma9V9dJwmkim98H6DQX4f7RH395vsUuqHCDxbKetcbj18"
       ]
     },
@@ -968,7 +888,6 @@
       "keccak256": "0xb0f7f19a8590e5c0aaf779019c1deaafed170d8c26bec9bfd782d212e097619e",
       "sha256": "0x7c3b3d0066fd381283b1d8d9a86153b2ddb5c01da14a1ae015c05cfa484e81b6",
       "urls": [
-        "bzzr://fa438d41ed52c9e0cca556efee61486fc77e60df06081921abb0a0f19b602d35",
         "dweb:/ipfs/QmcM1TcDB4ta8ttNLWZ4d24M4Qs35rc91sQkdNmJMNbuvV"
       ]
     },
@@ -980,7 +899,6 @@
       "keccak256": "0x4f6cdc0f25e734bcb977bb6a3e22fa41d8a82cbd5f220a2e4238c2d233526d1a",
       "sha256": "0x71135e459d691767ce3453bab4564ef4a640dd50182da36517cbc1f96c1d4c7c",
       "urls": [
-        "bzzr://ac5baefba32f4779a03d1207d9f1ed69365280c702fd73002a729b7a3d52c425",
         "dweb:/ipfs/QmPiBrYZxxpNZPQ98GNyL7Xa1F9Dq7uHtdt9ESwhPNkHhc"
       ]
     },
@@ -992,7 +910,6 @@
       "keccak256": "0x331f4bc6de3d44d87b68629e83f711105325b482da7e9ca9bdbdd01371fee438",
       "sha256": "0x27b2820ef93805a65c76b7945a49432582d306fd17a28985709a51e6403677c2",
       "urls": [
-        "bzzr://af0d70945c85865298732ac2bfdacdf2774fb4daf793c94fafe135b839a60a5c",
         "dweb:/ipfs/QmWzBJ8gdccvRSSB5YsMKiF2qt3RFmAP2X25QEWqqQnR4y"
       ]
     },
@@ -1004,7 +921,6 @@
       "keccak256": "0x3f2be218cf4545b4d2e380417c6da1e008fdc4255ab38c9ee12f64c0e3f55ea9",
       "sha256": "0x617828e63be485c7cc2dbcbdd5a22b582b40fafaa41016ad595637b83c90656c",
       "urls": [
-        "bzzr://fe8da5b2531d31e4b67acdce09c81eccba1100550a7222722152ffdb16ea85ef",
         "dweb:/ipfs/QmTedx1wBKSUaLatuqXYngjfKQLD2cGqPKjdLYCnbMYwiz"
       ]
     },
@@ -1016,7 +932,6 @@
       "keccak256": "0x9a8fa4183ef95496045189b80dfb39f745db89a903b398e40131f500953e5d57",
       "sha256": "0xd82bdcba2c386d60b33aca148a9cfdf097551f68c5e45d8ec01aebbafacf5075",
       "urls": [
-        "bzzr://338117c2130fcb6bce3006330712b6e7ee99875b56ce4bb6182312f76e4a6bac",
         "dweb:/ipfs/QmcKzrqRBy7PeFQxzJDs1AZZzNHKaKbJces6zUDysXZofJ"
       ]
     },
@@ -1028,7 +943,6 @@
       "keccak256": "0x6be35b86f5656c06ae897ef311c28da375bdcbded68c4a81e124f2cb36adf830",
       "sha256": "0xe0b74e0a16e783a35169f74d1a615ecb48d07c30f97346b83cd587949268681e",
       "urls": [
-        "bzzr://434c17a0cc3bf371e5b9baa7f804b37ffd2dc141a98c59b2ba6021fc419a39c0",
         "dweb:/ipfs/QmPnhNtzrEBeWWQMXdAByQTDPoKXXV9NFXLk3YL4QbghMP"
       ]
     },
@@ -1040,7 +954,6 @@
       "keccak256": "0x3a420fa9963772eee5b9221ebb8cf9548eea8f88b09537390960ea9b440f333c",
       "sha256": "0x5c509f760dc110a695c8b39bbc21e08c17dee431aa14d606f59e623d7c3cc657",
       "urls": [
-        "bzzr://fdc05062e4c7ec85ed18ab17b6f04f3274a4b7caf0be483eb86007d708825fb0",
         "dweb:/ipfs/QmciAxUX2kfuoxitmMdkKSfWn2SfxQdieLRa3S5S2munot"
       ]
     },
@@ -1052,7 +965,6 @@
       "keccak256": "0x370efd28e2d28b6d0ba55e20d8994f3d286c3772552ed63586b5fe157c0d3c57",
       "sha256": "0x45bea352b41d04039e19439962ddef1d3e10cf2bc9526feba39f2cc79e3c5a17",
       "urls": [
-        "bzzr://5e66947c220c91a6cd39bc22965dcf861015b8613a6e09aa7fb7dc10f367b5d7",
         "dweb:/ipfs/QmXLgy6oexvCBWYS5pTpJWohsDNGqgdNFLRKX7JrE3NxYt"
       ]
     },
@@ -1064,7 +976,6 @@
       "keccak256": "0x907eeba6e6e0d6977ac5a8f50e4dd2762539ca827ceab1afb1f5a4f0f3ce3e0c",
       "sha256": "0x92d283c545395b91a656fa1ec94d567a464bca55aebcdbb99debf42b43026845",
       "urls": [
-        "bzzr://63ec828814e2b57db2a7a146061a96cc39797ba39a0063a7b664421a48f21c00",
         "dweb:/ipfs/Qma6o4e57YtWj8cQLQs12r2Enx9qmRA7VHtupCauXjYTAk"
       ]
     },
@@ -1076,7 +987,6 @@
       "keccak256": "0x743aaafac24d9740a0b71215f55a132f89336a662487944767ca4bfd66400769",
       "sha256": "0x9c681b165c8647867589c0a5ecdc8692637a935928a2b1bbea2ff4a1f4976985",
       "urls": [
-        "bzzr://6e70fe6bfe8c3fc63f8a3eba733731aab129e6e58828b78058e53bb50440709b",
         "dweb:/ipfs/QmZy5ho8W943FMGwppXZFS1WFrVwV3UXhUUwcD7oH5vrYe"
       ]
     },
@@ -1088,7 +998,6 @@
       "keccak256": "0x1b6ceeabad21bbb2011ba13373160f7c4d46c11371a354243ee1be07159345f3",
       "sha256": "0x11b054b55273ec55f6ab3f445eb0eb2c83a23fed43d10079d34ac3eabe6ed8b1",
       "urls": [
-        "bzzr://c604bdd6384bf73594cd0e5cfbe979048191549ebc88e70996346f3b744c0680",
         "dweb:/ipfs/QmW2SQbEhiz3n2qV5iL8WBgzapv6cXjkLStvTMpCZhvr2x"
       ]
     },
@@ -1100,7 +1009,6 @@
       "keccak256": "0x4639103a26b2f669bd3ecc22b1a1665819f2a2956f917ab91380bd9565dbcd01",
       "sha256": "0xf8c9554471ff2db3843167dffb7a503293b5dc728c8305b044ef9fd37d626ca7",
       "urls": [
-        "bzzr://d201e60bd46193b11382988a854132b9e7fb0e1574cc766cb7f9efe8e44a680c",
         "dweb:/ipfs/QmdduJxmPXungjJk2FBDw1bdDQ6ucHxYGLXRMBJqMFW7h9"
       ]
     }

--- a/windows-amd64/list.json
+++ b/windows-amd64/list.json
@@ -8,7 +8,6 @@
       "keccak256": "0x8ad763849cff88a5e6446bc8d261d4983f993319fad8947538800316b22ed3e0",
       "sha256": "0xe2815a517b24f6695b5f85002dd5b6ba095a327687708cf0d762db311600f6e9",
       "urls": [
-        "bzzr://e96e68d314c6e0eac252093b983ff1a67eb1718277940505e73b0c8cea8cdb2a",
         "dweb:/ipfs/QmYJL1V3jyf5zJ7ZfzVgdCGUCHxhwQLgsqFi3SjaYRT17H"
       ]
     },
@@ -20,7 +19,6 @@
       "keccak256": "0xe45a3d296656d66cdf9e7c5eec47b37afe260b9eed81dcbf60717b5c7b388e08",
       "sha256": "0x34e10611651cbe9c2d7b8b4d1cc94779fc80d52a6c6975e308384308fe117eb9",
       "urls": [
-        "bzzr://48505b6688b4509345d078c566fb2ebcec2716905777cb6a3cd66af60bc44fb2",
         "dweb:/ipfs/QmbdrkjQMueW2dJ3kZFXpMoyuCXuPrb6YdUZXP9ud92ueT"
       ]
     },
@@ -32,7 +30,6 @@
       "keccak256": "0xe8ba1ef2f572e166e7a13173a6fb20d9bc4d7c018f53be1aa3b8597b2ac5364b",
       "sha256": "0xfca24ce3cb85bcb5e409aef626f27c2785493f895bdf7112e9c04d89c03dc288",
       "urls": [
-        "bzzr://2b1d8121498dff90d9188cdc21ae150fb33f3a18ffb49109ecd924f9436c87de",
         "dweb:/ipfs/Qmbz8uYBVWkLHCcDrfFojExPsgpPBniZvmYLajT1sSwuo7"
       ]
     },
@@ -44,7 +41,6 @@
       "keccak256": "0xbda1176403e9761c3ad8ebde0bc7103a60b3ce0f3668a096cf7eff712d094db2",
       "sha256": "0xaae6144ce5cd12326e80b95a570ff841490f052e0b45ce3408303cb3a2f307eb",
       "urls": [
-        "bzzr://f04069b53e048c5eb2cde4e515f18c749f5839e5f132eb83bd7c2cb244222526",
         "dweb:/ipfs/QmbLBjSNvQf8EwL7ENNsB13F8dFapYYXungbSkrHpoS51K"
       ]
     },
@@ -56,7 +52,6 @@
       "keccak256": "0x32a1309e9650bcbc79dac80e8c006058c2976d83dd0acc41335e10810e11c6e9",
       "sha256": "0xecf5f996b8ff66bae30071372728df4d8ce1c867d395411ac8463c2cef112851",
       "urls": [
-        "bzzr://a2edba454cbd3c9965ad8bbb825f439268eb82fae6a034ffdfdacd4872397683",
         "dweb:/ipfs/QmVpro2wSTnJEMvg2ExXNzkesuTzBCqGu7F7ZSm4Edm3PX"
       ]
     },
@@ -68,7 +63,6 @@
       "keccak256": "0x76e1198403fbf787eb35e7ddaf484529fb45808fee29a5fffc80df6094a8c678",
       "sha256": "0xa3647784541931671285db886827aae982942440cbcf5dda88ee03ec50b7d8ec",
       "urls": [
-        "bzzr://065e4cd673a82221a3c37363e84f192c7529401cccbfec8ab1543e319cf360be",
         "dweb:/ipfs/QmNrNEkB3csnBWDq7ynMjxbEkWgu3RPwghfHoaH66RtgGF"
       ]
     },
@@ -80,7 +74,6 @@
       "keccak256": "0xa86c1483ed721085adecc114ae77a8e03786dcc193135ea98262bbbb010a96c3",
       "sha256": "0x793418c77bf9fb065914ca9831411918e5c47f17708050cfb16abdda579dbe1d",
       "urls": [
-        "bzzr://6845f5ff6225adcca4e49272627490d1f95b3a1464832dc25dd6034602226414",
         "dweb:/ipfs/QmNmDGKmbgxcek11kKpfsaWcoQapAKtLhysCTw5Fa7rDMp"
       ]
     },
@@ -92,7 +85,6 @@
       "keccak256": "0x4aabfa3991923f514c7a55ed2cee9f0ecb52a4e752c13c7776224ef4f011bacf",
       "sha256": "0x4f1f5d548c6d1ce887a21a0730680c0955711cdc27fbd02b221f087271b5c40b",
       "urls": [
-        "bzzr://09e33f9f803de825a71ff14ef1f373a0b147b2fbb30f87d4e3a0a3cc75c79843",
         "dweb:/ipfs/QmPtuVqf2UZxAQJeMiBJL4t8CYB3HLHUst3YXwMdeAtxv9"
       ]
     },
@@ -104,7 +96,6 @@
       "keccak256": "0xbe2ba8f580adeadf340604e1d7f7e76f053f5a3dea31c723269910a92c74e479",
       "sha256": "0x4387ef9733643ed387e5975d2241e423bd8d79c54db90d07a70c62c8c3e1be77",
       "urls": [
-        "bzzr://3209ae7421c096bbb1a33d46040c5bfdff41587416667f8598c49f97f7a91c41",
         "dweb:/ipfs/QmSCVVtDLzwCBv3h9NXa2MKaXZnbofNFXFYZVPcsW6qNhe"
       ]
     },
@@ -116,7 +107,6 @@
       "keccak256": "0xd3c42b28bf9970da9d6675672b19ec97aab4b33c243633ff041df748f340c953",
       "sha256": "0x52e312b41980400cd37c9b7363cdf5d8f4efcaa0a1fd53ceb840e2837d6014f8",
       "urls": [
-        "bzzr://193648d3588b3951a98dc4e767db199acd82fcc3a50a5a6e39d17e187b3a476d",
         "dweb:/ipfs/QmbsVx5b7Y1jAr41C4PYHuH4sC8mhtg26yQoCppJzRxyjM"
       ]
     },
@@ -128,7 +118,6 @@
       "keccak256": "0x61bb18891689eacab989730ad71cb0ad812736b100e9c5b22ac92f51bfd52a75",
       "sha256": "0xe352d97d7fc9ebe2e271d46b38e0e8ca95e1b3d7e6eb87d998a0b439384b5e02",
       "urls": [
-        "bzzr://88932addea1b0e22da43077f72d405df894e81c917efa3b84ff9aa51e864a53e",
         "dweb:/ipfs/QmasAhfrHXw7oC5GEdUSqG9tQ4jSti1ZKKfajANpbVh7UU"
       ]
     },
@@ -140,7 +129,6 @@
       "keccak256": "0xa4f951bd073094f5223c6d3121bdf433b45d20acdf42e4a6143c8e0b11c42687",
       "sha256": "0x0d8e576d402d819e36e7020f875d4111335fa416d03ad0aebdf8596d6f3767fc",
       "urls": [
-        "bzzr://b5420ae0abcbedee59d8e34a02af3c961e2ba97a43d11e7ff5a5931d25293343",
         "dweb:/ipfs/QmckAmGaP8fPt6iTbHD4KmQXJzvxbMH3mk8ypWSG6RYjPV"
       ]
     },
@@ -152,7 +140,6 @@
       "keccak256": "0xd66750e9c72e3b83d2cf5182b24094b4c4e0246acab72d6380dbd7a01778dd8d",
       "sha256": "0xbe0550cc8fd6d60311eb149fc75152c49fbaee694ee9c0ada7ee06733b9744d6",
       "urls": [
-        "bzzr://e4d61367f9163881eda882e3eae3902e50d2854b98211782b83d88bac5b75ae8",
         "dweb:/ipfs/QmVFChhTFSWY9LwhMsiWULsEExvaaSbuixyhpM7nA9PmRU"
       ]
     },
@@ -164,7 +151,6 @@
       "keccak256": "0x861c801b4e9d126405474447021ec1dd5671561144b54841e9dc24ea318389a3",
       "sha256": "0x064c0e200bee546551d335174d765572972ee4e71a3d93b8d19599b0645f1a33",
       "urls": [
-        "bzzr://50ae2123a5fc558e47dacd7a390937ac4208242661c42a862f2d2d07aad05938",
         "dweb:/ipfs/QmSqJwh2duApEN17sVcp3pM9GUEaHzDCmuy4kD1ACeRq4D"
       ]
     },
@@ -176,7 +162,6 @@
       "keccak256": "0x6d4c6a8ae694dbd0e5cc08894f76915bc96346950d691bb6e9c1d13373ffaf53",
       "sha256": "0xb76cc572d072b1d6303aaa90eabf00d0defed061c356ea2320fb5684f2615417",
       "urls": [
-        "bzzr://45c103b3b14b4d01fdf0ede18c0fb6d814849c807f2395d00024e0bfa783fca9",
         "dweb:/ipfs/QmPwzUTg7oVbdSCzFnxUbo3UWStcSM6xPhC6bWopZJ7tyu"
       ]
     },
@@ -188,7 +173,6 @@
       "keccak256": "0x36749b20f7695b608e87d23db6f3750b150506da64262694b9ac6209a5542a04",
       "sha256": "0xcdd99d6c9a43e87130e57ef44e03a55e38b9bb1ce4a1121b22815d5655c1653a",
       "urls": [
-        "bzzr://8a88446abe699540e8ba4b62427b8b0802f682c3cf176d9351350295c3129455",
         "dweb:/ipfs/QmcRCfiwva7gpLKZGo7X6aiVRLZMmCQPRwx5jWhisW4u9j"
       ]
     },
@@ -200,7 +184,6 @@
       "keccak256": "0xe1a8e395e57ec9e4a526d3d30d5b5385be204134753f01f7fca978af42c3196e",
       "sha256": "0x12a44c124cd43ea975b00cd5d9d17d5eefe8e338a0f875208338f16a84a8a43f",
       "urls": [
-        "bzzr://19885d6d54ad58435c4e420561f2a8472c6074a2d021bfea445f2f5c5265c4e5",
         "dweb:/ipfs/QmVW5oBkmtovWxCq2rBzNeW6PnLvYYK5FAFgwctpxMPvJx"
       ]
     },
@@ -212,7 +195,6 @@
       "keccak256": "0x511a883d4dbdc86ece1fb217af219f3653c503408b7abc813d3964f1c772da0e",
       "sha256": "0x3ca115b8d9dac2b96e10b1d0bfa8b0fe4e7ccc087fe0890f4629ee09c3533314",
       "urls": [
-        "bzzr://19e8171b2c846fca302eeb45af1c7fa43ee7cc71ef7a14e458fa696b06596af9",
         "dweb:/ipfs/QmcZs3A8AC9S7E6KQ112fsAnaTHQ6Zz7GYTYfYXrgeEKGL"
       ]
     },
@@ -224,7 +206,6 @@
       "keccak256": "0xc92d2e1ce90dff0721a84f979f042fc136bc876e85effccbccabef2b68fd78c7",
       "sha256": "0x9e734b989f8d6a75bb009283020d991761c030b8af0d15158198d497410c87ad",
       "urls": [
-        "bzzr://15ce2c40101936975660c414e3130c5c46a6a05532a1795edecfb422f8df2e60",
         "dweb:/ipfs/QmT6B9HYKLfF2ET9B6SrNom9P9Ro1JSyJpFsvVoSbkFiEg"
       ]
     },
@@ -236,7 +217,6 @@
       "keccak256": "0xf00767c3ad0f0a3eca92dd2225b435093aee9f5dac587d825dc2f138e6744379",
       "sha256": "0x7c8a9fcadc6b7b970b904bdd372485ef2af74b8a5fe2439bb16d62fe11617972",
       "urls": [
-        "bzzr://685bd47a8066c19b9c9060fc156299d28bd5e480c1e82b5cd6941ab567415f27",
         "dweb:/ipfs/QmP2Z1vvoVX4eb8vWeadNUG25YX2aaWjTVCHJ6kfVzUEY4"
       ]
     },
@@ -248,7 +228,6 @@
       "keccak256": "0xa4fc748d1c7fc7c890f858cce9bd5847b8b6975da7c3f501594b71a58dccc747",
       "sha256": "0x28e001925fee2aeb0ed0afa4afb39313182b79a157b30a73df183efee29e306c",
       "urls": [
-        "bzzr://938679a37871b7716abb880ea6e7cda0c9d99afbdfef4b241718d32e55b032c7",
         "dweb:/ipfs/QmZ98KhvGDeiPAwB9ewfJZzLmsVpUgqRGpKaZwP76NsB1X"
       ]
     },
@@ -260,7 +239,6 @@
       "keccak256": "0x742efc21520455719958b12de128cb1498e18f11c44957d5b85006c5ae3270c7",
       "sha256": "0x0a9f3620a7c9ab63e92cbeb2a6c5ad1e02c023286576b4e61a9baadfa2fec42e",
       "urls": [
-        "bzzr://b826492fecf564bdd8b79df782339a0e4ec2a266d559dbd692eebe091ffc267b",
         "dweb:/ipfs/QmZfWvRr968XnGN1kvFyLzoLMg3V5u8tbSBiu7jdEJZzqM"
       ]
     },
@@ -272,7 +250,6 @@
       "keccak256": "0x0900921512e8135c93fc86ee12f2e1bb0b7199177bf395757a40f874b7aa96a0",
       "sha256": "0xbbcf687dea5d26de255fe585e10b3ad7a55f58b4487ad9235994788e7d16c7f4",
       "urls": [
-        "bzzr://1673dba72e363c2c552cf9f5593aef0970d4cdd0a17637836e56b48fa7657b73",
         "dweb:/ipfs/QmScHcM2YTywhhKDrYEULpbfiKBMavoedCeg12d9t9BgMs"
       ]
     },
@@ -284,7 +261,6 @@
       "keccak256": "0x12942db74740f7f2dbd051af39963d3d31bf8a649d9090c821942e4ad5a01cfd",
       "sha256": "0x8314b16303b1ae0eded0b2930a3f71c477e192ea7f37e3f4d01bf9e21ac4e505",
       "urls": [
-        "bzzr://6e96cfe93243126a0edfb056ad0625e4e6c649db69348e0e936463f28e058c41",
         "dweb:/ipfs/QmQrM4sogezWfmKY3SqdeR3tyhM8oTf3epvCXNJBDUABd4"
       ]
     },
@@ -296,7 +272,6 @@
       "keccak256": "0x5fecc2a4ec40b7571cefeae5a8d9e8a154e7c45a1126404901d1190adb1fe241",
       "sha256": "0xb3681a20aee97cea39915f9129430ded7a7b73c2c21ecb448c230f549e8276cd",
       "urls": [
-        "bzzr://a6b730e184ef384fd80674b0c18c44e7d380c1e7ca880ba2f10cbcc68c5b5369",
         "dweb:/ipfs/QmaPZqP9dfvM9gVTgtBbSfxGQSZUy8kHUcacfWBGGQeuBx"
       ]
     },
@@ -308,7 +283,6 @@
       "keccak256": "0x8bcbbf03c5964a092059f87f217826b8769fabd832335f82d001719c37e7980f",
       "sha256": "0x6cf8f23fcd3461b969bf6f60ccf3f52232b98cd8b34d58d0e7da86b2fb25a89e",
       "urls": [
-        "bzzr://dbf3dc58aa93c5617ecfc9982767ea56f97810b3d59eb3cc7a6cab9867a485f5",
         "dweb:/ipfs/QmY4mBkhMBqf692ebdPJH48TdzRd9ixFae7BFFerQsTfBc"
       ]
     },
@@ -320,7 +294,6 @@
       "keccak256": "0x6bd569335e38785105ec53c0ce247866a1dac725fddf3456460706346c040b9b",
       "sha256": "0x54b15641ad2217a5e1d836a8c13934884f41ec369d74542b0782e7fd70d47d86",
       "urls": [
-        "bzzr://8f808cc7e02f3d4ee2b76553894e94ceabd7a6d7f3c211d768b6c81462c25012",
         "dweb:/ipfs/QmY3miivVZPpUjxxhV6Ht7bGAbY8xf33Y1E1wb9Qfhr1aK"
       ]
     },
@@ -332,7 +305,6 @@
       "keccak256": "0xea6df6e8d1612630c93cb5f425650337d260bda8173aada5cb69c3403fbb9499",
       "sha256": "0x0ef5cc2d15c59e893ce376021ded40443988b332ae19dcdb5b06e57a014d5073",
       "urls": [
-        "bzzr://d95a39d403e6785f18e835ecffca735812cc5aa38d20c0ea5782eae8541ef2a8",
         "dweb:/ipfs/QmUJvGhePXTgAFvhoPJU7UXgfGShepPm7vX8RDTGc1EEAG"
       ]
     },
@@ -344,7 +316,6 @@
       "keccak256": "0x37c6799c359e99f5b352b02a730b45acafde46b3b6e17582dbf971988d5299e2",
       "sha256": "0x32fb8afaba5a54332a938158010622ef79b64b46fe9273f149be08fbc75afa5f",
       "urls": [
-        "bzzr://63b6baf23545e4e9ecf3c0ce69673a63fba9124c2d375a9b3ac9b8f7371e1f60",
         "dweb:/ipfs/QmZARxp8oQophq1Q3qxehYPTw8Jfs8ECa49Z4nHFaguc3x"
       ]
     },
@@ -356,7 +327,6 @@
       "keccak256": "0x687515d49a11e8996d39b2e349f1af9bf44c949b869d9cb8d140291d336ede36",
       "sha256": "0x9b8d949294ad15b8a23bf67b3776caf345b64753c2d06e697f6e012b7e473af4",
       "urls": [
-        "bzzr://a5aa444cf882323498fd61402813130e500160974819a3d06ae1e02d5026ac7a",
         "dweb:/ipfs/QmUAsFbkeKN8xZGhxe1KnNMvFimUuZmdEdqPacm6L4Lfqi"
       ]
     },
@@ -368,7 +338,6 @@
       "keccak256": "0x10b6ba85e0886f30fe07c012391e9ef84e74d2b26aabfac3f1f1fa15f825db5e",
       "sha256": "0x490130fb35eef67cb748eb5ad5ff728fc366302da80e1684af00723a07ef31d5",
       "urls": [
-        "bzzr://6c9766d1f9df5871f42e42f4a050161ebad1ad2b1a6fcc1f062b33d63a28c383",
         "dweb:/ipfs/QmT2XZoMzfLXGFBbHEZgeypYrbPSyReDQMcvESgQCBrsV2"
       ]
     },
@@ -380,7 +349,6 @@
       "keccak256": "0xacd33505d959ce83a2bdca4602067b14bc73854d521a7cbb07cfc9127f65c56c",
       "sha256": "0x16fa8226d52a00d88a887bbe2d49f08e10cdc04dafd789621686ab07485ec8dc",
       "urls": [
-        "bzzr://947dcd456b28fa9aeae736b2208cb5c7be2a43365b009bfbeeb187d3cfab2c7a",
         "dweb:/ipfs/QmTNXAhJikGpibfJFcQDC3oYgn11RbLm6dgfmHb8ucqHyC"
       ]
     },
@@ -392,7 +360,6 @@
       "keccak256": "0x253cd8ff00fbb05a4d26de79911f3156d068d392fee07dec1c64fbdd82b77501",
       "sha256": "0xd737fd544b7d5a34917ccd95b3c8251c2573caa54a3951332827d8b4bfd5d069",
       "urls": [
-        "bzzr://61c6eaf64799a9a28019d4ee744410a3942068d8970da0d4cb971e58fa53fff8",
         "dweb:/ipfs/QmdmP6W3VLrxociecXK8hj4W2z1DoqJ1RjcijAeo7F52B1"
       ]
     },
@@ -404,7 +371,6 @@
       "keccak256": "0x8e9d4df8c30194f0cfc776cd974b1491eb8f2090d36a6518499dac8ad7610d7c",
       "sha256": "0xbce6d4a77bffbc01bbfd0032a66e877a099af797fdcc0e5948df6766af7952ab",
       "urls": [
-        "bzzr://6f20ce77325a431a7eef2ee13fddba87c435c9cb2bb45e78f18a67c63d548449",
         "dweb:/ipfs/QmTHMBmRRoYyEB5tkmrYiZpCPWa8pxwhkHNR37smTLH6Hu"
       ]
     },
@@ -416,7 +382,6 @@
       "keccak256": "0x16acdfff67a7d55aba6e1bf14a678fa67bed913900e6308f278a2967201f960b",
       "sha256": "0x7ea0dfe43f7d9a69237d07cb23ca77eeaa9cb0c361ff62b798c42dd93de96596",
       "urls": [
-        "bzzr://06fa72a0bff48b9a762fd3fc3b679acaa351ca0c8520639f4eb2ef6637d387b9",
         "dweb:/ipfs/QmPU1ZeAaU2QAJxnV6mzTT1XzGAVoaDgGYFa5BM6Qi4mko"
       ]
     },
@@ -428,7 +393,6 @@
       "keccak256": "0x94de5c21f6883b3d17318924b8e1b270421095caa47f4a316bfaa539c13e1d36",
       "sha256": "0xe187556d3f244d441319f1e2f24da2ecc0f79d6c6f4baee820f9f321fdc89286",
       "urls": [
-        "bzzr://dd70cb62c8ac4810530a749c762639049c80391b2414618fe95d0a21c7017ac7",
         "dweb:/ipfs/QmWaw5VgUjRaCY2pA5ahstQZFFWUqWuvWgs3g8X9yPFrvt"
       ]
     },
@@ -440,7 +404,6 @@
       "keccak256": "0x1d2000b60e6bda98c97f85af32dde2e61b14e845a66ba804ff45271f2938b9d1",
       "sha256": "0xe9bd4722af7d300ceb1c896fa69eced4d25bfdc875e00a0e267cc85c9f121eb8",
       "urls": [
-        "bzzr://75c68455749fecb26dc914f70cea9c8a5d1f4d359b4d71944e3facdc919672e0",
         "dweb:/ipfs/QmSsvShhgcaSHmKQ6QNq5CzeCUoiUW2HCW43ECmicacAQV"
       ]
     },
@@ -452,7 +415,6 @@
       "keccak256": "0x2396f159dc82668f11778d50736198fe4e974c1f62a1361f8e412782462ad54d",
       "sha256": "0xaec5ef3a08b64b3d261ead18e3f9118fe5409e9a5861f89b274c07cc639fe9b3",
       "urls": [
-        "bzzr://1bce31ea2fd1fe35305458cc28d5a8ee1a119bf5de00470561c1061c5b7d8384",
         "dweb:/ipfs/QmU4w4Ft71R1f47fC6zxSA1FJSg5JB2ck5BS55yXjQwjGU"
       ]
     },
@@ -464,7 +426,6 @@
       "keccak256": "0xc4b94841c7e5f015fbb5c3aabe5fd75e62419f8c6468a1529b2c22de9ba64dab",
       "sha256": "0xd3311f4fab0072ae09647019e223e2a663a1eef66cfd0092f3ebb4180cff1b38",
       "urls": [
-        "bzzr://5e3cda74ad8c8cd48d7fe2c72b5285e3d1751a58916f2bc2df2902f71b767696",
         "dweb:/ipfs/Qmef9XoYoxzwFSDmijfSBp4WBnPFHaTDyepCfeZzZ7iCV1"
       ]
     },
@@ -476,7 +437,6 @@
       "keccak256": "0x1799e504983ed504ae10e2d00ca1db602f65b0be2bd989e6c06f08a429ccea7d",
       "sha256": "0x7c2acd9f607b9d20555e300a8452450fe1303717ca306a820e9fa254aab34684",
       "urls": [
-        "bzzr://2db9f4a5179eaa48191d0836016f6f7ae99b9b85defac85385f1ea20a06d4b27",
         "dweb:/ipfs/QmbqBiKFpbcJozstfgmUeHetDW4m7oTJKLBZradCvoXyri"
       ]
     },
@@ -488,7 +448,6 @@
       "keccak256": "0x97a1aab77cd458f7aa21370b575d42bf3b8af57d328693bd37d9be9eb30be818",
       "sha256": "0x7f1e4862a46bb3a5d203f1b995fe64bee4bbdb8a5d378090ae0e8306300bcbc0",
       "urls": [
-        "bzzr://50ace888f6f6498b151d31f4c742553b191e2b1219d8adace4da64dc93bab0f2",
         "dweb:/ipfs/Qmb2d1vZpuYNEL9DP1eg1wfAZPvmTevMJCCpUuJDyq9BiG"
       ]
     },
@@ -500,7 +459,6 @@
       "keccak256": "0xf841b88c8ec78153b6ff03c28ef9d755d8fdbc9d3076717e81a346e2e75e917e",
       "sha256": "0xb70623f47c66d24ad1aadcdce755d2788fe9cb7000d5c9059e44d5e7fa0060f1",
       "urls": [
-        "bzzr://8492514994e7c5c66c6cc62902950d800f95c7e144ea3bd0d5a9539a971a6f36",
         "dweb:/ipfs/QmQb1NgBrfsytxYLc4oLurvWNis6VNBhLJ1GS4hwGT9CfM"
       ]
     },
@@ -512,7 +470,6 @@
       "keccak256": "0x04c954fcc4412bd7c44edc03cfe537a74c894c4defdb91a8ddd4a2cec9c7bec0",
       "sha256": "0x9c0d54a3565affa409a80488297e8c253c80e0ef7dbffd4214921545015b5a47",
       "urls": [
-        "bzzr://9d552544b8b429a7679afd2fab22180845a51193f8fb1e1b3112aeebb449ccb1",
         "dweb:/ipfs/QmdhfjKaaM3CoSTJLtKfJLAdBFwWk269wrfuZbeKFhtzr4"
       ]
     },
@@ -524,7 +481,6 @@
       "keccak256": "0x867c4a633d59327b01e0f400a232a7b637a8144b0b9c5593deb51ee2f2229398",
       "sha256": "0xe232b49e88dbb7a33ada09a5ecce5047f3b1f7aa990ae0c682fc2ef48456e4ca",
       "urls": [
-        "bzzr://9df52208164d149981891700c25192dd883831638cc6f0df0d487850f16d578d",
         "dweb:/ipfs/QmckPWJhAkLyw3fBS2fMJCArpTEtZ2JSGd76ZqtkkMeTYw"
       ]
     },
@@ -536,7 +492,6 @@
       "keccak256": "0x60237b2fd407c4cab46e04397bf84050f9c189f0b6111e35f5abfe8cef7457d2",
       "sha256": "0x251fc0df7f24c1e000958bcb7c0507a7948eb4dcf8c1d61030f8be48ac462dd5",
       "urls": [
-        "bzzr://fc33bd1f84bf527d656c6bd76ef0c40f624e80e725fa0e1511ef3fd2860ee604",
         "dweb:/ipfs/QmaFJS29AFHwkay41GF6UFi1Z93jXEyW6mAtkKox3E3Edk"
       ]
     },
@@ -548,7 +503,6 @@
       "keccak256": "0x3bf94c472e6f62557744fe28b82947a8bddaed5bc3968499dff73ca93ff1c671",
       "sha256": "0x34792883aae2a488868d9463a4e629e10093f1f36671109d0bd76d322c697d9e",
       "urls": [
-        "bzzr://004a1924e4e8562c24b71589893cc0e62bdd9b74ff3aaf0198cf7761460795ce",
         "dweb:/ipfs/QmUCBTtEJYYm3oUjAzYuQBAJE2XZAy2m6tFxzPfAXQVxJQ"
       ]
     },
@@ -560,7 +514,6 @@
       "keccak256": "0xa0c76549c4c80211ef580091fd80fa4fa27a43f731822ba377ad9baff5be951d",
       "sha256": "0x82a6a676f8fe813bddb3cdac0923dc14ac23b8e039978708e2e54425575228be",
       "urls": [
-        "bzzr://d6928356241e04f716cc5bfe653ddaf7239ecee61abf5536fe1dd9bf9b661e53",
         "dweb:/ipfs/QmaKptGqTziTQDAvriXS5VuSdhTnXuzrPUJ7yKnZCyNtXn"
       ]
     },
@@ -572,7 +525,6 @@
       "keccak256": "0xd2dc01a3ac7dd765c07269ba18855de74c1102b1dcd302964e86433665eb280b",
       "sha256": "0xf143b32c9eb446fca787de1688167626a6e3f835775e590a8936e620b0e612db",
       "urls": [
-        "bzzr://fcb9ef68e92f69659a609c0033a0adaa80d09ceb3b6e123e0451fcb304c4e02b",
         "dweb:/ipfs/QmPwkFBd8N9JyYkqXyYgxr1mwf3nzSXPihuL2nYjeGTUSp"
       ]
     },
@@ -584,7 +536,6 @@
       "keccak256": "0xcfe3cca080638af87ce828de6d45fdb5ddf8375cc0215e0de2bd0a0e71d30c10",
       "sha256": "0x4b4c11253c77560ee7d891b48bf996ff7e2334ff9b95cca3ea4958a342de2e83",
       "urls": [
-        "bzzr://42f45506b79cfa5e0d9358dcc569ac8341757f383f4901c578076d0dffd8d6c7",
         "dweb:/ipfs/QmcrxLy15xiCq7vKdabpBTdbNQ6PbHt92aUXL1qR6fpG2n"
       ]
     },
@@ -596,7 +547,6 @@
       "keccak256": "0x0f43cc26292bef1fbf71d0c06dc8030620d355f3fe0e7670be1ab4dc1ac9834d",
       "sha256": "0xe565130ca2e80c8ddacd9957289c8f3816df21946d64dccc5ed8e7fead1b6273",
       "urls": [
-        "bzzr://e5157e692c109477dd6c3e1fb2cbdc5fd6a0d1bb1afc56d949b84ed7ae6765fd",
         "dweb:/ipfs/QmWbJGtLj72yzsy1MKGXTEWi1fBUKyM3bWsEiPwqiL8y2w"
       ]
     },
@@ -608,7 +558,6 @@
       "keccak256": "0xf80346c12f47f1c19f83d44164a56c549602b342aba5eeb065e76e534f88e6ff",
       "sha256": "0x39d26dc65588fc7ec8ba3177bd60a97471784202cb568028e6620458bfe68061",
       "urls": [
-        "bzzr://c1bdd8b7bc191ddb9d814f711624e09a649a7cb45277d6d3b901ad9507c27e12",
         "dweb:/ipfs/QmUoNRJdh9zbT3GZCYrYJ3Hjg6fDeDnbg6EdpLAezTtEZS"
       ]
     },
@@ -620,7 +569,6 @@
       "keccak256": "0xeb74baf460b5321c1307e73dab30b1a52a4098691d87719e930b05977a439474",
       "sha256": "0x5a609adf66875b85acdd672a48f35460659736b7c2cfded01e0d2c4874f48a20",
       "urls": [
-        "bzzr://c4c52398b7f6b4d4fe95a3e27d8fd01ac8ef6a5ff2f7047069425f21ab2077c3",
         "dweb:/ipfs/Qmd18LhCvamRQiEXi4LabHhha42YrsSnvLcRquzs1XAySb"
       ]
     },
@@ -632,7 +580,6 @@
       "keccak256": "0xda5153097c5abae3818abcc6700f11c81bb9f65dad151e6553ceda966606fcc5",
       "sha256": "0x6fcdd51640d82631f59d544958a04c06442f91740afc1c5f71badf83e6471dab",
       "urls": [
-        "bzzr://97b2807ff0a627723d0ee73f0d459443e27d65fe6d5949726a3ff9c88323c766",
         "dweb:/ipfs/QmXQ6tJYYEvfG8qAPthXEuipN3qngLuU8VGnMymmFGPdnb"
       ]
     },
@@ -644,7 +591,6 @@
       "keccak256": "0xf096317cd1a42f24824c72c248d6c8f4d56e32592a3d38c73d84ad32f5916b24",
       "sha256": "0x4f1f180b91f91ec2da8bda8c9ded620cc4c94d1430289238ba7e7af5e2a87172",
       "urls": [
-        "bzzr://d3322f2aa227d8c8e2ad9927dd07159cd34153ba6d7f62a5c15982d24524d447",
         "dweb:/ipfs/QmRUcAQ8CofqjdvCtWQtYARNRb55zprueYmj6QN4EF9x1v"
       ]
     },
@@ -656,7 +602,6 @@
       "keccak256": "0xd5642aecd13b6af819b70e1e2a4e642ad0b481356275d6ed5ff5b77f125d4fc4",
       "sha256": "0x7a1874cff4cae30b9ee0509631ddae34a8aa573cb2a6104f25e4a6a63ab3ad5f",
       "urls": [
-        "bzzr://a9e5bdc12bf07a279dcfa49e1abe45e0b6b83a67442ae60ef83d21d37968321a",
         "dweb:/ipfs/Qmaoy9L2hdrnvudqAkQXXu7kqNnhrtsj2bmcM1b6DLr125"
       ]
     },
@@ -668,7 +613,6 @@
       "keccak256": "0xbd0fc66c6643c7aeec128b6a2017414861c1ec5e06eceb43e7a19a66e29a35a6",
       "sha256": "0x13d9f2b614936c201e1214fea1084d70a59ddef4c7966d5c94716c008510e0ff",
       "urls": [
-        "bzzr://ed59474df948998ca73abc8ebdbd7c9620309efdc26728bb7d74c0d44b6ac9e1",
         "dweb:/ipfs/QmUUEw7mFj77AdLhEgKoGTbm9wbf6373gCuXrCVPiumqyd"
       ]
     },
@@ -680,7 +624,6 @@
       "keccak256": "0xe869643a8ff108344f83c69617f79d7f8f49b37ed65f7189a8c5a7648026a52d",
       "sha256": "0x241c16ca378b90801e784a9188c0e046538f4d6f9c35289cd4d7c7f855c2a0bc",
       "urls": [
-        "bzzr://007ec9302ae0fe96670a539bdec21d56ee7851713e4ca02068c18adb329edcf3",
         "dweb:/ipfs/QmdJHbxXDjG74dcDrEidEQKVKTgVG5UHfa8pXeoBYvfz7B"
       ]
     },
@@ -692,7 +635,6 @@
       "keccak256": "0x750f4d3806b74bfa1f9c2d937003103663e03aad047222add7838baa15cd71ba",
       "sha256": "0x4d4bdeaa6eac6a7633f4bc2882f5d59041d19d09851d33a64534491c96474591",
       "urls": [
-        "bzzr://9eab025cc22cb576920db9a5cdf3fe471312968991d2246ec38afc87912433b4",
         "dweb:/ipfs/QmPEdHnj2Fzb4TtE8gQDobqjmV2tJtBb4nFWfuCeavvngn"
       ]
     },
@@ -704,7 +646,6 @@
       "keccak256": "0x9da78e13815a0316e966c9548d87782198b0f2883df8427c74a069f16bed2e93",
       "sha256": "0x5461bddca624eedff1d5b70bc1f5955b017c4587a7467cb1260bd16a56a8e537",
       "urls": [
-        "bzzr://923159d76646df5147e0ff81a80c8583d77241bccc64c2ca27ae0f124d92f39b",
         "dweb:/ipfs/Qmdux34G3boJkvr49Hnnkf7fsLTjYYzvvE1dX8zfy1CrnG"
       ]
     },
@@ -716,7 +657,6 @@
       "keccak256": "0xa215850b05d1754f5737aa463cf7a9a048c279937994c35c3fb12aa644b4ee2d",
       "sha256": "0xb1532383cd3cec415d77a5415f298fc0a207c740fecfda3f371f2300306341a9",
       "urls": [
-        "bzzr://0eeca185f114d88da32d81af38a7ea4cd71a8e7cc4b132dd52a656108f1dea52",
         "dweb:/ipfs/QmZNMxnJEM499xJYJYD6L5GbkoHwVGmcSdFrhgefawTvbG"
       ]
     },
@@ -728,7 +668,6 @@
       "keccak256": "0x6d79ef8e3eebdb8a297088fd28c21afc96a795f4e408101417d49fb6b7ce0e42",
       "sha256": "0xc6243653b8d894a14bab2b342820bd79eb48695f447b402eebe702d5c9ee0d7d",
       "urls": [
-        "bzzr://3cc5aa9168b572c3d1c53e977fad597779b75ce5243c60e1c4ede50cd7e4aa31",
         "dweb:/ipfs/QmX5H1dHyzKqeFerHriuChCjk2tnfKqMKndnFwrErGg7pq"
       ]
     },
@@ -740,7 +679,6 @@
       "keccak256": "0x4fbd020496c3a9e02c1eeb825d23f4d83d9198c4e21fda19deccdb7e74435edf",
       "sha256": "0x9214e06741c5cb51a61d745697c905f37480c0c8da1d5ac69e3bacda0063dfa5",
       "urls": [
-        "bzzr://e13f9d5af36ac7b732225fb153328c4e533399ab0576c7343721a690460e5110",
         "dweb:/ipfs/QmbckJWhamjWcoeoe1vBMaJgs3cTW6PHnh6KcxAgCkMwn4"
       ]
     },
@@ -752,7 +690,6 @@
       "keccak256": "0xad7aa0c7b9139011142ca59b73483ee18f36f488edb061b2ffe515ff8ac0dff8",
       "sha256": "0xed74a625bd67dbb74f616aec64f771060df3376f38ef068bd17fd5a5fe19d98c",
       "urls": [
-        "bzzr://626c9cf53996323597485a33d19c29f37c08d90bc42d4ed78233675bb4e6ea6a",
         "dweb:/ipfs/QmY2hXxMX7mbtoZZmcZpfg4297DLkbJALAbKtiT19SZzsJ"
       ]
     },
@@ -764,7 +701,6 @@
       "keccak256": "0xc0b395aaf644dd201a91810a5660e7663da957a196ebdde6e872fe437d6090bb",
       "sha256": "0xde87d174b8858fb9cad0d10710009b65b7ac98b333522e82f555dfe62b42bc1d",
       "urls": [
-        "bzzr://e631e9af01c168e852653cc666f7c212a4b74eee3fc7ed87b39adaacd9b80ae5",
         "dweb:/ipfs/QmWtkgWyp5CsTkpiFuw45URN91SFUmj6V51BSLh6owj9C9"
       ]
     },
@@ -776,7 +712,6 @@
       "keccak256": "0xb9a01623672ba81da76e6ece5e1bd8f888218f544dedb8d9689d73cd03bd35c9",
       "sha256": "0x4cf71f8ba00ebc278f3e36f4ddf2074e91e4786ba1278b778cbc05453c4b6c71",
       "urls": [
-        "bzzr://1282031bdd1d4c93e048627285303f29ba92b82dcca5d61463b95cd659e04f8d",
         "dweb:/ipfs/QmUtsVpQLx7MbqRGpZfkoSV4AKvy4NYHThpwTgMUaxYSqP"
       ]
     },
@@ -788,7 +723,6 @@
       "keccak256": "0xe41a089f3fe09dc29c824afe0a6aca566a5a2d32db2b65273d27395c038e2a32",
       "sha256": "0x4ccebf8ffe5ce997fd983183042967be5eabdb835319426a324b334ebcbcc139",
       "urls": [
-        "bzzr://e71211a323d88983b6621576ddb6ed91dced1b520b93980389352f2484a2f162",
         "dweb:/ipfs/QmVt9NaXqy6ErmU7XAXiuo5hbTX66j2Ws3M23m46xmZRH8"
       ]
     },
@@ -800,7 +734,6 @@
       "keccak256": "0x21e4ac93b75af63450b560fdb64cbf444d9bdd003d6a51d6938807ce15ffdc29",
       "sha256": "0x6bd9bb0a601e791692358037b5558deba15f970d82de56d030c6eab0d1e28d67",
       "urls": [
-        "bzzr://c45d532abcff6d795e8abb7f8e55c49dc725cd9ed85a61398a28d1dca2e58dec",
         "dweb:/ipfs/QmbRxTTCNLY2yaPp3fvZfkGkiagCiYfe2ba8go33BFJvn5"
       ]
     },
@@ -812,7 +745,6 @@
       "keccak256": "0x85397d0b230dc8bfe83193932ddd44cdcc1b3086796ab5626e6c51afec594bb1",
       "sha256": "0xc29e39d296c6e6dc51f89e347715cb62176aa78b12f450583c4b2cb735c8a1ce",
       "urls": [
-        "bzzr://13851c6174ee72fd94992fa4024a9aaaf2641e55cb74a6fe5400e8c02f49c3e8",
         "dweb:/ipfs/QmXAzMa68euYVhkWPmee1ouho8p1xH4FFNhQJ6SxTcVieW"
       ]
     },
@@ -824,7 +756,6 @@
       "keccak256": "0x7e48e2b4a8e5f80bc922007288b01ec1f2cd50f9a2f5a3dbfaf3f0f858c3f085",
       "sha256": "0xe52b42739da41dfe8c902b0e65daf1447928af3311860abbb165acbb840df8fc",
       "urls": [
-        "bzzr://63c3eeb047497d54e349d93ea2b8e4abc760cfd29a89b14c4eaaba19a698f84d",
         "dweb:/ipfs/QmRnkwrjRPJsM96d4tsrDugn7StFaQSEKyFfK9aagmEq6c"
       ]
     },
@@ -836,7 +767,6 @@
       "keccak256": "0x12724cd950e1344e0bd32f9b5de14b783a4bfb76c77f93ad2cc60460fcbdcb7d",
       "sha256": "0x82db83111c6e2c892179486cb7050d85f1517bf851027607eb7f4e589e714bc5",
       "urls": [
-        "bzzr://8dc91e5377843cc853d8b1828ae443be2c77ac692ae94b2888c24213dd573b53",
         "dweb:/ipfs/QmQTrRBdvKTmdS9bwf5hxeh78sqwVcM1C4GgoyXhz6tefJ"
       ]
     },
@@ -848,7 +778,6 @@
       "keccak256": "0x360baf8c67c84f4318cbbdacfad53efdfcc47291ae115b02993e89a4ebecac93",
       "sha256": "0x2f712e94502d6477ecc592f42ea865022f4f313767bcfdc6d08840769020baf6",
       "urls": [
-        "bzzr://90cc6ff95a2ceceb91728620a8cc52cff3cb331cfbf95b4bd95d3d1b7afabe47",
         "dweb:/ipfs/QmRZKJ3HMJ2yS12pFpUsyB5kcGjrLfgBe13SGK8L4jDkop"
       ]
     },
@@ -860,7 +789,6 @@
       "keccak256": "0xbe1332a3d89a1f58e5943f489db8d84231acc4091806bf99cdbf1e38062a0b36",
       "sha256": "0x7990f118fcda426e18fe67766942c29ebe77817d2a59b1a983a69d11bf2d5aa8",
       "urls": [
-        "bzzr://4fbf5cbd184cc384389c1c809f53e6936541d4ec47808b0705628bb308835ee3",
         "dweb:/ipfs/QmPEaT6tNv3FSLMriXffYYuYttC3d6ZjyhKcUXRNRGBLNw"
       ]
     },
@@ -872,7 +800,6 @@
       "keccak256": "0x1089a195a97531976e0c2b12881e4a1cb9261c9703f784d7466bc5c1b64bea4e",
       "sha256": "0xec9feb83ff291ae74805b38cc6834502fb31be690f325de59dff8e60d8432d66",
       "urls": [
-        "bzzr://e807d7d28b4e7bb626e053fe0b21c66132545a024dd4e724f75fda150d49187d",
         "dweb:/ipfs/QmSF4sJcDNHsDpkfB2Q1JvRkFnErPukJdifoj9VpAaLJHY"
       ]
     },
@@ -884,7 +811,6 @@
       "keccak256": "0xb910bcbf91ef9a1d4cf019591260c73d727d49bb9c1372021a1bddbd39716375",
       "sha256": "0xaabdd5d5dd2148e9e107e3dccd09c92c9600c3c8190edf02c223495b49867c19",
       "urls": [
-        "bzzr://063395470c87499ffb16238b7493deae883464207e7df6eb35f6aa00664fe41a",
         "dweb:/ipfs/QmUFDcmc8MpucfbLSSLDpDZjveCRgV6oqLDaaLZHN1cNKr"
       ]
     },
@@ -896,7 +822,6 @@
       "keccak256": "0xda102739c3edb2e2c1f6850c7f8a91dd90e366391c466ff50b99357139e0dffa",
       "sha256": "0x42dbf39bb01ce6052040ca846081cfa47ce133c77c7600a25e91cc259687177f",
       "urls": [
-        "bzzr://2b5d1ff7f038b0f32ed5e1a0b601324dc052efa540298d4f2ed5d80bb5e18271",
         "dweb:/ipfs/QmXSTvuPNV7jGtvwabsZrpFcuRTpQyG5ad61HQbJc6ASfB"
       ]
     },
@@ -908,7 +833,6 @@
       "keccak256": "0x4ab7632e1aabab5cb9b64fa28b5306527feb48032b1b171a2cf906958baff3cc",
       "sha256": "0xcd01ed57421c125ff6a9e41b193b0d3bfd8b1fe0be265ab0a14e0ea2eb29ee66",
       "urls": [
-        "bzzr://5fc42d680f133d575adae862307f9b28d6fd5500cdc354fa67253ca867222db0",
         "dweb:/ipfs/QmRn9JePymcEMUSLSrykQDsWq47g34V7VJK4dbMFqvormx"
       ]
     },
@@ -920,7 +844,6 @@
       "keccak256": "0x116d6f241058b4080b97efd7d32927744e8123d8d31214a75f4387d7191cae03",
       "sha256": "0x70a5a7eaa9135d13bd036ca55735f489559368af819c5810cfaf0315df56ab53",
       "urls": [
-        "bzzr://010894a498050028bb0cf55ad14e79b69746b58d582763c3c80b02d74dbf8eb6",
         "dweb:/ipfs/QmQZf9YevKhiqk1oHa5NyM77ykYUXuaKmaVZrhdK9pejm4"
       ]
     },
@@ -932,7 +855,6 @@
       "keccak256": "0xb7771976985af1193cc0beb2a9b518ed09da136cfc7bf45d6dd7b3749b1b4b8b",
       "sha256": "0x2efa5adabd3589ba61361030a5df596562fb4b8e2c69b8a6e88d7891c327ee0a",
       "urls": [
-        "bzzr://02646b8af50c98aac95beb45c875d306f922f960170b1784084406cc8589b3e2",
         "dweb:/ipfs/QmeawYNqPzgADgXfUEPvDCEgPHm3D3A2AXnnJVVBHGxpAe"
       ]
     },
@@ -944,7 +866,6 @@
       "keccak256": "0x11aa8c48f7d31eb5ad347e129a9835df7f0df3383d7b4ade1db8b8f26a18a19c",
       "sha256": "0x84976fb1fc2b29267020d2ca0a3a877f0ec6f88018307d32bfbb43bece865767",
       "urls": [
-        "bzzr://2a00bc36fca5c5976550388d768e575c1f374b167b7e7e72818b351792005719",
         "dweb:/ipfs/QmP5g6WtQzqPwmCXNjatTr7aVCuF55qA3ArxgRtxp1Fu7v"
       ]
     },
@@ -956,7 +877,6 @@
       "keccak256": "0x5fb8637ad87d6efb1449e856c09609d0d1c152b99c5268c2c962ecf14f704fd2",
       "sha256": "0x7615e019666f29c7e77b20f9c506dda839a875fbc9baf3322d21348c88c05c69",
       "urls": [
-        "bzzr://6964ce32fe2c98640290220e4ef801f540303a597b0159bd2bb3ce6281594932",
         "dweb:/ipfs/QmPcignBbCmRwHL69Tqac7egxKP5bcmhadzXT81oXNs3fF"
       ]
     },
@@ -968,7 +888,6 @@
       "keccak256": "0x490c4c692aa16851973b9c444e178dc05377b79ff4c26f913b4b75d39437f5ba",
       "sha256": "0x3413d777e5a08e7240c5dc7e6a61afbc5fb78949ba0aa81ca3c9e9ad31d03490",
       "urls": [
-        "bzzr://cebedc02ca52e14503280627c16915b3afaa2d3328295d552aaf53c7e6b3fbe1",
         "dweb:/ipfs/QmS2fudS4qRMuNRXJXjMfxJTP9NFpRng6izUXgUTcsVrEP"
       ]
     },
@@ -980,7 +899,6 @@
       "keccak256": "0xda3dcff0fe9e3297d99ec184afab49b0eb0a95ce88ef3f44587618445cbe6546",
       "sha256": "0x00d3b5ca64b097964ed6d70d9805a63fdd27113b07c1b2559dbfdd579f994508",
       "urls": [
-        "bzzr://167975f6d12322404bb3c7248385059115347b152647bcdb6bd0c7a2dd441b09",
         "dweb:/ipfs/QmXTQQV8QYKSy33RGgknfcTANYtxaC6fvhnkmmfzGkkrLH"
       ]
     },
@@ -992,7 +910,6 @@
       "keccak256": "0xb9ad3f0074e86775733bbd5360a2a13a7dde7f6c96fe52b2bad5a9cf638789ad",
       "sha256": "0xa0fa8eb77805c530cfb6962f400643dbe83991387d27b319efd6b89482061946",
       "urls": [
-        "bzzr://a4289855cdaa7a1946b301b30264437e22a408fbe604ee31ca30343c74ee1e5b",
         "dweb:/ipfs/QmatehU9ZgFQRKAcbcU6iTdsFDtZXTZQ3rL1qpCW5evu3n"
       ]
     },
@@ -1004,7 +921,6 @@
       "keccak256": "0x2dd8feca31548694c0bd0865f3169bb9eb41e2caa54228fafe304a113d5c733b",
       "sha256": "0x8d9f82566d978ca9d6682a0a03e0238f92ac021710be41c6ed22daa8a9e9949f",
       "urls": [
-        "bzzr://8afb2f234834fd062dbb7afe05a0253bb930fc4da59360cef9f1b7aa24901be6",
         "dweb:/ipfs/QmckrHeMkjwp8LT9zvptEeADx1PJhr7bX7HV8PRrse8r1E"
       ]
     },
@@ -1016,7 +932,6 @@
       "keccak256": "0x9d7fe45b291e4453e93251a3454c2685b6cfffbf97a8f3a3f55bf14c2d37b871",
       "sha256": "0xa67dd61933385163053a5f3c61de140648bcb58560ad1578368d0aacbc860afa",
       "urls": [
-        "bzzr://b8e20c63227ceb7da1118bc3d49a89bd92c29d6cc3ef1867c621eddd8d0faecb",
         "dweb:/ipfs/QmX2LzRpr3duh8arR8AguV5aXxSiLH5cCnPFvYuZk73kn1"
       ]
     },
@@ -1028,7 +943,6 @@
       "keccak256": "0xc3e5b457f56d974bef822ea13473e07f0ae53de2912b134d9cb762b1e6825884",
       "sha256": "0xef1c4ade86699d9ad68cf9add61c93d0701411bb6050229fc0339148efa46414",
       "urls": [
-        "bzzr://02ea8caa900cbaed4fe555db8d76a9969fc7d68affdc9bf6e93e50ddfa5a7a67",
         "dweb:/ipfs/QmciFtN3cGAoVBmuAdnPJmv2WUWuBe3HEg6TqLdieNZyEW"
       ]
     },
@@ -1040,7 +954,6 @@
       "keccak256": "0xbbcdab9cc802a20bb07c207bcb1f16f712b9dc3ad1e0cb79a2e7355b73870ee6",
       "sha256": "0x580ee56b61bbcaad953117e1e4a0874d90e6af5cb4ce4359571d7da25f6620e9",
       "urls": [
-        "bzzr://3c38ec92497c9148fa7e1d13cfe15da011f4c316ffebb332ac337adf1388282a",
         "dweb:/ipfs/QmNnYYCBrwmwd78YWeVoyyPhSaXaD7rmGn88UFi9HcrPdd"
       ]
     },
@@ -1052,7 +965,6 @@
       "keccak256": "0xdb656215a6d040da90b4006e2a2161f36be013c5fa72473bd0150558a38fe446",
       "sha256": "0x5f2947705f3db7c8e267742038f5c7e43009ba1e63a27a0b6fd4bdb1ccc25a5c",
       "urls": [
-        "bzzr://43f4f9ce6adce6adab93eef98c8b48f1346e0fcb02fe70a28f7c80bf779830c2",
         "dweb:/ipfs/QmQutHehoWygWtxH6xPHKqA76EM45THGPZtDF8qf3me3px"
       ]
     }


### PR DESCRIPTION
This PR removes support for swarm hashes from the binary releases list and updates the Node.js dependency to its latest version in the CI.

Additionally, the PR updates the GitHub Actions to utilize their latest versions. Some of them, such as https://github.com/actions/download-artifact and https://github.com/actions/upload-artifact, were utilizing deprecated versions. Only actions maintained by Github were updated.

```
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions.
This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.
```

Fixes https://github.com/ethereum/solidity/issues/14700