### PR TITLE
Fix `purge_paths` in `sync-r2.sh` by removing unnecessary leading slashes

### DIFF
--- a/sync-r2.sh
+++ b/sync-r2.sh
@@ -75,13 +75,16 @@ purge_paths=(
 )
 while IFS= read -r path; do
     purge_paths+=("/${path}")
-done < <(find . \( -wholename '*/list.*' -o -wholename '*/*-latest' -o -wholename '*/*-latest.*' \) | cut --characters 2-)
+done < <(find . \( -wholename '*/list.*' -o -wholename '*/*-latest' -o -wholename '*/*-latest.*' \) | cut -c 2-)
 
 purge_payload="$(jq --null-input \
     --arg host "https://${cloudflare_cache_host}" \
     '{"files": ($ARGS.positional | map($host + .))}' \
     --args -- "${purge_paths[@]}"
 )"
+
+# Print the payload to check purged files
+echo $purge_payload
 
 curl --fail --show-error --silent \
     -X POST "https://api.cloudflare.com/client/v4/zones/${cloudflare_zone_id}/purge_cache" \

--- a/sync-r2.sh
+++ b/sync-r2.sh
@@ -74,7 +74,7 @@ purge_paths=(
     "/soljson.js"
 )
 while IFS= read -r path; do
-    purge_paths+=("/${path}")
+    purge_paths+=("${path}")
 done < <(find . \( -wholename '*/list.*' -o -wholename '*/*-latest' -o -wholename '*/*-latest.*' \) | cut -c 2-)
 
 purge_payload="$(jq --null-input \

--- a/sync-r2.sh
+++ b/sync-r2.sh
@@ -84,7 +84,7 @@ purge_payload="$(jq --null-input \
 )"
 
 # Print the payload to check purged files
-echo $purge_payload
+echo "$purge_payload"
 
 curl --fail --show-error --silent \
     -X POST "https://api.cloudflare.com/client/v4/zones/${cloudflare_zone_id}/purge_cache" \


### PR DESCRIPTION
`purge_paths`, a list containing the files to be purged was created by adding resources with the wrong path "https://binaries.soliditylang.org//bin/list.json" instead of "https://binaries.soliditylang.org/bin/list.json" (notice the double slash before `bin/list.json`).