### PR TITLE
Create two separate actions for R2 and S3 upload

### DIFF
--- a/.github/workflows/r2-mirror.yml
+++ b/.github/workflows/r2-mirror.yml
@@ -1,0 +1,65 @@
+name: Mirror repository content to R2 storage bucket
+
+on:
+  push:
+    branches:
+      - gh-pages
+
+  schedule:
+    # Pushes to `gh-pages` done from other actions cannot trigger this action so we also want it to run
+    # on a schedule. Let's give the nightly job a 1h head-start and run every day at 1:00.
+    - cron: "0 1 * * *"
+
+env:
+  R2_BUCKET: solc-bin
+  R2_ACCOUNT_ID: 1fbd136205d2c780838f0d2c014bf69c
+  R2_ZONE: EEUR
+  CLOUDFLARE_ZONE_ID: d63261269eeac3abf4c1b2f52e71ae1b
+  CLOUDFLARE_CACHE_HOST: binaries.soliditylang-test.org
+
+jobs:
+  mirror-content:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Symlink solc-bin to /mnt/solc-bin
+        # It's now too big to fit on the main partition on Ubuntu, which is mostly filled with software.
+        run: |
+          sudo mkdir /mnt/solc-bin/
+          sudo chown "$USER" /mnt/solc-bin/
+          ln -s /mnt/solc-bin/ solc-bin
+
+      - name: Wait for other instances of this workflow to finish
+        # It's not safe to run two S3 sync operations concurrently with different files
+        uses: softprops/turnstyle@v1
+        with:
+          same-branch-only: no
+          poll-interval-seconds: 120 # in seconds
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: "solc-bin"
+
+      - name: Render README.md to HTML
+        run: |
+          pip install markdown
+          cd solc-bin/
+          echo "<html><body>$(python -m markdown README.md)</body></html>" > README.html
+
+      - name: Configure the R2 client
+        run: |
+          aws configure set aws_access_key_id '${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}'
+          aws configure set aws_secret_access_key '${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}'
+
+      - name: Sync the R2 bucket
+        run: |
+          cd solc-bin/
+          ./sync-r2.sh \
+            "$R2_ACCOUNT_ID" \
+            "$R2_ZONE" \
+            "$R2_BUCKET" \
+            "$CLOUDFLARE_ZONE_ID" \
+            "$CLOUDFLARE_CACHE_HOST" \
+            '${{ secrets.CLOUDFLARE_API_TOKEN }}'

--- a/.github/workflows/s3-mirror.yml
+++ b/.github/workflows/s3-mirror.yml
@@ -1,4 +1,4 @@
-name: Mirror repository content to storage buckets
+name: Mirror repository content to S3 storage bucket
 
 on:
   push:
@@ -8,17 +8,12 @@ on:
   schedule:
     # Pushes to `gh-pages` done from other actions cannot trigger this action so we also want it to run
     # on a schedule. Let's give the nightly job a 1h head-start and run every day at 1:00.
-    - cron: '0 1 * * *'
+    - cron: "0 1 * * *"
 
 env:
   S3_BUCKET: solc-bin
   S3_REGION: eu-central-1
   CLOUDFRONT_DISTRIBUTION_ID: E1O6GT57WUFUHD
-  R2_BUCKET: solc-bin
-  R2_ACCOUNT_ID: 1fbd136205d2c780838f0d2c014bf69c
-  R2_ZONE: EEUR
-  CLOUDFLARE_ZONE_ID: d63261269eeac3abf4c1b2f52e71ae1b
-  CLOUDFLARE_CACHE_HOST: binaries.soliditylang-test.org
 
 jobs:
   mirror-content:
@@ -49,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          path: 'solc-bin'
+          path: "solc-bin"
 
       - name: Render README.md to HTML
         run: |
@@ -61,19 +56,3 @@ jobs:
         run: |
           cd solc-bin/
           ./sync-s3.sh "$S3_BUCKET" "$CLOUDFRONT_DISTRIBUTION_ID"
-
-      - name: Configure the R2 client
-        run: |
-          aws configure set aws_access_key_id '${{ secrets.CLOUDFLARE_ACCESS_KEY_ID }}'
-          aws configure set aws_secret_access_key '${{ secrets.CLOUDFLARE_SECRET_ACCESS_KEY }}'
-
-      - name: Sync the R2 bucket
-        run: |
-          cd solc-bin/
-          ./sync-r2.sh \
-            "$R2_ACCOUNT_ID" \
-            "$R2_ZONE" \
-            "$R2_BUCKET" \
-            "$CLOUDFLARE_ZONE_ID" \
-            "$CLOUDFLARE_CACHE_HOST" \
-            '${{ secrets.CLOUDFLARE_API_TOKEN }}'

--- a/sync-r2.sh
+++ b/sync-r2.sh
@@ -19,9 +19,6 @@
 # When running multiple instances of this script concurrently on different
 # revisions it's theoretically possible to end up with any combination of
 # their files in the bucket so it should be avoided.
-# If `sync-s3.sh` was run beforehand the timestamp/cleanup/symlink steps
-# below will run twice; they are currently idempotent, so keep any additions
-# in this area safe to repeat.
 #
 # WARNING: The script destructively modifies the working copy. Always run it
 # on a fresh clone!

--- a/sync-s3.sh
+++ b/sync-s3.sh
@@ -17,9 +17,6 @@
 # When running multiple instances of this script concurrently on different
 # revisions it's theoretically possible to end up with any combination of
 # their files in the bucket so it should be avoided.
-# If `sync-r2.sh` is run afterwards the timestamp/cleanup/symlink steps will
-# execute again; they are currently idempotent, so keep any additions in this
-# area safe to repeat.
 #
 # WARNING: The script destructively modifies the working copy. Always run it
 # on a fresh clone!


### PR DESCRIPTION
With the previous PR (#169), the r2 mirror script can no longer run because the .git files are removed. In general, both scripts run in the same environment, causing the second script to repeat the timestamp updates, removal of hidden files, and creation of symlinks that the S3 version has already performed.

With this PR, we introduce two separate GitHub actions: one for R2 and one for S3.