### PR TITLE
Remove swarmhash leftovers from nightly run

### DIFF
--- a/bin/list.json
+++ b/bin/list.json
@@ -20382,7 +20382,6 @@
       "keccak256": "0x04bd8b6970ea78f7900f6171363a15ad13af4f7393f5a2ee78f0153324b84f42",
       "sha256": "0xc63b8b51e227532051dfc30e4e8df57a644e989eacb998f3f13d05a604553259",
       "urls": [
-        "bzzr://26854820a6c5cde6d87b4d8b32072e2efadc0e0f33e123f0dbb4f5394fc0c4ec",
         "dweb:/ipfs/QmRCdRC143c2ZsK5UUusoQz66gD68U5jFALhT3LWBEuXSx"
       ]
     },
@@ -20395,7 +20394,6 @@
       "keccak256": "0xc6189881ff291f2af94122fb8ac697d4746638cf6e990476f8e62146497b2b5d",
       "sha256": "0x524fdc233824bf4ebae7dea3d3b9dd9ff06b41dfa3eb27dab2b5c9a4fcadd36b",
       "urls": [
-        "bzzr://60aaff3df964cabadc2faf45098b63593939f465d278ac6a662a1667691e3f59",
         "dweb:/ipfs/QmbjCQ8Vie12hk3DBcPn5rQfF9M5uWLSRUDVtjqbz14zoe"
       ]
     }


### PR DESCRIPTION
https://github.com/ethereum/solc-bin/pull/147 was merged after the nightly run of last night, and thus included some `bzzr` urls that are not supposed to be there anymore: https://app.circleci.com/pipelines/github/ethereum/solc-bin/1377/workflows/75c0f73f-1da0-42c9-9526-951fa65f49bd/jobs/1390