### PR TITLE
Add missing write permission for emscripten nightly job

### DIFF
--- a/.github/workflows/nightly-emscripten.yml
+++ b/.github/workflows/nightly-emscripten.yml
@@ -116,6 +116,9 @@ jobs:
       - build-emscripten-nightly
       - test-emscripten-nightly
 
+    permissions:
+      contents: write
+
     env:
       NIGHTLY_VERSION: ${{ needs.build-emscripten-nightly.outputs.nightly-version }}
 


### PR DESCRIPTION
Fix the following permission issue: https://github.com/argotorg/solc-bin/actions/runs/17814780551/job/50647275444