### PR TITLE
Update org name

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -8,7 +8,7 @@ on:
 env:
   TARGET_BRANCH: gh-pages
   COMMITTER_NAME: emscripten nightly action
-  COMMITTER_EMAIL: builds@ethereum.org
+  COMMITTER_EMAIL: builds@argot.org
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: 'ethereum/solidity'
+          repository: 'argotorg/solidity'
           ref: 'develop'
           path: 'solidity/'
           submodules: 'recursive'
@@ -97,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'ethereum/solidity'
+          repository: 'argotorg/solidity'
           submodules: 'recursive'
 
       - name: Download soljson.js artifact

--- a/.github/workflows/random-macosx-build.yml
+++ b/.github/workflows/random-macosx-build.yml
@@ -9,7 +9,7 @@ env:
   MIN_SUPPORTED_SOLIDITY_VERSION: 0.3.6
   TARGET_BRANCH: macosx-static-binaries
   COMMITTER_NAME: macosx build action
-  COMMITTER_EMAIL: builds@ethereum.org
+  COMMITTER_EMAIL: builds@argot.org
 
 jobs:
   select-solc-version:
@@ -24,7 +24,7 @@ jobs:
 
       - name: Select version to build
         run: |
-          github_tag_response=$(curl "https://api.github.com/repos/ethereum/solidity/git/refs/tags/")
+          github_tag_response=$(curl "https://api.github.com/repos/argotorg/solidity/git/refs/tags/")
           github_macosx_files_response=$(curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/contents/macosx-amd64?ref=${TARGET_BRANCH}")
 
           available_tags=$(
@@ -65,7 +65,7 @@ jobs:
       - name: Check out Solidity source
         uses: actions/checkout@v4
         with:
-          repository: 'ethereum/solidity'
+          repository: 'argotorg/solidity'
           ref: v${{ env.SOLIDITY_VERSION }}
           path: solidity/
           fetch-depth: 0
@@ -155,7 +155,7 @@ jobs:
 
               evmone_version="0.1.0"
               evmone_package="evmone-0.1.0-darwin-x86_64"
-              curl -O -L "https://github.com/ethereum/evmone/releases/download/v${evmone_version}/${evmone_package}.tar.gz"
+              curl -O -L "https://github.com/ipsilon/evmone/releases/download/v${evmone_version}/${evmone_package}.tar.gz"
               tar xzpf "${evmone_package}.tar.gz" -C /usr/local
               rm "${evmone_package}.tar.gz"
             else
@@ -228,7 +228,7 @@ jobs:
           fi
 
           # Pre-0.5.0 versions were using wrong boost test header, resulting in the 'duplicate symbol' linker error in static builds.
-          # See https://github.com/ethereum/solidity/pull/4572
+          # See https://github.com/argotorg/solidity/pull/4572
           if semver --range '< 0.5.0' "$SOLIDITY_VERSION"; then
             sed -i.bak 's|^[[:blank:]]*#include <boost/test/included/unit_test\.hpp>[[:blank:]]*$|#include <boost/test/unit_test.hpp>|g' test/boostTest.cpp
           fi

--- a/.github/workflows/t-bytecode-compare.yml
+++ b/.github/workflows/t-bytecode-compare.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: 'ethereum/solidity'
+          repository: 'argotorg/solidity'
           path: 'solidity/'
           # bytecode_reports_for_modified_binaries.sh requires access to a working copy with full history
           fetch-depth: 0
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: 'ethereum/solidity'
+          repository: 'argotorg/solidity'
           path: 'solidity/'
           submodules: 'recursive'
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # solc-bin
 
-This repository contains current and historical builds of the [Solidity Compiler](https://github.com/ethereum/solidity/).
+This repository contains current and historical builds of the [Solidity Compiler](https://github.com/argotorg/solidity/).
 
 Please refer to the section on [Static Binaries](https://docs.soliditylang.org/en/latest/installing-solidity.html#static-binaries)
 in the official documentation for information about the structure of this repository, its content and recommended usage.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,4 @@ This repository contains current and historical builds of the [Solidity Compiler
 Please refer to the section on [Static Binaries](https://docs.soliditylang.org/en/latest/installing-solidity.html#static-binaries)
 in the official documentation for information about the structure of this repository, its content and recommended usage.
 
-## Deprecation notice for the `ethereum.github.io` domain
-
 **The content of this repository is mirrored at https://binaries.soliditylang.org. This is the recommended way to fetch compiler binaries over HTTPS.**
-
-The binaries are also available at https://ethereum.github.io/solc-bin/ but this page
-stopped being updated just after the release of version 0.7.2, will not receive any new releases
-or nightly builds for any platform and does not serve the new directory structure, including
-non-emscripten builds.
-
-If you are using it, please switch to https://binaries.soliditylang.org, which is a drop-in
-replacement. This allows us to make changes to the underlying hosting in a transparent way and
-minimize disruption. Unlike the `ethereum.github.io` domain, which we do not have any control
-over, `binaries.soliditylang.org` is guaranteed to work and maintain the same URL structure
-in the long-term.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ethereum/solc-bin.git"
+    "url": "git+https://github.com/argotorg/solc-bin.git"
   },
   "keywords": [
     "ethereum",
@@ -28,7 +28,7 @@
   "author": "",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/ethereum/solc-bin/issues"
+    "url": "https://github.com/argotorg/solc-bin/issues"
   },
-  "homepage": "https://github.com/ethereum/solc-bin#readme"
+  "homepage": "https://github.com/argotorg/solc-bin#readme"
 }


### PR DESCRIPTION
There is a section on the [README](https://github.com/argotorg/solc-bin?tab=readme-ov-file#deprecation-notice-for-the-ethereumgithubio-domain) that I didn't update because I think we should maybe remove it completely, or at least change it to  `argotorg.github.io` since now we have control over the domain. Open for suggestions.