### PR TITLE
Update cloudflare cache host in R2 sync script

### DIFF
--- a/.github/workflows/r2-mirror.yml
+++ b/.github/workflows/r2-mirror.yml
@@ -15,7 +15,7 @@ env:
   R2_ACCOUNT_ID: 1fbd136205d2c780838f0d2c014bf69c
   R2_ZONE: EEUR
   CLOUDFLARE_ZONE_ID: d63261269eeac3abf4c1b2f52e71ae1b
-  CLOUDFLARE_CACHE_HOST: binaries.soliditylang-test.org
+  CLOUDFLARE_CACHE_HOST: binaries.soliditylang.org
 
 jobs:
   mirror-content:


### PR DESCRIPTION
For some unknown reason, the checkout of solc-bin that was taking around 6 minutes (https://github.com/argotorg/solc-bin/actions/runs/20085596221/job/57622225915), now takes around 24 minutes (https://github.com/argotorg/solc-bin/actions/runs/20100028534/job/57668159518).

This is not expected, but maybe it is related to the cache host that was wrong and was pointing to test domain. I did a small test in another PR and the checkout was faster when using the correct domain, so I'm confident this will solve the issue.