### PR TITLE
Reduce polling frequency of turnstyle GH action to avoid API rate limit for unauthenticated requests

### DIFF
--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -33,6 +33,7 @@ jobs:
         uses: softprops/turnstyle@v1
         with:
           same-branch-only: no
+          poll-interval-seconds: 120 # in seconds
 
       - name: Configure the S3 client
         run: |


### PR DESCRIPTION
We are performing unauthenticated request to GitHub API when running the job to mirror the binaries to S3 which [imposes a limited number of API request](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#primary-rate-limit-for-unauthenticated-users). See: https://github.com/ethereum/solc-bin/actions/runs/9055823647/job/24877483141#step:3:9

Passing the GH token (or a token with `actions:read` permission) for authentication should increase our rate limit of requests per hour. Alternatively,  we can increase the waiting time between checks for previous workflows completion done by the [turnstyle](https://github.com/softprops/turnstyle?tab=readme-ov-file#inputs) action.
